### PR TITLE
fix valid() in siemens-s7_fmt_plug.c

### DIFF
--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -78,7 +78,6 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	char *p;
 	char *ctcopy;
 	char *keeptr;
-	int outcome;
 	if (strncmp(ciphertext, "$siemens-s7$", 12) != 0)
 		return 0;
 	ctcopy = strdup(ciphertext);
@@ -86,8 +85,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	ctcopy += 12;		/* skip over "$siemens-s7$" */
 	if ((p = strtok(ctcopy, "$")) == NULL)	/* outcome, currently unused */
 		goto bail;
-	outcome = atoi(p);
-	if (outcome != 1 && outcome != 0)
+	if (strlen(p) != 1 || (*p != '1' && *p != '0')) /* outcome must be '1' or '0' */
 		goto bail;
 	if ((p = strtok(NULL, "$")) == NULL)	/* challenge */
 		goto bail;

--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -84,18 +84,18 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	ctcopy = strdup(ciphertext);
 	keeptr = ctcopy;
 	ctcopy += 12;		/* skip over "$siemens-s7$" */
-	if ((p = strtok(ctcopy, "$")) == NULL)	/* outcome */
+	if ((p = strtok(ctcopy, "$")) == NULL)	/* outcome, currently unused */
 		goto bail;
 	outcome = atoi(p);
 	if (outcome != 1 && outcome != 0)
 		goto bail;
 	if ((p = strtok(NULL, "$")) == NULL)	/* challenge */
 		goto bail;
-	if (strlen(p) != 40)
+	if (strlen(p) != 40 || !ishexlc(p))     /* must be hex string and lower cases*/
 		goto bail;
 	if ((p = strtok(NULL, "$")) == NULL)	/* Fix bug: #1090 */
 		goto bail;
-	if (strlen(p) != 40)
+	if (strlen(p) != 40 || !ishexlc(p))
 		goto bail;
 	MEM_FREE(keeptr);
 	return 1;


### PR DESCRIPTION
Add check for hex string and lower case, see #1091 
Add check for outcome field, close #1094 