### PR TITLE
pdf2john /Encrypt /Length problem for PDF versions 1.1 - 1.3

### DIFF
--- a/run/pdf2john.py
+++ b/run/pdf2john.py
@@ -68,7 +68,9 @@ class PdfParser:
         r = dr.findall(rr.findall(encryption_dictionary)[0])[0]
         lr = re.compile(b'\/Length \d+')
         longest = 0
-        length = ''
+        # According to the docs:
+        # Length : (Optional; PDF 1.4; only if V is 2 or 3). Default value: 40
+        length = b'40'
         for le in lr.findall(encryption_dictionary):
             if(int(dr.findall(le)[0]) > longest):
                 longest = int(dr.findall(le)[0])


### PR DESCRIPTION
According to the Adobe PDF documentations ( for instance https://wwwimages2.adobe.com/content/dam/Adobe/en/devnet/pdf/pdfs/PDF32000_2008.pdf ) , the /Length attribute in the encryption dictionary was not available/used for PDF documents with a PDF version number < 1.4.

The documentation says: (Optional; PDF 1.4; only if V is 2 or 3) The length of the encryption key, in bits. The value shall be a multiple of 8, in the range 40 to 128. Default value: 40.

Indeed, for PDF versions < 1.4 /Length afaik does never exist and hence the current code fails, generating something like this:
$pdf$1\*2\*\*...  instead of $pdf$1\*2\*40\*...

Hashes without a keysize are currently not acceted neither by jtr, nor by oclHashcat.
Example hashes to test (feel free to share/upload/post them): https://mega.co.nz/#!rdxQlTBS!XIfPnQQdtmrUGmBRgrTXN8qM53VFf7OIkt640V_w9Vg

The fix sets a default keysize, which should anyway always be overridden if a newer PDF version format is being used. This ensures that the keysize value (string) is never empty and hence an "invalid" hash (because of the keysize) cannot be generated by pdf2john.py

Greetz from the hashcat crew
phil, atom