### PR TITLE
Fix spell mistake, there is no BF_common_plug.c

### DIFF
--- a/src/BF_fmt.c
+++ b/src/BF_fmt.c
@@ -38,7 +38,7 @@
 #define MIN_KEYS_PER_CRYPT		BF_Nmin
 #define MAX_KEYS_PER_CRYPT		BF_N
 
-// static struct fmt_tests BF_common_tests[] = {  // defined in BF_common_plug.c
+// static struct fmt_tests BF_common_tests[] = {  // defined in BF_common.c
 
 static char saved_key[BF_N][PLAINTEXT_LENGTH + 1];
 static char keys_mode;

--- a/src/opencl_bf_fmt_plug.c
+++ b/src/opencl_bf_fmt_plug.c
@@ -44,7 +44,7 @@ john_register_one(&fmt_opencl_bf);
 #define MIN_KEYS_PER_CRYPT		DEFAULT_LWS
 #define MAX_KEYS_PER_CRYPT		BF_N
 
-// static struct fmt_tests BF_common_tests[] = {  // defined in BF_common_plug.c
+// static struct fmt_tests BF_common_tests[] = {  // defined in BF_common.c
 
 static char 	(*saved_key)[PLAINTEXT_LENGTH + 1] ;
 static char 	keys_mode ;


### PR DESCRIPTION
Fix spell mistake, there is  **no BF_common_plug.c**