### PR TITLE
Add check for get_binary()

### DIFF
--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -93,6 +93,10 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto bail;
 	if (strlen(p) != 40)
 		goto bail;
+	if ((p = strtok(NULL, "$")) == NULL)	/* Fix bug: #1090 */
+		goto bail;
+	if (strlen(p) < 40)
+		goto bail;
 	MEM_FREE(keeptr);
 	return 1;
 bail:

--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -95,7 +95,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto bail;
 	if ((p = strtok(NULL, "$")) == NULL)	/* Fix bug: #1090 */
 		goto bail;
-	if (strlen(p) < 40)
+	if (strlen(p) != 40)
 		goto bail;
 	MEM_FREE(keeptr);
 	return 1;


### PR DESCRIPTION
Fix bug: #1090

update:

According to the valid() function, the hash below can also pass the valid check.

"$siemens-s7$1$599fe00cdb61f76cc6e949162f22c95943468acb$0"

So, there is a bug in get_binary().

line 120: static void get_binary(char *ciphertext)
line 121: {
line 122: static union {
line 123: unsigned char c[BINARY_SIZE];
line 124: ARCH_WORD dummy;
line 125: } buf;
line 126: unsigned char *out = buf.c;
line 127: char *p;
line 128: int i;
line 129: p = strrchr(ciphertext, '$') + 1;
line 130: for (i = 0; i < BINARY_SIZE; i++) {
line 131: out[i] = 
line 132: (atoi16[ARCH_INDEX(p)] << 4) |
line 133: atoi16[ARCH_INDEX(p[1])];
line 134: p += 2;
line 135: }
line 136: 
line 137: return out;
line 138: }

In line 129, p points to "0", and BINARY_SIZE is 20. But in line 132 and 133 it tries 
to visit *p and p[1], also p += 2, thus it will visit the unknown areas!