### PR TITLE
Check the buffer size before fread(): keepass2john

### DIFF
--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -203,7 +203,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	print_hex(contents_hash, 32);
 	filesize = (long long)get_file_size(encryptedDatabase);
 	datasize = filesize - 124;
-	if((filesize + datasize) < inline_thr) {
+	if((filesize + datasize) < inline_thr && sizeof(buffer) > datasize) {
 		/* we can inline the content with the hash */
 		fprintf(stderr, "Inlining %s\n", encryptedDatabase);
 		printf("*1*%lld*", datasize);
@@ -218,7 +218,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 
 		printf("*0*%s", dbname); /* data is not inline */
 	}
-	if (keyfile) {
+	if (keyfile && sizeof(buffer) > filesize) {
 		printf("*1*%lld*", filesize); /* inline keyfile content */
 		count = fread(buffer, filesize, 1, kfp);
 		print_hex(buffer, filesize);


### PR DESCRIPTION
If the buffer size is small then the size to be written into it, there will be **buffer overflow**.

```C
Inlining keepass/out/crashes/id:000005,sig:06,src:000037,op:havoc,rep:32
*** buffer overflow detected ***: ../keepass2john terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x7338f)[0x7f4d6ab3b38f]
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x5c)[0x7f4d6abd2c9c]
/lib/x86_64-linux-gnu/libc.so.6(+0x109b60)[0x7f4d6abd1b60]
/lib/x86_64-linux-gnu/libc.so.6(__fread_chk+0x13c)[0x7f4d6abd223c]
../keepass2john[0x50a95e]
../keepass2john[0x50abff]
../keepass2john[0x50b572]
../keepass2john[0x73e066]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x7f4d6aae9ec5]
../keepass2john[0x406b33]
======= Memory map: ========
00400000-00989000 r-xp 00000000 08:01 8657382                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00b88000-00b8a000 r--p 00588000 08:01 8657382                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00b8a000-00c5d000 rw-p 0058a000 08:01 8657382                            /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/john
00c5d000-0144a000 rw-p 00000000 00:00 0
7fff7000-8fff7000 rw-p 00000000 00:00 0
8fff7000-2008fff7000 ---p 00000000 00:00 0
2008fff7000-10007fff8000 rw-p 00000000 00:00 0
600000000000-602000000000 ---p 00000000 00:00 0
602000000000-602000010000 rw-p 00000000 00:00 0
602000010000-606000000000 ---p 00000000 00:00 0
606000000000-606000010000 rw-p 00000000 00:00 0
606000010000-60c000000000 ---p 00000000 00:00 0
60c000000000-60c000010000 rw-p 00000000 00:00 0
60c000010000-616000000000 ---p 00000000 00:00 0
616000000000-616000020000 rw-p 00000000 00:00 0
616000020000-619000000000 ---p 00000000 00:00 0
619000000000-619000020000 rw-p 00000000 00:00 0
619000020000-624000000000 ---p 00000000 00:00 0
624000000000-624000020000 rw-p 00000000 00:00 0
624000020000-62d000000000 ---p 00000000 00:00 0
62d000000000-62d000020000 rw-p 00000000 00:00 0
62d000020000-640000000000 ---p 00000000 00:00 0
640000000000-640000003000 rw-p 00000000 00:00 0
7f4d683a8000-7f4d6a6ae000 rw-p 00000000 00:00 0
7f4d6a6ae000-7f4d6a6c4000 r-xp 00000000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7f4d6a6c4000-7f4d6a8c3000 ---p 00016000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7f4d6a8c3000-7f4d6a8c4000 rw-p 00015000 08:01 12320936                   /lib/x86_64-linux-gnu/libgcc_s.so.1
7f4d6a8c4000-7f4d6a8c7000 r-xp 00000000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7f4d6a8c7000-7f4d6aac6000 ---p 00003000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7f4d6aac6000-7f4d6aac7000 r--p 00002000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7f4d6aac7000-7f4d6aac8000 rw-p 00003000 08:01 12326547                   /lib/x86_64-linux-gnu/libdl-2.19.so
7f4d6aac8000-7f4d6ac83000 r-xp 00000000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7f4d6ac83000-7f4d6ae82000 ---p 001bb000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7f4d6ae82000-7f4d6ae86000 r--p 001ba000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7f4d6ae86000-7f4d6ae88000 rw-p 001be000 08:01 12326558                   /lib/x86_64-linux-gnu/libc-2.19.so
7f4d6ae88000-7f4d6ae8d000 rw-p 00000000 00:00 0
7f4d6ae8d000-7f4d6aea6000 r-xp 00000000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7f4d6aea6000-7f4d6b0a5000 ---p 00019000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7f4d6b0a5000-7f4d6b0a6000 r--p 00018000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7f4d6b0a6000-7f4d6b0a7000 rw-p 00019000 08:01 12326559                   /lib/x86_64-linux-gnu/libpthread-2.19.so
7f4d6b0a7000-7f4d6b0ab000 rw-p 00000000 00:00 0
7f4d6b0ab000-7f4d6b0c1000 r-xp 00000000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7f4d6b0c1000-7f4d6b2c0000 ---p 00016000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7f4d6b2c0000-7f4d6b2c1000 r--p 00015000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7f4d6b2c1000-7f4d6b2c2000 rw-p 00016000 08:01 4197290                    /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
7f4d6b2c2000-7f4d6b2cb000 r-xp 00000000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7f4d6b2cb000-7f4d6b4cb000 ---p 00009000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7f4d6b4cb000-7f4d6b4cc000 r--p 00009000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7f4d6b4cc000-7f4d6b4cd000 rw-p 0000a000 08:01 12326550                   /lib/x86_64-linux-gnu/libcrypt-2.19.so
7f4d6b4cd000-7f4d6b4fb000 rw-p 00000000 00:00 0
7f4d6b4fb000-7f4d6b513000 r-xp 00000000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7f4d6b513000-7f4d6b712000 ---p 00018000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7f4d6b712000-7f4d6b713000 r--p 00017000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7f4d6b713000-7f4d6b714000 rw-p 00018000 08:01 12324927                   /lib/x86_64-linux-gnu/libz.so.1.2.8
7f4d6b714000-7f4d6b819000 r-xp 00000000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7f4d6b819000-7f4d6ba18000 ---p 00105000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7f4d6ba18000-7f4d6ba19000 r--p 00104000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7f4d6ba19000-7f4d6ba1a000 rw-p 00105000 08:01 12324900                   /lib/x86_64-linux-gnu/libm-2.19.so
7f4d6ba1a000-7f4d6bbcb000 r-xp 00000000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7f4d6bbcb000-7f4d6bdca000 ---p 001b1000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7f4d6bdca000-7f4d6bde5000 r--p 001b0000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7f4d6bde5000-7f4d6bdf0000 rw-p 001cb000 08:01 12320858                   /lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7f4d6bdf0000-7f4d6bdf4000 rw-p 00000000 00:00 0
7f4d6bdf4000-7f4d6be48000 r-xp 00000000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7f4d6be48000-7f4d6c048000 ---p 00054000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7f4d6c048000-7f4d6c04b000 r--p 00054000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7f4d6c04b000-7f4d6c052000 rw-p 00057000 08:01 12320863                   /lib/x86_64-linux-gnu/libssl.so.1.0.0
7f4d6c052000-7f4d6c0ee000 r-xp 00000000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7f4d6c0ee000-7f4d6c2ee000 ---p 0009c000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7f4d6c2ee000-7f4d6c2f0000 r--p 0009c000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7f4d6c2f0000-7f4d6c2f1000 rw-p 0009e000 08:01 4195090                    /usr/lib/x86_64-linux-gnu/libasan.so.1.0.0
7f4d6c2f1000-7f4d6cf2a000 rw-p 00000000 00:00 0
7f4d6cf2a000-7f4d6cf4d000 r-xp 00000000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7f4d6d0ff000-7f4d6d130000 rw-p 00000000 00:00 0
7f4d6d130000-7f4d6d14c000 rw-p 00000000 00:00 0
7f4d6d14c000-7f4d6d14d000 r--p 00022000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7f4d6d14d000-7f4d6d14e000 rw-p 00023000 08:01 12326555                   /lib/x86_64-linux-gnu/ld-2.19.so
7f4d6d14e000-7f4d6d14f000 rw-p 00000000 00:00 0
7ffc28605000-7ffc2863a000 rw-p 00000000 00:00 0                          [stack]
7ffc286cc000-7ffc286ce000 r--p 00000000 00:00 0                          [vvar]
7ffc286ce000-7ffc286d0000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
id:000005,sig:06,src:000037,op:havoc,rep:32:$keepass$*1*-10531173*0*020000000200000000306e03d9a29a65*21112004dc03d9fffff8b9ccba648ceed456992d9c5757575757e3506d396a74*fb4bb50672352dfed487f59480bab0f3*9cad8dc04b1ce3506dbc1bf9663d625cfc57575757e1506d2c1bf96658bd948b*1*-1*Aborted
```