### PR TITLE
Change deprecated optparse to argparse

### DIFF
--- a/run/aix2john.py
+++ b/run/aix2john.py
@@ -4,7 +4,7 @@ import binascii
 import sys
 
 try:
-    import optparse
+	 import argparse
 except ImportError:
     sys.stderr.write("Stop living in the past. Upgrade your python!\n")
 
@@ -54,14 +54,14 @@ if __name__ == "__main__":
             "(/etc/security/passwd)>\n" % sys.argv[0])
         sys.exit(-1)
 
-parser = optparse.OptionParser()
-parser.add_option('-s', action="store_true",
-                  default=False,
-                  dest="is_standard",
-                  help='Use this option if "lpa_options '
-                        '= std_hash=true" is activated'
-                  )
-options, remainder = parser.parse_args()
+parser = argparse.ArgumentParser()
+parser.add_argument('-s', action="store_true",
+						default=False,
+						dest="is_standard",
+						help='Use this option if "lpa_options '
+								'= std_hash=true" is activated'
+						)
+args = parser.parse_args()
 
 for f in remainder:
     process_file(f, options.is_standard)

--- a/run/bitcoin2john.py
+++ b/run/bitcoin2john.py
@@ -789,20 +789,16 @@ def read_wallet(json_db, walletfile, print_wallet, print_wallet_transactions, tr
         return {'crypted':crypted}
 
 
-from optparse import OptionParser
 
 if __name__ == '__main__':
 
-    parser = OptionParser(usage="%prog [bitcoin wallet files]")
 
-    (options, args) = parser.parse_args()
-
-    if len(args) < 1:
+    if len(sys.argv) < 2:
         print >> sys.stderr, "Usage: %s [bitcon wallet files]" % sys.argv[0]
         sys.exit(-1)
 
-    for i in range(0, len(args)):
-        filename = args[i]
+    for i in range(0, len(sys.argv)):
+        filename = sys.argv[i]
         if read_wallet(json_db, filename, True, True, "", False) == -1:
             continue
 

--- a/run/blockchain2john.py
+++ b/run/blockchain2john.py
@@ -4,31 +4,34 @@ import sys
 import base64
 import binascii
 from optparse import OptionParser
+import argparse
 
 if __name__ == '__main__':
 
-    parser = OptionParser(usage="%prog [blockchain wallet files]")
+    parser = argparse.ArgumentParser(prog='blockchain2john.py', usage="%(prog)s [blockchain wallet files]")
+    parser.add_argument('--json', action='store_true', 
+								default=False,
+								dest='json', 
+								help='is input in base64 format?'
+								)
 
-    parser.add_option("--json", dest="json", action="store_true",
-            default=False, help="is input in base64 format?")
+    args = parser.parse_args()
 
-    (options, args) = parser.parse_args()
-
-    if len(args) < 1:
+    if len(sys.argv) < 2:
         parser.print_help()
         sys.exit(-1)
 
     if options.json:
-        for i in range(0, len(args)):
-            filename = args[i]
+        for i in range(0, len(sys.argv)):
+            filename = sys.argv[i]
             with open(filename, "rb") as f:
                 data = f.read()
                 ddata = base64.decodestring(data)
                 print "%s:$blockchain$%s$%s" % (filename,
                         len(ddata), binascii.hexlify(ddata))
     else:
-        for i in range(0, len(args)):
-            filename = args[i]
+        for i in range(0, len(sys.argv)):
+            filename = sys.argv[i]
             with open(filename, "rb") as f:
                 data = f.read()
                 print "%s:$blockchain$%s$%s" % (filename,

--- a/run/efs2john.py
+++ b/run/efs2john.py
@@ -25,7 +25,8 @@ try:
 except ImportError:
     sys.stderr.write("For additional functionality, please install python-m2crypto package.\n")
 import cPickle
-from optparse import OptionParser
+#from optparse import OptionParser
+import argparse
 from collections import defaultdict
 
 
@@ -1050,19 +1051,24 @@ efs2john.py --masterkey=samples/Win-2012-non-DC/1b52eb4f-440f-479e-b84a-654fdcca
 """
 
 if __name__ == "__main__":
-    parser = OptionParser()
-    parser.add_option("--sid", metavar="SID", dest="sid")
-    parser.add_option("--masterkey", metavar="DIRECTORY", dest="masterkey")
-    parser.add_option("--password", metavar="PASSWORD", dest="password")
+    #parser = OptionParser()
+    parser =  argparse.ArgumentParser()
+    #parser.add_option("--sid", metavar="SID", dest="sid")
+    parser.add_argument("--sid", metavar="SID", dest="sid")
+    #parser.add_option("--masterkey", metavar="DIRECTORY", dest="masterkey")
+    parser.add_argument("--masterkey", metavar="DIRECTORY", dest="masterkey")
+    #parser.add_option("--password", metavar="PASSWORD", dest="password")
+    parser.add_argument("--password", metavar="PASSWORD", dest="passwprd")
 
-    (options, args) = parser.parse_args()
+    #(options, args) = parser.parse_args()
+    args = parser.parse_args()
 
     mkp = MasterKeyPool()
-    if not options.sid:
+    if not args.sid:
         usage()
         sys.exit(-1)
 
-    mkdata = open(options.masterkey, 'rb').read()
-    mkp.addMasterKey(mkdata, SID=options.sid)
-    if options.password:
-        print mkp.try_credential(options.sid, options.password)
+    mkdata = open(args.masterkey, 'rb').read()
+    mkp.addMasterKey(mkdata, SID=args.sid)
+    if args.password:
+        print mkp.try_credential(args.sid, args.password)

--- a/run/efs2john.py
+++ b/run/efs2john.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     sys.stderr.write("For additional functionality, please install python-m2crypto package.\n")
 import cPickle
-#from optparse import OptionParser
 import argparse
 from collections import defaultdict
 
@@ -1051,16 +1050,11 @@ efs2john.py --masterkey=samples/Win-2012-non-DC/1b52eb4f-440f-479e-b84a-654fdcca
 """
 
 if __name__ == "__main__":
-    #parser = OptionParser()
     parser =  argparse.ArgumentParser()
-    #parser.add_option("--sid", metavar="SID", dest="sid")
     parser.add_argument("--sid", metavar="SID", dest="sid")
-    #parser.add_option("--masterkey", metavar="DIRECTORY", dest="masterkey")
     parser.add_argument("--masterkey", metavar="DIRECTORY", dest="masterkey")
-    #parser.add_option("--password", metavar="PASSWORD", dest="password")
     parser.add_argument("--password", metavar="PASSWORD", dest="passwprd")
 
-    #(options, args) = parser.parse_args()
     args = parser.parse_args()
 
     mkp = MasterKeyPool()

--- a/run/openssl2john.py
+++ b/run/openssl2john.py
@@ -2,8 +2,8 @@
 
 import sys
 import base64
-import optparse
-
+#import optparse
+import argparse
 
 def process(filename, plaintext=None, cipher=0, md=0):
 
@@ -50,11 +50,16 @@ if __name__ == '__main__':
         sys.stderr.write("md: 0 => md5, 1 => sha1\n")
         sys.exit(-1)
 
-    parser = optparse.OptionParser()
-    parser.add_option('-p', action="store", dest="plaintext")
-    parser.add_option('-c', action="store", dest="cipher", default=0)
-    parser.add_option('-m', action="store", dest="md", default=0)
-    options, remainder = parser.parse_args()
+    #parser = optparse.OptionParser()
+    parser = argparse.ArgumentParser()
+    #parser.add_option('-p', action="store", dest="plaintext")
+    parser.add_argument('-p', action="store", dest="plaintext")
+    #parser.add_option('-c', action="store", dest="cipher", default=0)
+    parser.add_argument('-c', action="store", dest="cipher", default=0)
+    #parser.add_option('-m', action="store", dest="md", default=0)
+    parser.add_argument('-m', action="store", dest="md", default=0)
+    #options, remainder = parser.parse_args()
+    args = parser.parse_args()
 
-    for j in range(0, len(remainder)):
-        data = process(remainder[j], options.plaintext, options.cipher, options.md)
+    for j in range(0, len(parser.REMAINDER)):
+        data = process(parser.REMAINDER[j], args.plaintext, args.cipher, args.md)


### PR DESCRIPTION
Change deprecated optparse to argparse in:
- aix2john.py
- bitcoin2john.py
- blockchain2john.py
To fix part of this issue:  Python helpers overhaul #1057 
------EDITED----
Added:
- efs2john.py
- openssl2john.py