### PR TITLE
pdf2john.py problem, commit efc315e926f521cc41c002742a994776edbacc1d broke it

### DIFF
--- a/run/pdf2john.py
+++ b/run/pdf2john.py
@@ -133,9 +133,9 @@ class PdfParser:
                     # print >> sys.stderr, encryption_dictionary
                     try:
                         pas = pr.findall(encryption_dictionary)[0]
-                        output += self.get_password_from_byte_string(pas)+"*"
                     except IndexError:
                         break
+                output += self.get_password_from_byte_string(pas)+"*"
             else:
                 pr = re.compile(let + b'\s*<\w+>')
                 pas = pr.findall(encryption_dictionary)


### PR DESCRIPTION
Commit efc315e926f521cc41c002742a994776edbacc1d broke pdf2john.py, at least for the pdf files I'm currently testing, i.e. following format (in hashcat)
-m 10500 = PDF 1.4 - 1.6 (Acrobat 5 - 8)

The signature (which I've investigated here) is: $pdf$2*3*128*

Some example hashes (which currently don't work, but with this pull request should work):
https://mega.co.nz/#!7UABCa5J!t1j7SGclg6UA3X_x1tGpWO7tGiu3D7G7oYBOsSRSUMA

The main problem here is the indentation (which for python is very important, yes sucks).

Greetz from hashcat's dev
philsmd, atom