### PR TITLE
A few fixes which might need discussion

### DIFF
--- a/src/listconf.c
+++ b/src/listconf.c
@@ -203,6 +203,24 @@ static void listconf_list_build_info(void)
 #if defined(__clang_version__) && !__INTEL_COMPILER
 	printf("clang version: %s\n", __clang_version__);
 #endif
+
+#ifdef _MSC_VER
+/*
+ * See https://msdn.microsoft.com/en-us/library/b0084kay.aspx
+ * Currently, _MSC_BUILD is not reported, but we could convert
+ * _MSC_FULL_VER 150020706 and _MSC_BUILD 1 into a string
+ * "15.00.20706.01".
+ */
+#ifdef _MSC_FULL_VER
+	printf("Microsoft compiler version: %d\n", _MSC_FULL_VER);
+#else
+	printf("Microsoft compiler version: %d\n", _MSC_VER);
+#endif
+#ifdef __CLR_VER
+	puts("Common Language Runtime version: " __CLR_VER);
+#endif
+#endif
+
 #ifdef __GLIBC_MINOR__
 #ifdef __GNUC__
 	printf("GNU libc version: %d.%d (loaded: %s)\n",

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -161,6 +161,9 @@ static void listconf_list_build_info(void)
 #endif
 	puts("Version: " JOHN_VERSION _MP_VERSION DEBUG_STRING MEMDBG_STRING ASAN_STRING);
 	puts("Build: " JOHN_BLD);
+#ifdef __TIMESTAMP__
+	puts("Time stamp: " __TIMESTAMP__);
+#endif
 	printf("Arch: %d-bit %s\n", ARCH_BITS,
 	       ARCH_LITTLE_ENDIAN ? "LE" : "BE");
 #if JOHN_SYSTEMWIDE

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -49,6 +49,10 @@
 #endif
 #endif
 
+#if __GNUC__
+#include <gnu/libc-version.h>
+#endif
+
 #include "regex.h"
 
 #ifdef NO_JOHN_BLD
@@ -191,6 +195,12 @@ static void listconf_list_build_info(void)
 #endif
 #if defined(__clang_version__) && !__INTEL_COMPILER
 	printf("clang version: %s\n", __clang_version__);
+#endif
+#ifdef __GLIBC_MINOR__
+#ifdef __GNUC__
+	printf("GNU libc version: %d.%d (loaded: %s)\n",
+	       __GLIBC__, __GLIBC_MINOR__, gnu_get_libc_version());
+#endif
 #endif
 #if HAVE_CUDA
 	printf("CUDA library version: %s\n",get_cuda_header_version());

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -11,6 +11,10 @@
 #include "autoconfig.h"
 #endif
 
+#if HAVE_OPENCL
+#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
+#endif
 #define NEED_OS_FLOCK
 #include "os.h"
 

--- a/src/options.c
+++ b/src/options.c
@@ -33,6 +33,7 @@
 #include "dynamic.h"
 #include "unicode.h"
 #include "fake_salts.h"
+#include "path.h"
 #include "regex.h"
 #ifdef HAVE_MPI
 #include "john-mpi.h"
@@ -591,6 +592,9 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 			}
 		}
 #endif
+		path_done();
+		cleanup_tiny_memory();
+		MEMDBG_PROGRAM_EXIT_CHECKS(stderr);
 		exit(0);
 	}
 #if FMT_MAIN_VERSION > 11

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -385,6 +385,20 @@ void rec_done(int save)
 
 static void rec_format_error(char *fn)
 {
+	path_done();
+	cleanup_tiny_memory();
+
+	/*
+	 * MEMDBG_PROGRAM_EXIT_CHECKS() would cause the output
+	 *     At Program Exit
+	 *     MemDbg_Validate level 0 checking Passed
+	 * to be writen prior to the
+	 *     Incorrect crash recovery file: ...
+	 * output.
+	 * Not sure if we want this.
+	 */
+	// MEMDBG_PROGRAM_EXIT_CHECKS(stderr); // FIXME
+
 	if (fn && errno && ferror(rec_file))
 		pexit("%s", fn);
 	else {


### PR DESCRIPTION
1. report glibc version with --list=build-info
2. Add _BSD_SOURCE and _DEFAULT_SOURCE definitions to listconf.c for HAVE_OPENCL (We use setenv() here, but didn't have the feature request definitions...)
3. Fix some memory leaks for ./john --status
4. Report build timestamp with --list=build-info
5. Report MS compiler version with --list=build-info

