### PR TITLE
Use header.caplen instead of header.len

### DIFF
--- a/src/vncpcap2john.c
+++ b/src/vncpcap2john.c
@@ -154,7 +154,7 @@ _Bool Packet_Reader_kick(struct Packet_Reader* self)
 		size_t payload_len;
 		char buf[512];
 
-		if (header.len < sizeof(struct ether_header))
+		if (header.caplen < sizeof(struct ether_header))
 			continue;
 
 		eptr = (void*) packet;
@@ -162,7 +162,7 @@ _Bool Packet_Reader_kick(struct Packet_Reader* self)
 		if (ntohs(eptr->ether_type) != ETHERTYPE_IP)
 			continue;
 
-		if (header.len < sizeof(struct ether_header) + sizeof(struct ip))
+		if (header.caplen < sizeof(struct ether_header) + sizeof(struct ip))
 			continue;
 
 		ip_header = (void*)(packet + sizeof(struct ether_header));
@@ -171,7 +171,7 @@ _Bool Packet_Reader_kick(struct Packet_Reader* self)
 		if (size_ip < 20)
 			continue;	// bogus IP header
 
-		if (header.len < sizeof(struct ether_header) + size_ip + sizeof(struct tcp_hdr))
+		if (header.caplen < sizeof(struct ether_header) + size_ip + sizeof(struct tcp_hdr))
 			continue;
 
 		tcp = (void*) (packet + sizeof(struct ether_header) + size_ip);
@@ -184,7 +184,7 @@ _Bool Packet_Reader_kick(struct Packet_Reader* self)
 		payload_buf =
 		    packet + sizeof(struct ether_header) + size_ip + size_tcp;
 		payload_len =
-		    header.len - (sizeof(struct ether_header) + size_ip + size_tcp);
+		    header.caplen - (sizeof(struct ether_header) + size_ip + size_tcp);
 
 		self->payload_str = malloc(payload_len);
 		if (self->payload_str == NULL) {


### PR DESCRIPTION
# Analysis
There is problem with the `const u_char *pcap_next(pcap_t *p, struct pcap_pkthdr *h);`
```C
struct pcap_pkthdr {
	struct timeval ts;	/* time stamp */
	bpf_u_int32 caplen;	/* length of portion present */
	bpf_u_int32 len;	/* length this packet (off wire) */
};
```

**caplen** means the length of packet we actually get.
**len** means the whole length of packet which should be.

Actually, caplen <= len, and the size of the packet should be **caplen**

# Reproduce

$ ./configure --enable-asan && make -sj8
$ ../vncpcap2john  failed_pw
```C
=================================================================
==130183==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6310000107ff at pc 0x7fb63ea52822 bp 0x7ffd04f6b3c0 sp 0x7ffd04f6ab80
READ of size 8388608 at 0x6310000107ff thread T0
    #0 0x7fb63ea52821 (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x2e821)
    #1 0x40162b in memcpy /usr/include/x86_64-linux-gnu/bits/string3.h:51
    #2 0x40162b in Packet_Reader_kick /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/vncpcap2john.c:195
    #3 0x402078 in VNC_Auth_Reader_find_next /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/vncpcap2john.c:228
    #4 0x402422 in attempt_crack /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/vncpcap2john.c:292
    #5 0x40280b in main /home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/src/vncpcap2john.c:312
    #6 0x7fb63e224ec4 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21ec4)
    #7 0x400fb8 (/home/zhaokai/WorkSpace/open_wall/JohnTheRipper_kai/run/vncpcap2john+0x400fb8)

0x6310000107ff is located 0 bytes to the right of 65535-byte region [0x631000000800,0x6310000107ff)
allocated by thread T0 here:
    #0 0x7fb63ea787df in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x547df)
    #1 0x7fb63e80355f (/usr/lib/x86_64-linux-gnu/libpcap.so.0.8+0x1d55f)

SUMMARY: AddressSanitizer: heap-buffer-overflow ??:0 ??
Shadow bytes around the buggy address:
  0x0c627fffa0a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c627fffa0b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c627fffa0c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c627fffa0d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c627fffa0e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c627fffa0f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00[07]
  0x0c627fffa100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c627fffa110: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c627fffa120: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c627fffa130: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c627fffa140: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Contiguous container OOB:fc
  ASan internal:           fe
==130183==ABORTING
Aborted (core dumped)
```

the failed_pw is very large, so I do not show it.
