### PR TITLE
Fix: keepass2john heap-buffer-overflow

### DIFF
--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -104,16 +104,13 @@ static void print_hex(unsigned char *str, int len)
 		printf("%02x", str[i]);
 }
 
-static uint64_t BytesToUInt64(unsigned char * s)
+static uint64_t BytesToUInt64(unsigned char * s, const int s_size)
 {
-	uint64_t v = s[0];
-	v |= (uint64_t)s[1] << 8;
-	v |= (uint64_t)s[2] << 16;
-	v |= (uint64_t)s[3] << 24;
-	v |= (uint64_t)s[4] << 32;
-	v |= (uint64_t)s[5] << 40;
-	v |= (uint64_t)s[6] << 48;
-	v |= (uint64_t)s[7] << 56;
+	int i;
+	uint64_t v = 0;
+
+	for (i = 0; i < 8 && i < s_size; i++)
+		v |= (uint64_t)s[i] << 8 * i;
 	return v;
 }
 
@@ -320,7 +317,7 @@ static void process_database(char* encryptedDatabase)
 					goto bailout;
 				}
 				else {
-					transformRounds = BytesToUInt64(pbData);
+					transformRounds = BytesToUInt64(pbData, uSize);
 					MEM_FREE(pbData);
 				}
 				break;


### PR DESCRIPTION
# 1. Analysis
There is **heap-buffer overflow** in `BytesToUInt64()`, since the array which **s** points to maybe smaller than 8.
```C
static uint64_t BytesToUInt64(unsigned char * s)
{
        uint64_t v = s[0];
        v |= (uint64_t)s[1] << 8;
        v |= (uint64_t)s[2] << 16;
        v |= (uint64_t)s[3] << 24;
        v |= (uint64_t)s[4] << 32;
        v |= (uint64_t)s[5] << 40;
        v |= (uint64_t)s[6] << 48;
        v |= (uint64_t)s[7] << 56;
        return v;
}
```
# 2. Reproduce
$ ./configure --enable-asan && make -sj8
$ ../keepass2john failed_keepass
```C
=================================================================
==53903==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000efb4 at pc 0x50a0df bp 0x7ffe1d01d7d0 sp 0x7ffe1d01d7c8
READ of size 1 at 0x60200000efb4 thread T0
    #0 0x50a0de in BytesToUInt64 /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/keepass2john.c:113
    #1 0x50afc5 in process_database /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/keepass2john.c:323
    #2 0x50b6b9 in keepass2john /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/keepass2john.c:430
    #3 0x73e1ad in main /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/john.c:1630
    #4 0x7f0da1841ec4 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21ec4)
    #5 0x406b32 (/home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john+0x406b32)
```
$ cat failed_keepass
```C
^C\331\242\232g\373K\265^@^@^C^@^B^P^@1\301\362\346\277qCP\276X^E!j\374Z\377^C^@^@^D ^@G\307\270p\217\242^D\340y]\205\336\304i\347^N\271$\347;j^RK\237\203M\363kT c:^E ^@\35\
4|\302\267^QX+J^U\332\303\236$\250\376\265\206\223\321\211U\307)C\362\306^_ d\3363\364^F^D^@p^W^@^@^@^@^@^@^G^P^@0^Z\346\233\331>\364^D\367\325\245!\241\307o+^H ^@V=^?\370^\
]}9cbc\242\267\364l[ \242\363~A\353\266|R\354L\300\3061\333\237S         ^@n_*Q\320\275\232!^W\370\266\337\210\335\213A\274\244e\362\210^\\317\230D\307\331\345z^W\307\372
^D^@^B^@^@^@^@^D^@^M
^M
\226\241J\360\355\355\236\345e\315&\201\312^\j^S\270G\366\206\211'^Z84\301\310M"\355#^T\330^M
```