### PR TITLE
Fix: keyring2john remove assert by checking the return value

### DIFF
--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -35,7 +35,6 @@
 #include "missing_getopt.h"
 #endif
 #include <errno.h>
-#include <assert.h>
 // needs to be above sys/types.h and sys/stat.h for mingw, if -std=c99 used.
 #include "jumbo.h"
 #include <sys/stat.h>


### PR DESCRIPTION
$ ./configure && make -sj8
$ ../keyring2john  failed_pw
```C
keyring2john: keyring2john.c:38: fget32_: Assertion 'count == 1' failed.
Aborted (core dumped)
```
$ emacs failed_pw
```
GnomeKeyring
^M^@
^@^@^@^@^@^@^@^Hopenwall^@^@^@^@^@..^@O\365\200\334^@^@^@^@^@^@^@^@^@^@^D\232|9^T\236\210\343\351\251^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@\327^Q\272\270\207\265\370^Hopenwad\
l^@^A^@^@^@..^@O\365\200\334^@^@^@^@^@^@^@^D^@^@^D\232|9^T\236\210\343\351\251^@^@^@^@^@
^@^@^@^@^A^@^@^Hopenwall^@^@^@^@^@..^@d^@\200\334^@^@^@^@^@^@^@^@^@L^D\232|9^T\236\210\343\351\251^@^@^@^@^@^@^@^@^@^@^@^@^@^Hopenwall^@^@^@^@^@..^@d^@\200\334^@^@^@^@^@^@^\
@^@^@L^D\232|9^T\236\210yring
^M^@
^@^@^@^@^@^@^@^Hopenwall^@^@^@^@^@&.^@O\365\200\334^@^@^@^@^@^@^@^@^@^@^D\232|9^T\236\210\343\351\251^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@\327^Q\272\270\207\265\370^Hop
```