### PR TITLE
Report error if config file does not exist when '--config=somefile'

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1245,7 +1245,7 @@ static void john_init(char *name, int argc, char **argv)
 		if (options.config)
 		{
 			path_init_ex(options.config);
-			cfg_init(options.config, 1);
+			cfg_init(options.config, 0);
 			cfg_init(CFG_FULL_NAME, 1);
 			cfg_init(CFG_ALT_NAME, 0);
 		}


### PR DESCRIPTION
Close #1359 