### PR TITLE
Fix: 32bit build with GMP fails

### DIFF
--- a/src/mpz_int128.h
+++ b/src/mpz_int128.h
@@ -193,6 +193,7 @@ extern double __ntod(__uint128_t);
 #else
 #define mpf_set_z(x, y) x = y
 #endif // __MIC__
+#define mpf_sgn(F) ((F) < (double)0.0 ? -1 : (F) > (double)0.0)
 #define mpf_div(q, n, d) q = n / d
 #define mpf_clear(x) x = 0
 #define mpf_get_d(x) x

--- a/src/pp.c
+++ b/src/pp.c
@@ -882,9 +882,7 @@ static double get_progress(void)
   mpf_init(fpos); mpf_init(perc);
 
   mpf_set_z(fpos, rec_pos);
-  if ((double)0 == count)
-    perc = 0;
-  else
+  if (0 != mpf_sgn(count))
     mpf_div(perc, fpos, count);
   progress = 100.0 * mpf_get_d(perc);
 


### PR DESCRIPTION
Close #1268 

When **GNP** is supported, `mpf_t` is not `double` and it is defined in `gmp.h`.
GMP has the function `mpf_sgn` to check the value of `mpf_t`, and I define one in `mpz_int128.h`