### PR TITLE
Remove assert(count == 1) by check the return of fread()

### DIFF
--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -26,6 +26,7 @@
 #include "autoconfig.h"
 #endif
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -130,6 +131,19 @@ static uint16_t fget16(FILE * fp)
 	return v;
 }
 
+static void warn_exit(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	if (fmt != NULL)
+		vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fprintf(stderr, "\n");
+
+	exit(EXIT_FAILURE);
+}
+
 /* process KeePass 1.x databases */
 static void process_old_database(FILE *fp, char* encryptedDatabase)
 {
@@ -143,26 +157,30 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	uint32_t num_entries;
 	uint32_t key_transf_rounds;
 	unsigned char buffer[LINE_BUFFER_SIZE];
-	int count;
 	long long filesize = 0;
 	long long datasize;
 	int algorithm = -1;
 	char *dbname;
 	FILE *kfp = NULL;
+
 	enc_flag = fget32(fp);
 	version = fget32(fp);
-	count = fread(final_randomseed, 16, 1, fp);
-	assert(count == 1);
-	count = fread(enc_iv, 16, 1, fp);
-	assert(count == 1);
+
+	if (fread(final_randomseed, 16, 1, fp) != 1)
+		warn_exit("Error: read failed.");
+	if (fread(enc_iv, 16, 1, fp) != 1)
+		warn_exit("Error: read failed.");
+
 	num_groups = fget32(fp);
 	num_entries = fget32(fp);
 	(void)num_groups;
 	(void)num_entries;
-	count = fread(contents_hash, 32, 1, fp);
-	assert(count == 1);
-	count = fread(transf_randomseed, 32, 1, fp);
-	assert(count == 1);
+
+	if (fread(contents_hash, 32, 1, fp) != 1)
+		warn_exit("Error: read failed.");
+	if (fread(transf_randomseed, 32, 1, fp) != 1)
+		warn_exit("Error: read failed.");
+
 	key_transf_rounds = fget32(fp);
 	/* Check if the database is supported */
 	if((version & 0xFFFFFF00) != (0x00030002 & 0xFFFFFF00)) {
@@ -208,8 +226,9 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 		fprintf(stderr, "Inlining %s\n", encryptedDatabase);
 		printf("*1*%lld*", datasize);
 		fseek(fp, 124, SEEK_SET);
-		count = fread(buffer, datasize, 1, fp);
-		assert(count == 1);
+		if (fread(buffer, datasize, 1, fp) != 1)
+			warn_exit("Error: read failed.");
+
 		print_hex(buffer, datasize);
 	}
 	else {
@@ -220,7 +239,9 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	}
 	if (keyfile) {
 		printf("*1*%lld*", filesize); /* inline keyfile content */
-		count = fread(buffer, filesize, 1, kfp);
+		if (fread(buffer, filesize, 1, kfp) != 1)
+			warn_exit("Error: read failed.");
+
 		print_hex(buffer, filesize);
 	}
 	printf("\n");


### PR DESCRIPTION
There are some **assert()** in keepass2john.c.
```C
$ ./configure --enable-asan && make -sj8
$ ../keepass2john  failed_keepass

keepass2john: keepass2john.c:165: process_old_database: Assertion 'count == 1' failed.
Aborted
```
```
$ emacs failed_keepass
^C\331\242\232e\373K\265^@^@^C^@^B^P^@1~A\353\266| ^@L\300\3061\333\237S         ^@n_*Q\320\275\232!^W\370\266\337\210\335\213A\274\244e\362\210^\\317\2305\307\331\345z^W\3\
07\372
^D^@^B^@^@^@^@^D^@^M
^M^C\331\242\232e\373K\265\345e\315&\201\312^\j^S\270G\366\206\211'^Z84\301\310M"\355
```

So I replaced the assert() by checking the return value of fread().