### PR TITLE
fix valid() function in src/blackberry_ES10_fmt_plug.c

### DIFF
--- a/src/blackberry_ES10_fmt_plug.c
+++ b/src/blackberry_ES10_fmt_plug.c
@@ -114,6 +114,8 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	keeptr = ctcopy;
 	ctcopy += FORMAT_TAG_LENGTH;
 
+	if (0 < strlen(ctcopy) && '$' == ctcopy[strlen(ctcopy) - 1]) /* Can not end with '$' */
+		goto err;
 	if ((p = strtokm(ctcopy, "$")) == NULL) /* hash */
 		goto err;
 	if(strlen(p) != BINARY_SIZE * 2)


### PR DESCRIPTION
There is a bug in src/blackberry_ES10_fmt_plug.c

$ cat format

$bbes10$76BDF6BE760FCF5DEE7B20E27632D1FEDD9D64E1BBCC941F42957E87CBFB96F176324B2E2C71976CEBE67CA6F400F33F001D7453D80F4AF5D80C8A93ED0BA0E6$DB1C19C0$

$ john format

This format can pass the valid(), but in **get_salt()** function, p points **""** which should be **"DB1C19C0"**. So the end of format can not be **'$'**.

```C
static void *get_salt(char *ciphertext)
{
	char *p;
	static struct custom_salt cs;

	memset(&cs, 0, sizeof(cs));
	p = strrchr(ciphertext, '$') + 1;
	strcpy((char*)cs.salt, p);

	return (void *)&cs;
}
```