### PR TITLE
Fix: ssh2john.c double free

### DIFF
--- a/src/ssh2john.c
+++ b/src/ssh2john.c
@@ -83,8 +83,9 @@ static void process_file(const char *filename)
 					PEM_R_NO_START_LINE) {
 				/* ERR_print_errors_fp(stderr); */
 				fprintf(stderr, "! %s : %s\n", filename, "input keyfile validation failed");
-				goto out;
 			}
+			fclose(keyfile);
+			return;
 		}
 		if(!nm) {
 			fprintf(stderr, "! %s : %s\n", filename, "input keyfile validation failed");


### PR DESCRIPTION
# 1. Bug analysis
`OPENSSL_free(data);` is **double free** in the case below:

1. `PEM_read_bio(bp, &nm, &header, &data, &len)`  return true
2. `OPENSSL_free(data)`
3. `PEM_read_bio(bp, &nm, &header, &data, &len)`  return false
4. `goto out;`
5. `OPENSSL_free(data)`

So step 5 double free **data**.

# 2. Reproduce

$ ./configure --enable-asan && make -sj8
$ ../ssh2john ssh-new-format-1.key
```
! test_ssh/openssh-new-format-keys/ssh-new-format-1.key : input keyfile validation failed
=================================================================
==60725==ERROR: AddressSanitizer: attempting double-free on 0x61e00000f080 in thread T0:
    #0 0x7f577e3115c7 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x545c7)
    #1 0x7f577dce4f8c in CRYPTO_free (/lib/x86_64-linux-gnu/libcrypto.so.1.0.0+0x5ff8c)
    #2 0x4e538a in process_file /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/ssh2john.c:158
    #3 0x4e54ca in ssh2john /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/ssh2john.c:178
    #4 0x73e0ca in main /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/john.c:1605
    #5 0x7f577cd54ec4 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21ec4)
    #6 0x406b32 (/home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john+0x406b32)

0x61e00000f080 is located 0 bytes inside of 2448-byte region [0x61e00000f080,0x61e00000fa10)
freed by thread T0 here:
    #0 0x7f577e3115c7 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x545c7)
    #1 0x7f577dce4f8c in CRYPTO_free (/lib/x86_64-linux-gnu/libcrypto.so.1.0.0+0x5ff8c)
    #2 0x4e54ca in ssh2john /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/ssh2john.c:178
    #3 0x73e0ca in main /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/john.c:1605
    #4 0x7f577cd54ec4 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21ec4)

previously allocated by thread T0 here:
    #0 0x7f577e311a96 in __interceptor_realloc (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x54a96)
    #1 0x7f577dce4e28 in CRYPTO_realloc (/lib/x86_64-linux-gnu/libcrypto.so.1.0.0+0x5fe28)

SUMMARY: AddressSanitizer: double-free ??:0 __interceptor_free
==60725==ABORTING
Aborted
```
$ cat ssh-new-format-1.key
```
-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jYmMAAAAGYmNyeXB0AAAAGAAAABCtd/cYpB
4IxeFLsu6JwG5PAAAAEAAAAAEAAAEXAAAAB3NzaC1yc2EAAAADAQABAAABAQCXnUtxR3Br
8QLnKbcgt4T+wkPCq+6ccDk2+aqVvoYT01H9/GlCeAt9HN5HVV4bpfS4BXnVgJ3CRaeFsu
P42RSScSgzj+VDvbPUh6hUHgOWw49UzCgxjadfMUTzLxATqSpWyHsFoqwOphXBnSASoyEX
+D7RVDtNi2jx1XUq2VGebsWPee1iZf1RJrpZqrJCzvOWTA7H10UKAGTH1Mb6ZqCjD50tay
1u0ZtSBmVwGaQL1Degv8tUCBQHwHv6rTzKckN9aae5K29l1sPBJFMYiEYoczT+UbSkJOFC
VzdZVmzHmhguqpH5nlgm6j9HB027CPCE+GmTeyKAvDd+2RSWpXEBAAAD4HFtoj7ssl+ab2
a4JcZuzcuxzZWbmn+ALIbyDoI3oadCZ8dNH2SoxQMqseK5ye6JRP3slJOcIIruy/Zif5Fb
1cXnJhum6mvxemyRp7CzsbCVJ/Een9Q/YA5zFoaVDnsvPgFzZ/AQ+lxtQsxs5b5vAs+v2L
jn3JNqCH1idePzNYnYIM1ymaiy30u+Dy09DGyNJeGYbJXr1F/bIb7T69yNEKuoHvhiLYgJ
bRVxCgSlLrBLFnmVD60LCLotVjJXD2SqJnm34Ht0ju+dswoYuczLqg5jVNUhmAadUl3jHg
NupPZ0F6BarDHNJ3hNJtd96VzH+tObarOvzvOI+rVZ3AxMVsHKFRJ2yXA9mUwvsg75geZc
3xTq92oMB1y7MW8gtsK5qvP23LAma9nhStBg//xEmBLnR+tOxlqqI1Oa96NweBvhksMJWf
bUiyixL/+EuNxA73peTNYpxXh+GURd0nUjf3Otu70qP3ytSDt+s1nhKfRUH9Z66zXXZH5u
jEb35nDjsmS38bLYOPnpOg0pkv7a/gSiasHmBfd4C/oR/2Qf9e8mg4j6RZGjufcrGsuklC
eiBUIN3YpmLN4GaJXOVZXSMmq7ZdDatl4AOQhU9n4d9uQq1VP82unDlR7B9Sgut+YbXGDd
U/u/TOter/kXk6xtf32X4DWnzsA72oygg4yn/G9/lvaIcI+DBX9NDqlAekcGgJMRE5YWS5
RDrwW4KS2j8CBIWIu3TWmnmkr4YVQj63GPQKY8WlbjujJ4LQ9xMxgUc4An8hxvjnPtjv6r
QHruK4d5hhemGkKhi/nJUdi6DpNTUWZB1ZL0RA35QGByOyVht48twYIlG9n8tkYy01jZA0
l8yQjuRIXaeFXqIiv3PI6mhIRVPX9WalP6iM5eFSn0SfWYLGxV4GKvhjYxagNtumVGHcJK
a9AMeUS4KSbCDaL70u/ssY/oy0SCcoOS6hNwcidKZQsPAlrBoPEPdij3BuqugVJY8AfK0t
6hWsqoM03/AvBpwTj3J59SpSz7Tgkiu4fTmrLVJLBq0eHttIOmr9udK7SiyOyCTMmDRBeo
XgdMKZsjAFeFeKqrVdczjBKi97JxA/rk2vlbmKcxGx1Kha2VDmc7Uf9Qp1+x2TMpf1axZR
+U+Lqg9mg6/I8M5d0tFtnl//h9yvh+WxvJW71rfcPvOshnx7s1LkOxD8fJgiZ1gvDBmzZM
18ezd2F2azLLLpcYEb7klfgwkRiCgNltj6IDppD4qEm/eCZhfYnAJ9leHqc/rvSQ0BYSad
saPc+8nP4HKBL2w5XaU21t0BW4PVrbPgu4xdad+woK4dhk3aBv
-----END OPENSSH PRIVATE KEY-----
```
