### PR TITLE
Fix crash when receiving CTRL_C_EVENT on Windows from parent like Johny

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -266,6 +266,7 @@ static void sig_install_abort(void)
  * CTRL+C is inherited by child processes."  So restore normal processing here
  * in case our parent (such as Johnny the GUI) had disabled it.
  */
+	SetConsoleCtrlHandler(NULL, FALSE);
 	SetConsoleCtrlHandler(sig_handle_abort_ctrl, TRUE);
 #endif
 


### PR DESCRIPTION
Johnny had a problem : it couldn't pause a cracking session on Windows. To make Johnny be able to safely stop john on Windows, we had to send a CTRL_C_EVENT to the console in Johnny and modify john core. The core john patch is discussed there by Solar, you can see the diff too. 
http://www.openwall.com/lists/john-dev/2015/05/31/4

Even though the commit of Solar is in bleeding-jumbo https://github.com/magnumripper/JohnTheRipper/commit/b9cd224a86b3cdb4c8f3b56256d14a1a81928177, magnum made a small mistake in merging commit https://github.com/magnumripper/JohnTheRipper/blob/bleeding-jumbo/src/signals.c and he didn't kept the most important line SetConsoleCtrlHandler(NULL, FALSE);.