### PR TITLE
pwsafe2john.c: Remove unused variable

### DIFF
--- a/src/pwsafe2john.c
+++ b/src/pwsafe2john.c
@@ -50,7 +50,6 @@ static void print_hex(unsigned char *str, int len)
 static void process_file(const char *filename)
 {
 	FILE *fp;
-	int count;
 	unsigned char buf[32];
 	unsigned int iterations;
 	const char *ext[] = {".psafe3"};


### PR DESCRIPTION
Build warning:

```C
pwsafe2john.c: In function ‘process_file’:
pwsafe2john.c:53:6: warning: unused variable ‘count’ [-Wunused-variable]
  int count;
      ^
```