### PR TITLE
Check the second parameter of fread()

### DIFF
--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -203,7 +203,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	print_hex(contents_hash, 32);
 	filesize = (long long)get_file_size(encryptedDatabase);
 	datasize = filesize - 124;
-	if((filesize + datasize) < inline_thr) {
+	if((filesize + datasize) < inline_thr && datasize > 0) {
 		/* we can inline the content with the hash */
 		fprintf(stderr, "Inlining %s\n", encryptedDatabase);
 		printf("*1*%lld*", datasize);
@@ -218,7 +218,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 
 		printf("*0*%s", dbname); /* data is not inline */
 	}
-	if (keyfile) {
+	if (keyfile && filesize > 0) {
 		printf("*1*%lld*", filesize); /* inline keyfile content */
 		count = fread(buffer, filesize, 1, kfp);
 		print_hex(buffer, filesize);


### PR DESCRIPTION
# 1. Analysis

There is no check of the second parameter of fread(). It will fail if the second parameter is negative.

```C
        if((filesize + datasize) < inline_thr) {
                /* we can inline the content with the hash */
                fprintf(stderr, "Inlining %s\n", encryptedDatabase);
                printf("*1*%lld*", datasize);
                fseek(fp, 124, SEEK_SET);
                count = fread(buffer, datasize, 1, fp);
                assert(count == 1);
                print_hex(buffer, datasize);
        }
        else {
                fprintf(stderr, "[!] Not inlining %s. You will need %s too for cracking!\n",
                                encryptedDatabase, encryptedDatabase);

                printf("*0*%s", dbname); /* data is not inline */
        }
        if (keyfile) {
                printf("*1*%lld*", filesize); /* inline keyfile content */
                count = fread(buffer, filesize, 1, kfp);
                print_hex(buffer, filesize);
        }
```

# 2. Reproduce
$ ./configure --enable-asan && make -sj8
$ ../keepass2john  failed_keepass
```C
Inlining keepass/out/crashes/id:000005,sig:06,src:000037,op:havoc,rep:32
*** buffer overflow detected ***: ../keepass2john terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x7338f)[0x7fec14ca338f]
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x5c)[0x7fec14d3ac9c]
/lib/x86_64-linux-gnu/libc.so.6(+0x109b60)[0x7fec14d39b60]
/lib/x86_64-linux-gnu/libc.so.6(__fread_chk+0x13c)[0x7fec14d3a23c]
../keepass2john[0x50a95e]
../keepass2john[0x50abff]
../keepass2john[0x50b572]
../keepass2john[0x73e066]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x7fec14c51ec5]
../keepass2john[0x406b33]
======= Memory map: ========
00400000-00989000 r-xp 00000000 08:01 8657380                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00b88000-00b8a000 r--p 00588000 08:01 8657380                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00b8a000-00c5d000 rw-p 0058a000 08:01 8657380                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00c5d000-0144a000 rw-p 00000000 00:00 0
7fff7000-8fff7000 rw-p 00000000 00:00 0
8fff7000-2008fff7000 ---p 00000000 00:00 0
2008fff7000-10007fff8000 rw-p 00000000 00:00 0
600000000000-602000000000 ---p 00000000 00:00 0
602000000000-602000010000 rw-p 00000000 00:00 0
602000010000-606000000000 ---p 00000000 00:00 0
606000000000-606000010000 rw-p 00000000 00:00 0
606000010000-60c000000000 ---p 00000000 00:00 0
60c000000000-60c000010000 rw-p 00000000 00:00 0
60c000010000-616000000000 ---p 00000000 00:00 0
616000000000-616000020000 rw-p 00000000 00:00 0
616000020000-619000000000 ---p 00000000 00:00 0
619000000000-619000020000 rw-p 00000000 00:00 0
619000020000-624000000000 ---p 00000000 00:00 0
624000000000-624000020000 rw-p 00000000 00:00 0
624000020000-62d000000000 ---p 00000000 00:00 0
62d000000000-62d000020000 rw-p 00000000 00:00 0
62d000020000-640000000000 ---p 00000000 00:00 0
640000000000-640000003000 rw-p 00000000 00:00 0
7fec12510000-7fec14816000 rw-p 00000000 00:00 0
7fec14816000-7fec1482c000 r-xp 00000000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7fec1482c000-7fec14a2b000 ---p 00016000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7fec14a2b000-7fec14a2c000 rw-p 00015000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7fec14a2c000-7fec14a2f000 r-xp 00000000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7fec14a2f000-7fec14c2e000 ---p 00003000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7fec14c2e000-7fec14c2f000 r--p 00002000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7fec14c2f000-7fec14c30000 rw-p 00003000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7fec14c30000-7fec14deb000 r-xp 00000000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7fec14deb000-7fec14fea000 ---p 001bb000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7fec14fea000-7fec14fee000 r--p 001ba000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7fec14fee000-7fec14ff0000 rw-p 001be000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7fec14ff0000-7fec14ff5000 rw-p 00000000 00:00 0
7fec14ff5000-7fec1500e000 r-xp 00000000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7fec1500e000-7fec1520d000 ---p 00019000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7fec1520d000-7fec1520e000 r--p 00018000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7fec1520e000-7fec1520f000 rw-p 00019000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7fec1520f000-7fec15213000 rw-p 00000000 00:00 0
7fec15213000-7fec15229000 r-xp 00000000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7fec15229000-7fec15428000 ---p 00016000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7fec15428000-7fec15429000 r--p 00015000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7fec15429000-7fec1542a000 rw-p 00016000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7fec1542a000-7fec15433000 r-xp 00000000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7fec15433000-7fec15633000 ---p 00009000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7fec15633000-7fec15634000 r--p 00009000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7fec15634000-7fec15635000 rw-p 0000a000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7fec15635000-7fec15663000 rw-p 00000000 00:00 0
7fec15663000-7fec1567b000 r-xp 00000000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7fec1567b000-7fec1587a000 ---p 00018000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7fec1587a000-7fec1587b000 r--p 00017000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7fec1587b000-7fec1587c000 rw-p 00018000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7fec1587c000-7fec15981000 r-xp 00000000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7fec15981000-7fec15b80000 ---p 00105000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7fec15b80000-7fec15b81000 r--p 00104000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7fec15b81000-7fec15b82000 rw-p 00105000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7fec15b82000-7fec15d33000 r-xp 00000000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7fec15d33000-7fec15f32000 ---p 001b1000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7fec15f32000-7fec15f4d000 r--p 001b0000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7fec15f4d000-7fec15f58000 rw-p 001cb000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7fec15f58000-7fec15f5c000 rw-p 00000000 00:00 0
7fec15f5c000-7fec15fb0000 r-xp 00000000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7fec15fb0000-7fec161b0000 ---p 00054000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7fec161b0000-7fec161b3000 r--p 00054000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7fec161b3000-7fec161ba000 rw-p 00057000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7fec161ba000-7fec16256000 r-xp 00000000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7fec16256000-7fec16456000 ---p 0009c000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7fec16456000-7fec16458000 r--p 0009c000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7fec16458000-7fec16459000 rw-p 0009e000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7fec16459000-7fec17092000 rw-p 00000000 00:00 0
7fec17092000-7fec170b5000 r-xp 00000000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7fec17267000-7fec17298000 rw-p 00000000 00:00 0
7fec17298000-7fec172b4000 rw-p 00000000 00:00 0
7fec172b4000-7fec172b5000 r--p 00022000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7fec172b5000-7fec172b6000 rw-p 00023000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7fec172b6000-7fec172b7000 rw-p 00000000 00:00 0
7ffd74411000-7ffd74446000 rw-p 00000000 00:00 0                          [stack]
7ffd745b7000-7ffd745b9000 r--p 00000000 00:00 0                          [vvar]
7ffd745b9000-7ffd745bb000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
id:000005,sig:06,src:000037,op:havoc,rep:32:$keepass$*1*-10531173*0*020000000200000000306e03d9a29a65*21112004dc03d9fffff8b9ccba648ceed456992d9c5757575757e3506d396a74*fb4bb50672352dfed487f59480bab0f3*9cad8dc04b1ce3506dbc1bf9663d625cfc57575757e1506d2c1bf96658bd948b*1*-1*Aborted
```

$ emacs failed_keepass
```
^C\331\242\232e\373K\265^C^@^@^@^B^@^C^@^B^@^@^@^B^@^@^@^@0n^C\331\242\232e\373K\265^Fr5-\376\324\207\365\224\200\272\260\363\237* \254^VV\214-\234\255\215\300K^\\343Pm\274\
^[\371f=b\\374WWWW\341Pm,^[\371fX\275\224\213!^Q ^D\334^C\331\377\377\370\271\314\272d\214\356\324V\231-\234WWWWW\343Pm9jt\233N_
```