### PR TITLE
Check the buffer size before fread(): zip2john

### DIFF
--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -212,7 +212,8 @@ static void process_file(const char *fname)
 				(void) actual_compression_method; /* we need this!! */
 
 				if (store) cp += sprintf(cp, "%s:$zip2$*0*%x*%x*", bname, efh_aes_strength, magic_enum);
-				if (fread(salt, 1, 4+4*efh_aes_strength, fp) != 4+4*efh_aes_strength) {
+				if (sizeof(salt) < 4 + 4 * efh_aes_strength ||
+					fread(salt, 1, 4+4*efh_aes_strength, fp) != 4+4*efh_aes_strength) {
 						fprintf(stderr, "Error, in fread of file data!\n");
 						goto cleanup;
 				}
@@ -349,7 +350,8 @@ static int LoadZipBlob(FILE *fp, zip_ptr *p, zip_file *zfp, const char *zip_fnam
 	/* unused variables */
 	(void) lastmod_date;
 
-	if (fread(filename, 1, filename_length, fp) != filename_length) {
+	if (sizeof(filename) < filename_length ||
+		fread(filename, 1, filename_length, fp) != filename_length) {
 		fprintf(stderr, "Error, fread could not read the data from the file:  %s\n", zip_fname);
 		return 0;
 	}


### PR DESCRIPTION
Check the buffer size before fread().

If the buffer size is small then the size to be written into it, there will be **buffer overflow**.

```C
*** buffer overflow detected ***: ../zip2john terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x7338f)[0x7fb5db9e238f]
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x5c)[0x7fb5dba79c9c]
/lib/x86_64-linux-gnu/libc.so.6(+0x109b60)[0x7fb5dba78b60]
/lib/x86_64-linux-gnu/libc.so.6(__fread_chk+0x13c)[0x7fb5dba7923c]
../zip2john[0x50280a]
../zip2john[0x503aa2]
../zip2john[0x73e1e9]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x7fb5db990ec5]
../zip2john[0x406b33]
======= Memory map: ========
00400000-00989000 r-xp 00000000 08:01 8657382                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00b88000-00b8a000 r--p 00588000 08:01 8657382                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00b8a000-00c5d000 rw-p 0058a000 08:01 8657382                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00c5d000-0144a000 rw-p 00000000 00:00 0
7fff7000-8fff7000 rw-p 00000000 00:00 0
8fff7000-2008fff7000 ---p 00000000 00:00 0
2008fff7000-10007fff8000 rw-p 00000000 00:00 0
600000000000-602000000000 ---p 00000000 00:00 0
602000000000-602000010000 rw-p 00000000 00:00 0
602000010000-606000000000 ---p 00000000 00:00 0
606000000000-606000010000 rw-p 00000000 00:00 0
606000010000-60c000000000 ---p 00000000 00:00 0
60c000000000-60c000010000 rw-p 00000000 00:00 0
60c000010000-615000000000 ---p 00000000 00:00 0
615000000000-615000020000 rw-p 00000000 00:00 0
615000020000-616000000000 ---p 00000000 00:00 0
616000000000-616000020000 rw-p 00000000 00:00 0
616000020000-619000000000 ---p 00000000 00:00 0
619000000000-619000020000 rw-p 00000000 00:00 0
619000020000-624000000000 ---p 00000000 00:00 0
624000000000-624000020000 rw-p 00000000 00:00 0
624000020000-62d000000000 ---p 00000000 00:00 0
62d000000000-62d000020000 rw-p 00000000 00:00 0
62d000020000-640000000000 ---p 00000000 00:00 0
640000000000-640000003000 rw-p 00000000 00:00 0
7fb5d924f000-7fb5db555000 rw-p 00000000 00:00 0
7fb5db555000-7fb5db56b000 r-xp 00000000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7fb5db56b000-7fb5db76a000 ---p 00016000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7fb5db76a000-7fb5db76b000 rw-p 00015000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7fb5db76b000-7fb5db76e000 r-xp 00000000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7fb5db76e000-7fb5db96d000 ---p 00003000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7fb5db96d000-7fb5db96e000 r--p 00002000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7fb5db96e000-7fb5db96f000 rw-p 00003000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7fb5db96f000-7fb5dbb2a000 r-xp 00000000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7fb5dbb2a000-7fb5dbd29000 ---p 001bb000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7fb5dbd29000-7fb5dbd2d000 r--p 001ba000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7fb5dbd2d000-7fb5dbd2f000 rw-p 001be000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7fb5dbd2f000-7fb5dbd34000 rw-p 00000000 00:00 0
7fb5dbd34000-7fb5dbd4d000 r-xp 00000000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7fb5dbd4d000-7fb5dbf4c000 ---p 00019000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7fb5dbf4c000-7fb5dbf4d000 r--p 00018000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7fb5dbf4d000-7fb5dbf4e000 rw-p 00019000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7fb5dbf4e000-7fb5dbf52000 rw-p 00000000 00:00 0
7fb5dbf52000-7fb5dbf68000 r-xp 00000000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7fb5dbf68000-7fb5dc167000 ---p 00016000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7fb5dc167000-7fb5dc168000 r--p 00015000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7fb5dc168000-7fb5dc169000 rw-p 00016000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7fb5dc169000-7fb5dc172000 r-xp 00000000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7fb5dc172000-7fb5dc372000 ---p 00009000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7fb5dc372000-7fb5dc373000 r--p 00009000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7fb5dc373000-7fb5dc374000 rw-p 0000a000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7fb5dc374000-7fb5dc3a2000 rw-p 00000000 00:00 0
7fb5dc3a2000-7fb5dc3ba000 r-xp 00000000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7fb5dc3ba000-7fb5dc5b9000 ---p 00018000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7fb5dc5b9000-7fb5dc5ba000 r--p 00017000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7fb5dc5ba000-7fb5dc5bb000 rw-p 00018000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7fb5dc5bb000-7fb5dc6c0000 r-xp 00000000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7fb5dc6c0000-7fb5dc8bf000 ---p 00105000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7fb5dc8bf000-7fb5dc8c0000 r--p 00104000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7fb5dc8c0000-7fb5dc8c1000 rw-p 00105000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7fb5dc8c1000-7fb5dca72000 r-xp 00000000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7fb5dca72000-7fb5dcc71000 ---p 001b1000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7fb5dcc71000-7fb5dcc8c000 r--p 001b0000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7fb5dcc8c000-7fb5dcc97000 rw-p 001cb000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7fb5dcc97000-7fb5dcc9b000 rw-p 00000000 00:00 0
7fb5dcc9b000-7fb5dccef000 r-xp 00000000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7fb5dccef000-7fb5dceef000 ---p 00054000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7fb5dceef000-7fb5dcef2000 r--p 00054000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7fb5dcef2000-7fb5dcef9000 rw-p 00057000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7fb5dcef9000-7fb5dcf95000 r-xp 00000000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7fb5dcf95000-7fb5dd195000 ---p 0009c000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7fb5dd195000-7fb5dd197000 r--p 0009c000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7fb5dd197000-7fb5dd198000 rw-p 0009e000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7fb5dd198000-7fb5dddd1000 rw-p 00000000 00:00 0
7fb5dddd1000-7fb5dddf4000 r-xp 00000000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7fb5ddfa7000-7fb5ddfd7000 rw-p 00000000 00:00 0
7fb5ddfd7000-7fb5ddff3000 rw-p 00000000 00:00 0
7fb5ddff3000-7fb5ddff4000 r--p 00022000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7fb5ddff4000-7fb5ddff5000 rw-p 00023000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7fb5ddff5000-7fb5ddff6000 rw-p 00000000 00:00 0
7ffe71458000-7ffe71479000 rw-p 00000000 00:00 0                          [stack]
7ffe715ce000-7ffe715d0000 r--p 00000000 00:00 0                          [vvar]
7ffe715d0000-7ffe715d2000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
Aborted
```