### PR TITLE
report error message and exit when --input-encoding= a long string

### DIFF
--- a/src/unicode.c
+++ b/src/unicode.c
@@ -958,7 +958,9 @@ int cp_name2id(char *encoding)
 	char enc[16] = "";
 	char *d = enc;
 
-	if (!encoding || strlen(encoding) > sizeof(enc))
+	if (!encoding)
+		return CP_UNDEF;
+	if (strlen(encoding) > sizeof(enc))
 		goto err;
 
 	/* Strip iso prefix */

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -959,7 +959,7 @@ int cp_name2id(char *encoding)
 	char *d = enc;
 
 	if (!encoding || strlen(encoding) > sizeof(enc))
-		return CP_UNDEF;
+		goto err;
 
 	/* Strip iso prefix */
 	if (!strncasecmp(encoding, "iso-", 4))
@@ -1041,8 +1041,8 @@ int cp_name2id(char *encoding)
 	else
 	if (!strcmp(enc, "raw") || !strcmp(enc, "ascii"))
 		return ASCII;
-	else
 
+ err:
 	fprintf(stderr, "Invalid encoding. Supported encodings:\n");
 	listEncodings(stderr);
 	exit(EXIT_FAILURE);


### PR DESCRIPTION
closes #1157.