### PR TITLE
Fix: gpg2john.c buffer over flow

### DIFF
--- a/src/gpg2john.c
+++ b/src/gpg2john.c
@@ -2583,6 +2583,10 @@ read_radix64(byte *p, unsigned int max)
 			done = YES;
 			return out;
 		}
+
+		if (sizeof(base256) <= c)
+			warn_exit("illegal radix64 character.");
+
 		d = base256[c];
 		switch (d) {
 		case OOB:


### PR DESCRIPTION
# 1. Bug analysis

`128 == sizeof(base256)`

There is **buffer over flow** when c is bigger than 127.

```C
                c = getchar();
                if (c == EOF) {
                        done = YES;
                        return out;
                }

                d = base256[c];
```

# 2. Reproduce

$ ./configure --enable-asan && make -sj8
$ ../gpg2john  failed_gpg
```
=================================================================
==130292==ERROR: AddressSanitizer: global-buffer-overflow on address 0x000000940230 at pc 0x7a3ed5 bp 0x7ffcfbd43be0 sp 0x7ffcfbd43bd8
READ of size 1 at 0x000000940230 thread T0
    #0 0x7a3ed4 in read_radix64 /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/gpg2john.c:2586
    #1 0x7a379d in decode_radix64 /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/gpg2john.c:2629
    #2 0x7a42d0 in Getc1 /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/gpg2john.c:2764
    #3 0x7a8772 in parse_packet /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/gpg2john.c:1405
    #4 0x7a8bf5 in gpg2john /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/gpg2john.c:348
    #5 0x73e2ce in main /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/john.c:1664
    #6 0x7fcd2fcc7ec4 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21ec4)
    #7 0x406b32 (/home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john+0x406b32)
```
$ cat failed_gpg
```
-----BEGIN PGP P

lQHpBFJ�PVIRBADhjnqRa7AYQIGerrlrti+lGb6oetURRTM6kYoJJrBO83q9bgjD
eYDmZqDh4j5UIkqjeMbSo0mKuTR9spAFQ3L8jRAxVgE5FQcRiPYOePQN3mo1R+cF
KmY3Fw9Q6S5Y+Rdwa1QUaqljsLgaEi88TI9EGu/2gW5aV1dqB5Eyu9uV5wCg1AfC
uIsPh/FtPxNKVhUWjbHk9RUEANi6IkwlhKBD11knjdtcBPS61vvYNYJhoPXVkurI
TpCJ0gOo2U5JJVb+WeJLIYe78XrY5itcb5P6JIWV0iM8WQlIHxVx48VdSHjnHfSS
kT6UNH10/maXGpnQx9JLkwi4lGjecLDDI2vvcFfB+qRbI2w623TpDyllQDBNPQEO
4L8rBACqbDXTM1OmbuANKcir7CNSu6TbJ4hR1ctlbPRyedkUdCZmTEczaGeGqhm8
+DK4TzHkU+HJznZE0JhgiVIcqGn9eSx+x5WlqmZ2dDJ62gDBUB+mdQzkVT67viDh
XncWZee2UTmMCrKDrYwU/MSEF28j7INs4edK3HsDNkM/FEu3rf4NAwIAsY7pUEEc
bWDRvzwrhYy6J/fTqnWqrfVKTJiVZ0MgrGpsVjyjNXLnth0lrlIdTAhFJIWNFjse
+zSds7CkbAjst1HstEJKdFIgKHBhc3MgaXMgU0hBMS1DQU1FTExJQTI1Ni1vcGVu
d2FsbCkgPFNIQTEtQ0FNRUxMSUEyNTZAZm9vLmJhcj6IYgQTEQIAIgUCUnQ9UgIb
IwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQO6SEN2ooQmHxXgCdE2df3Exr
Q3XvGw8zFzSg675j0wEAoJcaXReCOqQ69t4pIimVQdvfIW0unQFgBFJ0PVIQBADR
1Zykqay99zmIGM841/HuwZAboZz44UQS3q7LIoI1urrcrQvRcvtEI2D8cTv14jyg
VFXchPwPKL7kjBukUds5cwdywrDkVGZVi7YHlFosQDveiP7uPPjaGB6oAiv6yFji
qPxYIbi/hEbyFM1dU/Ak9Qwb5hAyDuLGrmNuBlT/YwADBgP/SH8zO55u+Nq2If/Q
Dqga/sSH7nibEd+7mmrSWxapvY+YXEtQ4tGkaLwilU+p6TR0NUUijgBmx57Dd6Ap
LyyJnfZ7znX8mgQV/ZVszwpXThNCh704pj/V0KwoNM0wB08n0Ix7FazjRmUF7E31
/n6cMSdLn/oXEIyDFT2eFi3DMNn+DQMCALGO6VBBHG1gDaBxogXngCDx56cYuH9t
/ruz2w5yEYSF3wry+i2THfN38f3cvvBr3nw9rgNrrtXdyReICN432djz2ZpyyDOU
sb2a98fjjYhJBBgRAgAJBQJSdD1SAhsMAAoJEDukhDdqKEJhsakAniEVBUtkoAK8
3gXMFIB7G8GeoREFAKDTRvQhNIBdaADNGGAsZOvBuQcQFw==
```