### PR TITLE
Use: warn_exit("%s: Error: read failed: %s.", argv[0], strerror(errno));

### DIFF
--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -166,9 +166,11 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	version = fget32(fp);
 
 	if (fread(final_randomseed, 16, 1, fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.", encryptedDatabase,
+			strerror(errno));
 	if (fread(enc_iv, 16, 1, fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.", encryptedDatabase,
+			strerror(errno));
 
 	num_groups = fget32(fp);
 	num_entries = fget32(fp);
@@ -176,9 +178,11 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	(void)num_entries;
 
 	if (fread(contents_hash, 32, 1, fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.", encryptedDatabase,
+			strerror(errno));
 	if (fread(transf_randomseed, 32, 1, fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.", encryptedDatabase,
+			strerror(errno));
 
 	key_transf_rounds = fget32(fp);
 	/* Check if the database is supported */
@@ -226,7 +230,8 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 		printf("*1*%lld*", datasize);
 		fseek(fp, 124, SEEK_SET);
 		if (fread(buffer, datasize, 1, fp) != 1)
-			warn_exit("Error: read failed.");
+			warn_exit("%s: Error: read failed: %s.",
+				encryptedDatabase, strerror(errno));
 
 		print_hex(buffer, datasize);
 	}
@@ -239,7 +244,8 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	if (keyfile && sizeof(buffer) > filesize) {
 		printf("*1*%lld*", filesize); /* inline keyfile content */
 		if (fread(buffer, filesize, 1, kfp) != 1)
-			warn_exit("Error: read failed.");
+			warn_exit("%s: Error: read failed: %s.",
+				encryptedDatabase, strerror(errno));
 
 		print_hex(buffer, filesize);
 	}
@@ -414,6 +420,7 @@ int keepass2john(int argc, char **argv)
 {
 	int c;
 
+	errno = 0;
 	/* Parse command line */
 	while ((c = getopt(argc, argv, "i:k:")) != -1) {
 		switch (c) {

--- a/src/keystore2john.c
+++ b/src/keystore2john.c
@@ -126,7 +126,8 @@ static void process_file(char *filename)
 			size, sizeof(data));
 	fseek(fp, 0, SEEK_SET);
 	if (fread(data, size, 1,  fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.", filename,
+			strerror(errno));
 
 	fseek(fp, 0, SEEK_SET);
 
@@ -148,16 +149,20 @@ static void process_file(char *filename)
 			length = fgetc(fp);
 
 			if (sizeof(buf) < length || fread(buf, length, 1, fp) != 1)
-				warn_exit("Error: read failed.");
+				warn_exit("%s: Error: read failed: %s.",
+					filename, strerror(errno));
 
 			// Read the (entry creation) date
 			if (fread(buf, 8, 1, fp) != 1)
-				warn_exit("Error: read failed.");
+				warn_exit("%s: Error: read failed: %s.",
+					filename, strerror(errno));
 
 			// Read the key
 			keysize = fget32(fp);
-			if (sizeof(protectedPrivKey) < keysize || fread(protectedPrivKey, keysize, 1, fp) != 1)
-				warn_exit("Error: read failed.");
+			if (sizeof(protectedPrivKey) < keysize ||
+				fread(protectedPrivKey, keysize, 1, fp) != 1)
+				warn_exit("%s: Error: read failed: %s.",
+					filename, strerror(errno));
 
 			// read certificates
 			numOfCerts = fget32(fp);
@@ -169,13 +174,17 @@ static void process_file(char *filename)
 						if (p != 1 && p != 0)
 							warn_exit("Error: p=%d which should be 1 or 0.", p);
 						length = fgetc(fp);
-						if (sizeof(buf) < length || fread(buf, length, 1, fp) != 1)
-							warn_exit("Error: read failed.");
+						if (sizeof(buf) < length ||
+							fread(buf, length, 1, fp) != 1)
+							warn_exit("%s: Error: read failed: %s.",
+								filename, strerror(errno));
 					}
 					// read certificate data
 					certsize = fget32(fp);
-					if (sizeof(certdata) < certsize || fread(certdata, certsize, 1, fp) != 1)
-						warn_exit("Error: read failed.");
+					if (sizeof(certdata) < certsize ||
+						fread(certdata, certsize, 1, fp) != 1)
+						warn_exit("%s: Error: read failed: %s.",
+							filename, strerror(errno));
 				}
 			}
 			// We can be sure now that numOfCerts of certs are read
@@ -183,24 +192,31 @@ static void process_file(char *filename)
 			// Read the alias
 			p = fgetc(fp);
 			length = fgetc(fp);
-			if (sizeof(buf) < length || fread(buf, length, 1, fp) != 1)
-				warn_exit("Error: read failed.");
+			if (sizeof(buf) < length ||
+				fread(buf, length, 1, fp) != 1)
+				warn_exit("%s: Error: read failed: %s.",
+					filename, strerror(errno));
 
 			// Read the (entry creation) date
 			if (fread(buf, 8, 1, fp) != 1)
-				warn_exit("Error: read failed.");
+				warn_exit("%s: Error: read failed: %s.",
+					filename, strerror(errno));
 
 			// Read the trusted certificate
 			if (xVersion == 2) {
 				// read the certificate type
 				p = fgetc(fp);
 				length = fgetc(fp);
-				if (sizeof(buf) < length || fread(buf, length, 1, fp) != 1)
-					warn_exit("Error: read failed.");
+				if (sizeof(buf) < length ||
+					fread(buf, length, 1, fp) != 1)
+					warn_exit("%s: Error: read failed: %s.",
+						filename, strerror(errno));
 			}
 			certsize = fget32(fp);
-			if (sizeof(certdata) < certsize || fread(certdata, certsize, 1, fp) != 1)
-				warn_exit("Error: read failed.");
+			if (sizeof(certdata) < certsize ||
+				fread(certdata, certsize, 1, fp) != 1)
+				warn_exit("%s: Error: read failed: %s.",
+					filename, strerror(errno));
 		} else {
 			fprintf(stderr, "Unrecognized keystore entry");
 			fclose(fp);
@@ -213,7 +229,8 @@ static void process_file(char *filename)
 
 	/* read hash */
 	if (fread(md, 20, 1, fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.",
+			filename, strerror(errno));
 
 	bname = strip_suffixes(basename(filename), extension, 1);
 	printf("%s:$keystore$0$%d$", bname, pos);
@@ -229,11 +246,12 @@ bail:
 
 int keystore2john(int argc, char **argv)
 {
-        if (argc < 2) {
-                fprintf(stderr, "Usage: %s <.keystore file>\n", argv[0]);
-                exit(-1);
-        }
-        process_file(argv[1]);
+	if (argc < 2) {
+		fprintf(stderr, "Usage: %s <.keystore file>\n", argv[0]);
+		exit(-1);
+	}
+	errno = 0;
+	process_file(argv[1]);
 	MEMDBG_PROGRAM_EXIT_CHECKS(stderr);
 	return 0;
 }

--- a/src/kwallet2john.c
+++ b/src/kwallet2john.c
@@ -89,7 +89,8 @@ static void process_file(const char *fname)
 	fseek(fp, 0, SEEK_SET);
 
 	if (fread(buf, KWMAGIC_LEN, 1, fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.", fname,
+			strerror(errno));
 
 	if (memcmp(buf, KWMAGIC, KWMAGIC_LEN) != 0) {
 		fprintf(stderr, "%s : Not a KDE KWallet file!\n", fname);
@@ -98,7 +99,8 @@ static void process_file(const char *fname)
 
 	offset += KWMAGIC_LEN;
 	if (fread(buf, 4, 1, fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.", fname,
+			strerror(errno));
 
 	offset += 4;
 
@@ -134,24 +136,24 @@ static void process_file(const char *fname)
 		uint32_t fsz;
 
 		if (fread(buf, 16, 1, fp) != 1)
-			warn_exit("Error: read failed.");
-
+			warn_exit("%s: Error: read failed: %s.", fname,
+				strerror(errno));
 		offset += 16;
 		fsz = fget32_(fp);
 		offset += 4;
 		for (j = 0; j < fsz; ++j) {
 			if (fread(buf, 16, 1, fp) != 1)
-				warn_exit("Error: read failed.");
-
+				warn_exit("%s: Error: read failed: %s.",
+					fname, strerror(errno));
 			offset += 16;
-
 		}
 	}
 
 	/* Read in the rest of the file. */
 	encrypted_size = size - offset;
 	if (fread(encrypted, encrypted_size, 1, fp) != 1)
-		warn_exit("Error: read failed.");
+		warn_exit("%s: Error: read failed: %s.",
+			fname, strerror(errno));
 
 	if ((encrypted_size % 8) != 0) {
 		fprintf(stderr, "%s : invalid file structure!\n", fname);
@@ -177,6 +179,7 @@ int kwallet2john(int argc, char **argv)
 		exit(-1);
 	}
 
+	errno = 0;
 	for (i = 1; i < argc; i++)
 		process_file(argv[i]);
 


### PR DESCRIPTION
Use: 
```C
warn_exit("%s: Error: read failed: %s.", argv[0], strerror(errno)); 
```
instead of: 
```C
warn_exit("Error: read failed."); 
```