### PR TITLE
Close #1242

### DIFF
--- a/src/pp.c
+++ b/src/pp.c
@@ -882,7 +882,10 @@ static double get_progress(void)
   mpf_init(fpos); mpf_init(perc);
 
   mpf_set_z(fpos, rec_pos);
-  mpf_div(perc, fpos, count);
+  if ((double)0 == count)
+    perc = 0;
+  else
+    mpf_div(perc, fpos, count);
   progress = 100.0 * mpf_get_d(perc);
 
   mpf_clear(fpos); mpf_clear(perc);


### PR DESCRIPTION
Close #1242

mpf_div(perc, fpos, count);

Handle the case that `0==count`