### PR TITLE
Clear the buffer before output to it

### DIFF
--- a/src/hmacMD5_fmt_plug.c
+++ b/src/hmacMD5_fmt_plug.c
@@ -172,6 +172,7 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 		int len;
 		char *d, *o = out;
 
+		memset(out, 0, sizeof(out));
 		p += 10;
 		if (!(d = strchr(p, '$')))
 			return split_fields[1];


### PR DESCRIPTION
Close #1472 .

And I have a question.

```C
/* Convert from Base64 format with tag to our legacy format */
static char *prepare(char *split_fields[10], struct fmt_main *self)
{
        char *p = split_fields[1];

        if (!strncmp(p, "$cram_md5$", 10)) {
                static char out[256];
                int len;
                char *d, *o = out;

                memset(out, 0, sizeof(out));
                p += 10;
                if (!(d = strchr(p, '$')))
                        return split_fields[1];
                len = base64_convert(p, e_b64_mime, (int)(d - p - 1),
                                     o, e_b64_raw,
#if SIMD_COEF_32
                                     55,
#else
                                     SALT_LENGTH,
#endif
                                     flg_Base64_MIME_TRAIL_EQ);
                o += len;
                *o++ = '#';
                d++;
                len = base64_convert(d, e_b64_mime, strlen(d),
                                     o, e_b64_raw,
                                     sizeof(out) - len - 2,
                                     flg_Base64_MIME_TRAIL_EQ);
                if (!(p = strchr(o, ' ')))
                        return split_fields[1];
                p++;
                memmove(o, p, len - (p - o) + 1);
                if (strlen(o) == BINARY_SIZE * 2)
                        return out;
        }
        return p;
}
```

` if (!(p = strchr(o, ' ')))`, **Can we use** `strchr` for `o` which is a buffer returned by `base64_convert()` ?

I think we can not, since the `o` buffer may contains `\0`, such as below
```C
o = { 0, 0, 65 }
```
