### PR TITLE
add check in valid() for agilekeychain_fmt_plug.c

### DIFF
--- a/src/agilekeychain_fmt_plug.c
+++ b/src/agilekeychain_fmt_plug.c
@@ -108,7 +108,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	ctcopy += 15;
 	if ((p = strtok(ctcopy, "*")) == NULL)	/* nkeys */
 		goto err;
-	if(atoi(p) > 2)
+	if('0' != *p && '1' != *p && '2' != *p) /* must be '0' or '1' or '2' */
 		goto err;
 	if ((p = strtok(NULL, "*")) == NULL)	/* iterations */
 		goto err;


### PR DESCRIPTION

id | nkeys                  | Result    
---|------------------- | -------------
1| "0"                       | PASS
2|"1"                       | PASS
3|"2"                       | PASS
**4**|**"ABCDEF"**          | **PASS**
**5**|**"//\\\\+++--"**          | **PASS**
6|"3"          | FAILED
7|"123"          | FAILED

Should No.4 and No.5 nkeys pass the valid() check?
If they are should not, I guess **the author wants only '0' or '1' or '2'**?
Am I right?  @kholia 
