### PR TITLE
keepass plaintext length

### DIFF
--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -40,7 +40,7 @@ john_register_one(&fmt_KeePass);
 #define ALGORITHM_NAME		"SHA256 AES 32/" ARCH_BITS_STR " " SHA2_LIB
 #define BENCHMARK_COMMENT	""
 #define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	32
+#define PLAINTEXT_LENGTH	100
 #define BINARY_SIZE		0
 #define BINARY_ALIGN		MEM_ALIGN_NONE
 #define SALT_SIZE		sizeof(struct custom_salt)


### PR DESCRIPTION
as per http://openwall.com/lists/john-users/2015/05/29/3 plaintext length is set to 32, but it works fine with 100