### PR TITLE
 Add const to count

### DIFF
--- a/src/7z_fmt_plug.c
+++ b/src/7z_fmt_plug.c
@@ -345,7 +345,7 @@ void sevenzip_kdf(UTF8 *password, unsigned char *master)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/AFS_fmt.c
+++ b/src/AFS_fmt.c
@@ -289,7 +289,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index, pos, length;
 	char xor[8];
 	ARCH_WORD_32 space[(PLAINTEXT_LENGTH + SALT_SIZE + 8) / 4 + 1];

--- a/src/BFEgg_fmt_plug.c
+++ b/src/BFEgg_fmt_plug.c
@@ -182,7 +182,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/BF_fmt.c
+++ b/src/BF_fmt.c
@@ -127,7 +127,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	if (keys_mode != saved_salt.subtype) {
 		int i;

--- a/src/BSDI_fmt.c
+++ b/src/BSDI_fmt.c
@@ -325,7 +325,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+        const int count = *pcount;
 	DES_bs_crypt(saved_count, count);
 	return count;
 }
@@ -344,7 +344,7 @@ static int cmp_exact(char *source, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 
 	if (current_salt != saved_salt)

--- a/src/DES_fmt.c
+++ b/src/DES_fmt.c
@@ -204,7 +204,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	DES_bs_crypt_25(count);
 	return count;
 }
@@ -279,7 +279,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 
 	for (index = 0; index < count; index++)

--- a/src/DMD5_fmt_plug.c
+++ b/src/DMD5_fmt_plug.c
@@ -305,7 +305,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/DOMINOSEC_fmt_plug.c
+++ b/src/DOMINOSEC_fmt_plug.c
@@ -620,7 +620,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 
 #ifdef _OPENMP

--- a/src/EPI_fmt_plug.c
+++ b/src/EPI_fmt_plug.c
@@ -145,7 +145,7 @@ static char* get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i=0;
 #ifdef _OPENMP
 #pragma omp parallel for private(i) shared(global_salt, saved_key, key_len, crypt_out)

--- a/src/HDAA_fmt_plug.c
+++ b/src/HDAA_fmt_plug.c
@@ -398,7 +398,7 @@ static inline void crypt_done(unsigned const int *source, unsigned int *dest, in
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #if MMX_COEF
 #if defined(_OPENMP)
 #define ti	(thread*NBKEYS+index)

--- a/src/IPB2_fmt_plug.c
+++ b/src/IPB2_fmt_plug.c
@@ -285,7 +285,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #ifdef MMX_COEF
 #if defined(_OPENMP)
 	int t;

--- a/src/MD5_fmt.c
+++ b/src/MD5_fmt.c
@@ -242,7 +242,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #ifdef MD5_SSE_PARA
 #ifdef _OPENMP
 	int t;

--- a/src/MSCHAPv2_bs_fmt_plug.c
+++ b/src/MSCHAPv2_bs_fmt_plug.c
@@ -394,7 +394,7 @@ static inline void setup_des_key(unsigned char key_56[], int index)
 */
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 
 	if (!keys_prepared) {

--- a/src/NETLMv2_fmt_plug.c
+++ b/src/NETLMv2_fmt_plug.c
@@ -273,7 +273,7 @@ static void *get_binary(char *ciphertext)
 */
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i = 0;
 
 #ifdef _OPENMP

--- a/src/NETNTLM_bs_fmt_plug.c
+++ b/src/NETNTLM_bs_fmt_plug.c
@@ -270,7 +270,7 @@ static inline void setup_des_key(unsigned char key_56[], int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 
 	if (!keys_prepared) {

--- a/src/NETNTLMv2_fmt_plug.c
+++ b/src/NETNTLMv2_fmt_plug.c
@@ -283,7 +283,7 @@ static void *get_binary(char *ciphertext)
 */
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int identity_length, challenge_size;
 	int i = 0;
 

--- a/src/SybasePROP_fmt_plug.c
+++ b/src/SybasePROP_fmt_plug.c
@@ -153,7 +153,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -359,7 +359,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 #ifdef MMX_COEF_SHA512
 	int inc = MMX_COEF_SHA512;

--- a/src/XSHA_fmt_plug.c
+++ b/src/XSHA_fmt_plug.c
@@ -333,7 +333,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #ifdef MMX_COEF
 	int i = 0;
 #if defined(_OPENMP)

--- a/src/agilekeychain_fmt_plug.c
+++ b/src/agilekeychain_fmt_plug.c
@@ -207,7 +207,7 @@ static int akcdecrypt(unsigned char *derived_key, unsigned char *data)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/aix_smd5_fmt_plug.c
+++ b/src/aix_smd5_fmt_plug.c
@@ -300,7 +300,7 @@ static void crypt_md5(char *pw, char *salt, int is_standard, char *passwd)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/aix_ssha_fmt_plug.c
+++ b/src/aix_ssha_fmt_plug.c
@@ -287,7 +287,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/androidfde_fmt_plug.c
+++ b/src/androidfde_fmt_plug.c
@@ -300,7 +300,7 @@ void hash_plugin_check_hash(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	memset(cracked, 0, sizeof(cracked[0])*max_cracked);

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -236,7 +236,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/blackberry_ES10_fmt_plug.c
+++ b/src/blackberry_ES10_fmt_plug.c
@@ -166,7 +166,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/blockchain_fmt_plug.c
+++ b/src/blockchain_fmt_plug.c
@@ -204,7 +204,7 @@ static int blockchain_decrypt(unsigned char *derived_key, unsigned char *data)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/chap_fmt_plug.c
+++ b/src/chap_fmt_plug.c
@@ -164,7 +164,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/citrix_ns_fmt_plug.c
+++ b/src/citrix_ns_fmt_plug.c
@@ -315,7 +315,7 @@ static int cmp_exact(char *source, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/clipperz_srp_fmt_plug.c
+++ b/src/clipperz_srp_fmt_plug.c
@@ -340,7 +340,7 @@ static inline void hex_encode(unsigned char *str, int len, unsigned char *out)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int j;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/cloudkeychain_fmt_plug.c
+++ b/src/cloudkeychain_fmt_plug.c
@@ -303,7 +303,7 @@ static int ckcdecrypt(unsigned char *key)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/cq_fmt_plug.c
+++ b/src/cq_fmt_plug.c
@@ -428,7 +428,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/crc32_fmt_plug.c
+++ b/src/crc32_fmt_plug.c
@@ -178,7 +178,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 #ifdef _OPENMP
 #pragma omp parallel for private(i)

--- a/src/crypt-sha1_fmt_plug.c
+++ b/src/crypt-sha1_fmt_plug.c
@@ -121,7 +121,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/cryptsha256_fmt_plug.c
+++ b/src/cryptsha256_fmt_plug.c
@@ -577,7 +577,7 @@ static void LoadCryptStruct(cryptloopstruct *crypt_struct, int index, int idx, c
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 	int *MixOrder, tot_todo;
 

--- a/src/cryptsha512_fmt_plug.c
+++ b/src/cryptsha512_fmt_plug.c
@@ -561,7 +561,7 @@ static void LoadCryptStruct(cryptloopstruct *crypt_struct, int index, int idx, c
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 	int *MixOrder, tot_todo;
 

--- a/src/cuda_cryptsha256_fmt_plug.c
+++ b/src/cuda_cryptsha256_fmt_plug.c
@@ -134,7 +134,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	sha256_crypt_gpu(inbuffer, outbuffer, &host_salt, count);
 	return count;

--- a/src/cuda_cryptsha512_fmt_plug.c
+++ b/src/cuda_cryptsha512_fmt_plug.c
@@ -140,7 +140,7 @@ static void gpu_crypt_all(int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	gpu_crypt_all(count);
 	return count;

--- a/src/cuda_mscash2_fmt_plug.c
+++ b/src/cuda_mscash2_fmt_plug.c
@@ -172,7 +172,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	mscash2_gpu(inbuffer, outbuffer, &currentsalt, count);
 	return count;

--- a/src/cuda_mscash_fmt_plug.c
+++ b/src/cuda_mscash_fmt_plug.c
@@ -216,7 +216,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	cuda_mscash(inbuffer, outbuffer, &currentsalt, count);
 	return count;

--- a/src/cuda_pwsafe_fmt_plug.c
+++ b/src/cuda_pwsafe_fmt_plug.c
@@ -153,7 +153,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
         gpu_pwpass(host_pass, host_salt, host_hash, count);
         return count;

--- a/src/cuda_rawsha256_fmt.c
+++ b/src/cuda_rawsha256_fmt.c
@@ -221,7 +221,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #ifdef SHA256
 	gpu_rawsha256(inbuffer, outbuffer, overlap);
 #else

--- a/src/cuda_rawsha512_fmt_plug.c
+++ b/src/cuda_rawsha512_fmt_plug.c
@@ -246,7 +246,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	cuda_sha512(gkey, ghash, count);
 	sha512_key_changed = 0;

--- a/src/cuda_wpapsk_fmt_plug.c
+++ b/src/cuda_wpapsk_fmt_plug.c
@@ -63,7 +63,7 @@ static void init(struct fmt_main *self)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	if (new_keys || strcmp(last_ssid, hccap.essid)) {
 		wpapsk_gpu(inbuffer, outbuffer, &currentsalt, count);

--- a/src/cuda_xsha512_fmt_plug.c
+++ b/src/cuda_xsha512_fmt_plug.c
@@ -303,7 +303,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	cuda_xsha512(gkey, &gsalt, ghash, g_ext_key, count);
 	xsha512_key_changed = 0;

--- a/src/dahua_fmt_plug.c
+++ b/src/dahua_fmt_plug.c
@@ -143,7 +143,7 @@ static void compressor(unsigned char *in, unsigned char *out)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/django_fmt_plug.c
+++ b/src/django_fmt_plug.c
@@ -197,7 +197,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/django_scrypt_fmt_plug.c
+++ b/src/django_scrypt_fmt_plug.c
@@ -179,7 +179,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/dmg_fmt_plug.c
+++ b/src/dmg_fmt_plug.c
@@ -728,7 +728,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 
 	memset(cracked, 0, sizeof(cracked[0])*cracked_count);

--- a/src/dragonfly3_fmt_plug.c
+++ b/src/dragonfly3_fmt_plug.c
@@ -172,7 +172,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/dragonfly4_fmt_plug.c
+++ b/src/dragonfly4_fmt_plug.c
@@ -178,7 +178,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/drupal7_fmt_plug.c
+++ b/src/drupal7_fmt_plug.c
@@ -161,7 +161,7 @@ static int cmp_exact(char *source, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/ecryptfs_fmt_plug.c
+++ b/src/ecryptfs_fmt_plug.c
@@ -199,7 +199,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/efs_fmt_plug.c
+++ b/src/efs_fmt_plug.c
@@ -251,7 +251,7 @@ static int kcdecrypt(unsigned char *key, unsigned char *iv, unsigned char *pwdha
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/eigrp_fmt_plug.c
+++ b/src/eigrp_fmt_plug.c
@@ -257,7 +257,7 @@ static unsigned char zeropad[16] = {0};
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/encfs_fmt_plug.c
+++ b/src/encfs_fmt_plug.c
@@ -131,7 +131,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 	if (any_cracked) {
 		memset(cracked, 0, cracked_size);

--- a/src/episerver_fmt_plug.c
+++ b/src/episerver_fmt_plug.c
@@ -191,7 +191,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/gost_fmt_plug.c
+++ b/src/gost_fmt_plug.c
@@ -182,7 +182,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/gpg_fmt_plug.c
+++ b/src/gpg_fmt_plug.c
@@ -1256,7 +1256,7 @@ static int check(unsigned char *keydata, int ks)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/hmacMD5_fmt_plug.c
+++ b/src/hmacMD5_fmt_plug.c
@@ -353,7 +353,7 @@ static int cmp_exact(char *source, int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #if _OPENMP

--- a/src/hmacSHA1_fmt_plug.c
+++ b/src/hmacSHA1_fmt_plug.c
@@ -307,7 +307,7 @@ static int cmp_exact(char *source, int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #if _OPENMP

--- a/src/hmacSHA224_fmt_plug.c
+++ b/src/hmacSHA224_fmt_plug.c
@@ -304,7 +304,7 @@ static int cmp_exact(char *source, int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #if defined(_OPENMP) || MAX_KEYS_PER_CRYPT > 1
 	int inc = 1;

--- a/src/hmacSHA256_fmt_plug.c
+++ b/src/hmacSHA256_fmt_plug.c
@@ -316,7 +316,7 @@ static int cmp_exact(char *source, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #if defined(_OPENMP) || MAX_KEYS_PER_CRYPT > 1
 	int inc = 1;

--- a/src/hmacSHA384_fmt_plug.c
+++ b/src/hmacSHA384_fmt_plug.c
@@ -333,7 +333,7 @@ static int cmp_exact(char *source, int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #if defined(_OPENMP) || MAX_KEYS_PER_CRYPT > 1
 	int inc = 1;

--- a/src/hmacSHA512_fmt_plug.c
+++ b/src/hmacSHA512_fmt_plug.c
@@ -344,7 +344,7 @@ static int cmp_exact(char *source, int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #if defined(_OPENMP) || MAX_KEYS_PER_CRYPT > 1
 	int inc = 1;

--- a/src/hsrp_fmt_plug.c
+++ b/src/hsrp_fmt_plug.c
@@ -182,7 +182,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/ike_fmt_plug.c
+++ b/src/ike_fmt_plug.c
@@ -227,7 +227,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -380,7 +380,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/keychain_fmt_plug.c
+++ b/src/keychain_fmt_plug.c
@@ -191,7 +191,7 @@ static int kcdecrypt(unsigned char *key, unsigned char *iv, unsigned char *data)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/keyring_fmt_plug.c
+++ b/src/keyring_fmt_plug.c
@@ -292,7 +292,7 @@ static int verify_decrypted_buffer(unsigned char *buffer, int len)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/keystore_fmt_plug.c
+++ b/src/keystore_fmt_plug.c
@@ -212,7 +212,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/known_hosts_fmt_plug.c
+++ b/src/known_hosts_fmt_plug.c
@@ -158,7 +158,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/krb5-18_fmt_plug.c
+++ b/src/krb5-18_fmt_plug.c
@@ -194,7 +194,7 @@ static void *get_binary(char *ciphertext)
 
 static int crypt_all(int *pcount, struct db_salt *_salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/krb5pa-md5_fmt_plug.c
+++ b/src/krb5pa-md5_fmt_plug.c
@@ -313,7 +313,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	const unsigned char one[] = { 1, 0, 0, 0 };
 	int i = 0;
 

--- a/src/krb5pa-sha1_fmt_plug.c
+++ b/src/krb5pa-sha1_fmt_plug.c
@@ -503,7 +503,7 @@ static void krb_encrypt(const unsigned char ciphertext[], size_t ctext_size,
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/kwallet_fmt_plug.c
+++ b/src/kwallet_fmt_plug.c
@@ -239,7 +239,7 @@ static int verify_passphrase(char *passphrase)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/lastpass_fmt_plug.c
+++ b/src/lastpass_fmt_plug.c
@@ -161,7 +161,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/lastpass_sniffed_fmt_plug.c
+++ b/src/lastpass_sniffed_fmt_plug.c
@@ -166,7 +166,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/lotus5_fmt_plug.c
+++ b/src/lotus5_fmt_plug.c
@@ -268,7 +268,7 @@ static void lotus_mix (unsigned char *m0, unsigned char *m1)
 /*the last public function; generates ciphertext*/
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 
 #ifdef _OPENMP

--- a/src/luks_fmt_plug.c
+++ b/src/luks_fmt_plug.c
@@ -546,7 +546,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/md2_fmt_plug.c
+++ b/src/md2_fmt_plug.c
@@ -129,7 +129,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/md4_gen_fmt_plug.c
+++ b/src/md4_gen_fmt_plug.c
@@ -181,7 +181,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	MD4_Init(&ctx);
 	if (saved_salt[1] == 'p') {
 		MD4_Update(&ctx, &saved_salt[2], (unsigned char)saved_salt[0]);

--- a/src/mdc2_fmt_plug.c
+++ b/src/mdc2_fmt_plug.c
@@ -122,7 +122,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/mongodb_fmt_plug.c
+++ b/src/mongodb_fmt_plug.c
@@ -189,7 +189,7 @@ static inline void hex_encode(unsigned char *str, int len, unsigned char *out)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/mozilla_ng_fmt_plug.c
+++ b/src/mozilla_ng_fmt_plug.c
@@ -270,7 +270,7 @@ static void set_salt(void *salt)
 // http://www.drh-consultancy.demon.co.uk/key3.html
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/mssql-old_fmt_plug.c
+++ b/src/mssql-old_fmt_plug.c
@@ -283,7 +283,7 @@ static int cmp_one(void * binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #ifdef MMX_COEF
 	unsigned i, index;
 

--- a/src/mssql05_fmt_plug.c
+++ b/src/mssql05_fmt_plug.c
@@ -457,7 +457,7 @@ static int cmp_one(void * binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #ifdef MMX_COEF
 	unsigned i, index;
 

--- a/src/mssql12_fmt_plug.c
+++ b/src/mssql12_fmt_plug.c
@@ -299,7 +299,7 @@ static int cmp_one(void *binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef MMX_COEF_SHA512
 	const int inc = MMX_COEF_SHA512;

--- a/src/mysqlSHA1_fmt_plug.c
+++ b/src/mysqlSHA1_fmt_plug.c
@@ -261,7 +261,7 @@ static int cmp_one(void * binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #ifdef MMX_COEF
 	unsigned int i;
 

--- a/src/mysql_netauth_fmt_plug.c
+++ b/src/mysql_netauth_fmt_plug.c
@@ -155,7 +155,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/net_md5_fmt_plug.c
+++ b/src/net_md5_fmt_plug.c
@@ -207,7 +207,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (cur_salt->magic != MAGIC) {

--- a/src/net_sha1_fmt_plug.c
+++ b/src/net_sha1_fmt_plug.c
@@ -199,7 +199,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (cur_salt->magic != MAGIC) {

--- a/src/nsldap_fmt_plug.c
+++ b/src/nsldap_fmt_plug.c
@@ -219,7 +219,7 @@ static int cmp_one(void * binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 #ifdef MMX_COEF
 	SSESHA1body(saved_key, (ARCH_WORD_32*)crypt_key, NULL, SSEi_MIXED_IN);

--- a/src/nt2_fmt_plug.c
+++ b/src/nt2_fmt_plug.c
@@ -545,10 +545,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 {
 #ifdef MMX_COEF
 #if (BLOCK_LOOPS > 1)
-	int count;
 	int i;
 
-	count = (*pcount + NBKEYS - 1) / NBKEYS;
+	const int count = (*pcount + NBKEYS - 1) / NBKEYS;
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -1098,7 +1098,7 @@ out:
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	if (!keys_prepared) {
 		int i = 0;

--- a/src/nukedclan_fmt_plug.c
+++ b/src/nukedclan_fmt_plug.c
@@ -190,7 +190,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/o5logon_fmt_plug.c
+++ b/src/o5logon_fmt_plug.c
@@ -158,7 +158,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/odf_fmt_plug.c
+++ b/src/odf_fmt_plug.c
@@ -261,7 +261,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/office_fmt_plug.c
+++ b/src/office_fmt_plug.c
@@ -578,7 +578,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0, inc = SHA1_LOOP_CNT;
 
 	if (cur_salt->version == 2013)

--- a/src/oldoffice_fmt_plug.c
+++ b/src/oldoffice_fmt_plug.c
@@ -264,7 +264,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/openbsdsoftraid_fmt_plug.c
+++ b/src/openbsdsoftraid_fmt_plug.c
@@ -171,7 +171,7 @@ static void *binary(char *ciphertext)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/opencl_7z_fmt_plug.c
+++ b/src/opencl_7z_fmt_plug.c
@@ -474,7 +474,7 @@ static int sevenzip_decrypt(unsigned char *derived_key, unsigned char *data)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i, index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_agilekeychain_fmt_plug.c
+++ b/src/opencl_agilekeychain_fmt_plug.c
@@ -343,7 +343,7 @@ static int akcdecrypt(unsigned char *derived_key, unsigned char *data)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_bf_fmt_plug.c
+++ b/src/opencl_bf_fmt_plug.c
@@ -120,7 +120,7 @@ static char *get_key(int index) {
 }
 
 static int crypt_all(int *pcount, struct db_salt *salt) {
-	int count = *pcount ;
+	const int count = *pcount ;
 	if (keys_mode != saved_salt.subtype) {
 		int i ;
 

--- a/src/opencl_blockchain_fmt_plug.c
+++ b/src/opencl_blockchain_fmt_plug.c
@@ -340,7 +340,7 @@ static int blockchain_decrypt(unsigned char *derived_key, unsigned char *data)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_cryptmd5_fmt_plug.c
+++ b/src/opencl_cryptmd5_fmt_plug.c
@@ -320,7 +320,7 @@ static void *binary(char *ciphertext)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	global_work_size = local_work_size ? (count + local_work_size - 1) / local_work_size * local_work_size : count;

--- a/src/opencl_cryptsha256_fmt_plug.c
+++ b/src/opencl_cryptsha256_fmt_plug.c
@@ -400,7 +400,7 @@ static int crypt_all_benchmark(int *pcount, struct db_salt *_salt)
 
 static int crypt_all(int *pcount, struct db_salt *_salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 	size_t gws;
 

--- a/src/opencl_cryptsha512_fmt_plug.c
+++ b/src/opencl_cryptsha512_fmt_plug.c
@@ -451,7 +451,7 @@ static int crypt_all_benchmark(int *pcount, struct db_salt *_salt) {
 
 static int crypt_all(int *pcount, struct db_salt *_salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 	size_t gws;
 

--- a/src/opencl_dmg_fmt_plug.c
+++ b/src/opencl_dmg_fmt_plug.c
@@ -736,7 +736,7 @@ static int hash_plugin_check_hash(unsigned char *derived_key)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_encfs_fmt_plug.c
+++ b/src/opencl_encfs_fmt_plug.c
@@ -283,7 +283,7 @@ static char* get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i, j, index;
 	size_t scalar_gws;
 

--- a/src/opencl_gpg_fmt_plug.c
+++ b/src/opencl_gpg_fmt_plug.c
@@ -1012,7 +1012,7 @@ static int check(unsigned char *keydata, int ks)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_keychain_fmt_plug.c
+++ b/src/opencl_keychain_fmt_plug.c
@@ -335,7 +335,7 @@ static void print_hex(unsigned char *str, int len)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_keyring_fmt_plug.c
+++ b/src/opencl_keyring_fmt_plug.c
@@ -333,7 +333,7 @@ static int verify_decrypted_buffer(unsigned char *buffer, int len)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_krb5pa-md5_fmt_plug.c
+++ b/src/opencl_krb5pa-md5_fmt_plug.c
@@ -322,7 +322,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 	size_t lws;
 

--- a/src/opencl_krb5pa-sha1_fmt_plug.c
+++ b/src/opencl_krb5pa-sha1_fmt_plug.c
@@ -665,7 +665,7 @@ static void krb_decrypt(const unsigned char ciphertext[], size_t ctext_size,
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 	int key_size;
 	size_t scalar_gws;

--- a/src/opencl_lotus5_fmt_plug.c
+++ b/src/opencl_lotus5_fmt_plug.c
@@ -267,7 +267,7 @@ static int cmp_exact (char *source, int index)
 /*the last public function; generates ciphertext*/
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t mem_cpy_sz;
 	size_t N, *M;
 

--- a/src/opencl_mscash2_fmt_plug.c
+++ b/src/opencl_mscash2_fmt_plug.c
@@ -265,7 +265,7 @@ static void pbkdf2_iter0(unsigned int *input_dcc_hash,unsigned char *salt_buffer
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount ;
+	const int count = *pcount ;
 	int salt_len;
 #ifdef _DEBUG
 	struct timeval startc, endc, startg, endg ;

--- a/src/opencl_mysqlsha1_fmt_plug.c
+++ b/src/opencl_mysqlsha1_fmt_plug.c
@@ -302,7 +302,7 @@ static int cmp_exact(char *source, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	global_work_size = local_work_size ? (count + local_work_size - 1) / local_work_size * local_work_size : count;

--- a/src/opencl_nsldaps_fmt_plug.c
+++ b/src/opencl_nsldaps_fmt_plug.c
@@ -343,7 +343,7 @@ static int cmp_exact(char *source, int index){
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	global_work_size = local_work_size ? (count + local_work_size - 1) / local_work_size * local_work_size : count;

--- a/src/opencl_nt_fmt_plug.c
+++ b/src/opencl_nt_fmt_plug.c
@@ -228,7 +228,7 @@ static void init(struct fmt_main *self)
 // TODO: Use concurrent memory copy & execute
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int key_length_mul_4 = (((max_key_length+1) + 3)/4)*4;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_ntlmv2_fmt_plug.c
+++ b/src/opencl_ntlmv2_fmt_plug.c
@@ -479,7 +479,7 @@ static void *get_binary(char *ciphertext)
 */
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_o5logon_fmt_plug.c
+++ b/src/opencl_o5logon_fmt_plug.c
@@ -305,7 +305,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 	size_t gws;
         size_t *lws = local_work_size ? &local_work_size : NULL;

--- a/src/opencl_odf_aes_fmt_plug.c
+++ b/src/opencl_odf_aes_fmt_plug.c
@@ -383,7 +383,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_odf_fmt_plug.c
+++ b/src/opencl_odf_fmt_plug.c
@@ -388,7 +388,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_office2007_fmt_plug.c
+++ b/src/opencl_office2007_fmt_plug.c
@@ -303,7 +303,7 @@ static void init(struct fmt_main *self)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t gws, scalar_gws;
 

--- a/src/opencl_office2010_fmt_plug.c
+++ b/src/opencl_office2010_fmt_plug.c
@@ -304,7 +304,7 @@ static void init(struct fmt_main *self)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t gws, scalar_gws;
 

--- a/src/opencl_office2013_fmt_plug.c
+++ b/src/opencl_office2013_fmt_plug.c
@@ -311,7 +311,7 @@ static void init(struct fmt_main *self)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t gws, scalar_gws;
 

--- a/src/opencl_oldoffice_fmt_plug.c
+++ b/src/opencl_oldoffice_fmt_plug.c
@@ -401,7 +401,8 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int index, count = *pcount;
+        int index;
+        const int count = *pcount;
 	int m = cur_salt->has_mitm;
 	size_t lws;
 

--- a/src/opencl_pbkdf2_hmac_sha1_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha1_fmt_plug.c
@@ -438,7 +438,7 @@ static char* get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 	size_t scalar_gws;
 

--- a/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
@@ -384,7 +384,8 @@ static int crypt_all_benchmark(int *pcount, struct db_salt *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i, count = *pcount;
+        int i;
+        const int count = *pcount;
 	int loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	opencl_limit_gws(count);

--- a/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
@@ -391,7 +391,8 @@ static void opencl_limit_gws(int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i, count = *pcount;
+        int i;
+        const int count = *pcount;
 	int loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	opencl_limit_gws(count);

--- a/src/opencl_phpass_fmt_plug.c
+++ b/src/opencl_phpass_fmt_plug.c
@@ -324,7 +324,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	global_work_size = local_work_size ? (((count + 7) / 8) + local_work_size - 1) / local_work_size * local_work_size : (count + 7 / 8);

--- a/src/opencl_pwsafe_fmt_plug.c
+++ b/src/opencl_pwsafe_fmt_plug.c
@@ -325,7 +325,7 @@ static int crypt_all_benchmark(int *pcount, struct db_salt *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i = 0;
 
 	global_work_size = (count + local_work_size - 1) / local_work_size * local_work_size;

--- a/src/opencl_rakp_fmt_plug.c
+++ b/src/opencl_rakp_fmt_plug.c
@@ -392,7 +392,7 @@ static int cmp_exact(char *source, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_rar5_fmt_plug.c
+++ b/src/opencl_rar5_fmt_plug.c
@@ -291,7 +291,8 @@ static int crypt_all_benchmark(int *pcount, struct db_salt *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i, count = *pcount;
+        int i;
+        const int count = *pcount;
 	int loops = host_salt->rounds / HASH_LOOPS;
 
 	loops += host_salt->rounds % HASH_LOOPS > 0;

--- a/src/opencl_rar_fmt_plug.c
+++ b/src/opencl_rar_fmt_plug.c
@@ -899,7 +899,7 @@ static int crypt_all_benchmark(int *pcount, struct db_salt *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 	int k;
 	size_t gws = ((count + (local_work_size - 1)) / local_work_size) * local_work_size;

--- a/src/opencl_rawmd4_fmt_plug.c
+++ b/src/opencl_rawmd4_fmt_plug.c
@@ -393,7 +393,7 @@ static void load_hash(struct db_salt *salt) {
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	global_work_size = local_work_size ? (count + local_work_size - 1) / local_work_size * local_work_size : count;

--- a/src/opencl_rawmd5_fmt_plug.c
+++ b/src/opencl_rawmd5_fmt_plug.c
@@ -264,7 +264,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	global_work_size = local_work_size ? (count + local_work_size - 1) / local_work_size * local_work_size : count;

--- a/src/opencl_rawsha1_fmt_plug.c
+++ b/src/opencl_rawsha1_fmt_plug.c
@@ -321,7 +321,7 @@ static int cmp_exact(char *source, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	if (local_work_size)

--- a/src/opencl_rawsha256_fmt_plug.c
+++ b/src/opencl_rawsha256_fmt_plug.c
@@ -368,7 +368,7 @@ static void * get_full_binary(char *ciphertext) {
 
 /* ------- Crypt function ------- */
 static int crypt_all(int *pcount, struct db_salt *_salt) {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_rawsha512_fmt_plug.c
+++ b/src/opencl_rawsha512_fmt_plug.c
@@ -508,7 +508,7 @@ static void * get_full_binary(char *ciphertext) {
 
 /* ------- Crypt function ------- */
 static int crypt_all(int *pcount, struct db_salt *_salt) {
-	int count = *pcount;
+	const int count = *pcount;
 	size_t gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_sha1crypt_fmt_plug.c
+++ b/src/opencl_sha1crypt_fmt_plug.c
@@ -283,7 +283,7 @@ static int crypt_all_benchmark(int *pcount, struct db_salt *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 	size_t scalar_gws;
 

--- a/src/opencl_strip_fmt_plug.c
+++ b/src/opencl_strip_fmt_plug.c
@@ -312,7 +312,7 @@ static int verify_page(unsigned char *page1)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_sxc_fmt_plug.c
+++ b/src/opencl_sxc_fmt_plug.c
@@ -406,7 +406,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/opencl_wpapsk_fmt_plug.c
+++ b/src/opencl_wpapsk_fmt_plug.c
@@ -272,7 +272,7 @@ static void init(struct fmt_main *self)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 	size_t scalar_gws;
 

--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -510,7 +510,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 

--- a/src/openssl_enc_fmt_plug.c
+++ b/src/openssl_enc_fmt_plug.c
@@ -375,7 +375,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 
 #ifdef _OPENMP

--- a/src/oracle11_fmt_plug.c
+++ b/src/oracle11_fmt_plug.c
@@ -294,7 +294,7 @@ static int cmp_one(void * binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #ifdef MMX_COEF
 	unsigned int index;
 

--- a/src/oracle_fmt_plug.c
+++ b/src/oracle_fmt_plug.c
@@ -250,7 +250,7 @@ static char *get_key(int index) {
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	unsigned char buf[sizeof(cur_salt)];
 	unsigned int l;
 

--- a/src/panama_fmt_plug.c
+++ b/src/panama_fmt_plug.c
@@ -125,7 +125,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/pbkdf2-hmac-sha1_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha1_fmt_plug.c
@@ -273,7 +273,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/pbkdf2-hmac-sha512_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha512_fmt_plug.c
@@ -274,7 +274,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/pbkdf2_hmac_sha256_fmt_plug.c
@@ -248,7 +248,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/pdf_fmt_plug.c
+++ b/src/pdf_fmt_plug.c
@@ -593,7 +593,7 @@ static void pdf_compute_user_password(unsigned char *password,  unsigned char *o
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/pfx_fmt_plug.c
+++ b/src/pfx_fmt_plug.c
@@ -230,7 +230,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -1314,7 +1314,7 @@ MAYBE_INLINE static int check_inflate_CODE1(u8 *next, int left) {
  */
 static int crypt_all(int *pcount, struct db_salt *_salt)
 {
-	int _count = *pcount;
+	const int _count = *pcount;
 	int idx;
 #if (ZIP_DEBUG==2)
 	static int CNT, FAILED, FAILED2;

--- a/src/postgres_fmt_plug.c
+++ b/src/postgres_fmt_plug.c
@@ -191,7 +191,7 @@ static inline void hex_encode(unsigned char *str, int len, unsigned char *out)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/pst_fmt_plug.c
+++ b/src/pst_fmt_plug.c
@@ -107,7 +107,7 @@ static int cmp_exact(char *source, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int i;
 
 #ifdef _OPENMP

--- a/src/putty_fmt_plug.c
+++ b/src/putty_fmt_plug.c
@@ -341,7 +341,7 @@ error:
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 	if (any_cracked) {

--- a/src/pwsafe_fmt_plug.c
+++ b/src/pwsafe_fmt_plug.c
@@ -514,7 +514,7 @@ static void pwsafe_sha256_iterate(unsigned int * state, unsigned int iterations)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/racf_fmt_plug.c
+++ b/src/racf_fmt_plug.c
@@ -242,7 +242,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/radmin_fmt_plug.c
+++ b/src/radmin_fmt_plug.c
@@ -121,7 +121,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 
 #ifdef _OPENMP

--- a/src/rakp_fmt_plug.c
+++ b/src/rakp_fmt_plug.c
@@ -308,7 +308,7 @@ static int cmp_exact(char *source, int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #if _OPENMP

--- a/src/rar5_fmt_plug.c
+++ b/src/rar5_fmt_plug.c
@@ -90,7 +90,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rar_fmt_plug.c
+++ b/src/rar_fmt_plug.c
@@ -659,7 +659,7 @@ static MAYBE_INLINE int check_huffman(unsigned char *next) {
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawBLAKE2_512_fmt_plug.c
+++ b/src/rawBLAKE2_512_fmt_plug.c
@@ -186,7 +186,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawKeccak_256_fmt_plug.c
+++ b/src/rawKeccak_256_fmt_plug.c
@@ -191,7 +191,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/rawKeccak_512_fmt_plug.c
+++ b/src/rawKeccak_512_fmt_plug.c
@@ -185,7 +185,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -268,7 +268,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -265,7 +265,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawSHA0_fmt_plug.c
+++ b/src/rawSHA0_fmt_plug.c
@@ -113,7 +113,7 @@ static int cmp_one(void * binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	SHA_Init( &ctx );
 	SHA_Update( &ctx, (unsigned char *) saved_key, strlen( saved_key ) );

--- a/src/rawSHA1_fmt_plug.c
+++ b/src/rawSHA1_fmt_plug.c
@@ -258,7 +258,7 @@ static void *binary(char *ciphertext)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawSHA1_linkedIn_fmt_plug.c
+++ b/src/rawSHA1_linkedIn_fmt_plug.c
@@ -260,7 +260,7 @@ static int cmp_one(void * binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
   // get plaintext input in saved_key put it into ciphertext crypt_key
 #ifdef MMX_COEF

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -249,7 +249,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -254,7 +254,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -1,3 +1,4 @@
+
 /*
  * This file is part of John the Ripper password cracker,
  * Copyright (c) 2010 by Solar Designer
@@ -274,7 +275,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -296,7 +296,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/rawmd5u_fmt_plug.c
+++ b/src/rawmd5u_fmt_plug.c
@@ -504,7 +504,7 @@ static int cmp_one(void *binary, int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #if defined(MMX_COEF)
 #if (BLOCK_LOOPS > 1)
 	int i;

--- a/src/rsvp_fmt_plug.c
+++ b/src/rsvp_fmt_plug.c
@@ -198,7 +198,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/salted_sha1_fmt_plug.c
+++ b/src/salted_sha1_fmt_plug.c
@@ -319,7 +319,7 @@ static inline void set_onesalt(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/sapB_fmt_plug.c
+++ b/src/sapB_fmt_plug.c
@@ -440,7 +440,7 @@ static unsigned int walld0rf_magic(const int index, const unsigned char *temp_ke
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #if MMX_COEF
 #if defined(_OPENMP)
 	int t;

--- a/src/sapG_fmt_plug.c
+++ b/src/sapG_fmt_plug.c
@@ -408,7 +408,7 @@ static inline void crypt_done(unsigned const int *source, unsigned int *dest, in
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 #if MMX_COEF
 
 #if defined(_OPENMP)

--- a/src/sha1_gen_fmt_plug.c
+++ b/src/sha1_gen_fmt_plug.c
@@ -184,7 +184,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	SHA1_Init(&ctx);
 	if (saved_salt[1] == 'p') {

--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -152,7 +152,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/sip_fmt_plug.c
+++ b/src/sip_fmt_plug.c
@@ -286,7 +286,7 @@ static void * binary(char *ciphertext) {
 }
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/ssh_ng_fmt_plug.c
+++ b/src/ssh_ng_fmt_plug.c
@@ -349,7 +349,7 @@ int bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt, size_t s
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -317,7 +317,7 @@ static void set_salt(void *salt) {
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index;
 
 #ifdef _OPENMP

--- a/src/strip_fmt_plug.c
+++ b/src/strip_fmt_plug.c
@@ -175,7 +175,7 @@ static int verify_page(unsigned char *page1)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/sunmd5_fmt_plug.c
+++ b/src/sunmd5_fmt_plug.c
@@ -516,7 +516,7 @@ static int nbig, nsmall;
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int idx, roundasciilen;
 	int round, maxrounds = BASIC_ROUND_COUNT + getrounds(saved_salt);
 	char roundascii[8];

--- a/src/sxc_fmt_plug.c
+++ b/src/sxc_fmt_plug.c
@@ -265,7 +265,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/tcp_md5_fmt_plug.c
+++ b/src/tcp_md5_fmt_plug.c
@@ -163,7 +163,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/tiger_fmt_plug.c
+++ b/src/tiger_fmt_plug.c
@@ -142,7 +142,7 @@ static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/trip_fmt.c
+++ b/src/trip_fmt.c
@@ -491,7 +491,7 @@ static MAYBE_INLINE void crypt_traverse_by_salt(int count)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	crypt_link_by_salt(count);
 	crypt_traverse_by_salt(count);
 	return count;

--- a/src/truecrypt_fmt_plug.c
+++ b/src/truecrypt_fmt_plug.c
@@ -284,7 +284,8 @@ static void AES_256_XTS_first_sector(const unsigned char *double_key,
 }
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i, count = *pcount;
+        int i;
+        const int count = *pcount;
 
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/vnc_fmt_plug.c
+++ b/src/vnc_fmt_plug.c
@@ -203,7 +203,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 
 #ifdef _OPENMP

--- a/src/vtp_fmt_plug.c
+++ b/src/vtp_fmt_plug.c
@@ -307,7 +307,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/wbb3_fmt_plug.c
+++ b/src/wbb3_fmt_plug.c
@@ -186,7 +186,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int index = 0;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/wow_srp_fmt_plug.c
+++ b/src/wow_srp_fmt_plug.c
@@ -371,7 +371,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 	int j;
 #ifdef _OPENMP
 #pragma omp parallel for

--- a/src/wpapsk_fmt_plug.c
+++ b/src/wpapsk_fmt_plug.c
@@ -349,7 +349,7 @@ static MAYBE_INLINE void wpapsk_sse(int count, wpapsk_password * in, wpapsk_hash
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int count = *pcount;
+	const int count = *pcount;
 
 	if (new_keys || strcmp(last_ssid, hccap.essid)) {
 #ifndef MMX_COEF


### PR DESCRIPTION
1. change 'int count = *pcount;' to 'const int count = *pcount;' 
2. Thus makes it clear that the variable 'count' will never be changed in crypt_all()