### PR TITLE
fix segfault: --markov::default:

### DIFF
--- a/src/mkv.c
+++ b/src/mkv.c
@@ -353,7 +353,7 @@ void get_markov_options(struct db_main *db,
 		error();
 	}
 	/* treat 'empty' level token same as NULL, i.e. pull in from config */
-	if (!strlen(lvl_token))
+	if (NULL != lvl_token && !strlen(lvl_token))
 		lvl_token = 0;
 	if(lvl_token != NULL)
 	{


### PR DESCRIPTION
This is a bug found by fuzzing the options of John.

# 1. Prepare
## 1.1 content of 7z_fmt
$7z$0$19$0$1122$8$d1f50227759415890000000000000000$1412385885$112$112$5e5b8b734adf52a64c541a5a5369023d7cccb78bd910c0092535dfb013a5df84ac692c5311d2e7bbdc580f5b867f7b5dd43830f7b4f37e41c7277e228fb92a6dd854a31646ad117654182253706dae0c069d3f4ce46121d52b6f20741a0bb39fc61113ce14d22f9184adafd6b5333fb1

## 1.2 compile
$ ./configure && make -sj8

# 2. Reproduce

# 2.1 Run

$ ./john 7z_fmt --markov::default:

Loaded 1 password hash (7z, 7-Zip [SHA256 AES 32/64])
Will run 8 OpenMP threads
Note: This format may emit false positives, so it will keep trying even after
finding a possible candidate.
**Segmentation fault (core dumped)**

# 2.2 GDB debug

#0  get_markov_options (db=db@entry=0x104a1c0 <database>, mkv_param=0x187d0af "default",
    mkv_minlevel=mkv_minlevel@entry=0x7fffb278c0f8, mkv_level=mkv_level@entry=0x7fffb278c0fc,
    start_token=start_token@entry=0x7fffb278c110, end_token=end_token@entry=0x7fffb278c118,
    mkv_minlen=mkv_minlen@entry=0x7fffb278c104, mkv_maxlen=mkv_maxlen@entry=0x7fffb278c100, statfile=statfile@entry=0x7fffb278c108)
    at mkv.c:359
#1  0x000000000060ed69 in do_markov_crack (db=0x104a1c0 <database>, mkv_param=<optimized out>) at mkv.c:618
#2  0x00000000005ecd08 in john_run () at john.c:1406
#3  0x00000000005ed528 in main (argc=3, argv=0x7fffb278c3e8) at john.c:1687