### PR TITLE
Add --enable-ubsan (UndefinedBehaviorSanitizer)

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -526,7 +526,14 @@ AGAIN:
 	total = failed = 0;
 #ifdef WITH_ASAN
 	if (benchmark_time)
+#ifdef WITH_UBSAN
+	puts("NOTE: This is an ASan+UbSan debug build, speed will be lower than normal");
+#else
 	puts("NOTE: This is an ASan debug build, speed will be lower than normal");
+#endif
+#elif WITH_UBSAN
+	if (benchmark_time)
+	puts("NOTE: This is an UbSan debug build, speed will be lower than normal");
 #elif defined(DEBUG)
 	if (benchmark_time)
 	puts("NOTE: This is a -DDEBUG build, speed may be lower than normal");

--- a/src/configure
+++ b/src/configure
@@ -755,6 +755,7 @@ with_systemwide
 with_flock
 enable_memdbg
 enable_asan
+enable_ubsan
 enable_plugin_dependencies
 enable_openmp_for_fast_formats
 enable_mpi
@@ -1385,6 +1386,7 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-memdbg         Enable memdbg memory debugging (safe level)
   --enable-asan           * Build with AddressSanitizer
+  --enable-ubsan          * Build with UndefinedBehaviorSanitizer
   --disable-plugin-dependencies
                           Do not create best-effort Makefile dependencies for
                           plugins
@@ -3516,6 +3518,13 @@ if test "${enable_asan+set}" = set; then :
   enableval=$enable_asan; asan=$enableval
 else
   asan=no
+fi
+
+# Check whether --enable-ubsan was given.
+if test "${enable_ubsan+set}" = set; then :
+  enableval=$enable_ubsan; ubsan=$enableval
+else
+  ubsan=no
 fi
 
 # Check whether --enable-plugin-dependencies was given.
@@ -5743,7 +5752,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
    OPT_INLINE_FLAGS="${CFLAGS_EX}"
 
 
-   # pick -Og or -O1 for debug targets (applies to ASan too)
+   # pick -Og or -O1 for debug targets (applies to ASan/UbSan too)
    CFLAGS_EX=""
      if test "1" = 1; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Og" >&5
@@ -5908,6 +5917,63 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
    fi
    LDFLAGS=${LDFLAGS_BAK}
 fi
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   # if user requested  UbSan, make sure we can properly build/link with it.
+   # FIXME: for now, exclude -fsanitize=alignment on all architectures, not just x86
+if test "x$ubsan" = xyes ; then
+   CFLAGS_EX=""
+   LDFLAGS_BAK=${LDFLAGS}
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error --param=max-vartrack-size=0" >&5
+$as_echo_n "checking if $CC supports -fsanitize=undefined... " >&6; }
+  fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -DWITH_UBSAN -fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error --param=max-vartrack-size=0"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -DWITH_UBSAN -fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error --param=max-vartrack-size=0"
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+fi
 
    # now fill out CFLAGS
    CFLAGS_EX=""
@@ -6002,8 +6068,7 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-
-if test "x$asan" = xyes ; then
+if test "x$asan" = xyes || "x$ubsan" = xyes; then
      if test "1" = 1; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -fno-omit-frame-pointer" >&5
 $as_echo_n "checking if $CC supports -fno-omit-frame-pointer... " >&6; }
@@ -13463,6 +13528,13 @@ if test "x$asan" = xyes ; then
    LDFLAGS="-fsanitize=address $LDFLAGS"
 fi
 
+if test "x$ubsan" = xyes ; then
+  CFLAGS=`echo $CFLAGS | sed 's/-g //g; s/-O2 //g'`
+  CFLAGS=`echo $CFLAGS | sed 's/-g$//g; s/-O2$//g'`
+  CFLAGS="-g $O_DEBUG -DWITH_UBSAN -fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error --param=max-vartrack-size=0 $CFLAGS"
+  LDFLAGS="-fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error $LDFLAGS"
+fi
+
 #add ARCH_LITTLE_ENDIAN to command line, IF we know it is big or little
 if test "x$endian" = "xbig"; then
    CFLAGS="$CFLAGS -DARCH_LITTLE_ENDIAN=0"
@@ -15078,6 +15150,12 @@ else
    asan="disabled"
 fi
 
+if test "x$ubsan" = xyes ; then
+   ubsan="enabled"
+else
+   ubsan="disabled"
+fi
+
 if test "x$enable_int128" = xno; then
    have_int128=disabled
 elif test "x$ac_cv_type_int128" = xyes ||
@@ -15117,6 +15195,7 @@ Memory map (share/page large files) ......... ${using_mmap}
 Development options (these may hurt performance when enabled):
 Memdbg memory debugging settings ............ ${memdbg_settings}
 AddressSanitizer ("ASan") ................... ${asan}
+UndefinedBehaviorSanitizer ("UbSan") ........ ${ubsan}
 
 Install missing libraries to get any needed features that were omitted.
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -66,6 +66,7 @@ AC_ARG_WITH(flock, [AS_HELP_STRING([--with-flock],[use flock() file locking inst
 
 AC_ARG_ENABLE([memdbg], [AC_HELP_STRING([--enable-memdbg], [Enable memdbg memory debugging (safe level)])], [memdbg=$enableval], [memdbg=no])
 AC_ARG_ENABLE([asan], [AS_HELP_STRING([--enable-asan], [* Build with AddressSanitizer])], [asan=$enableval], [asan=no])
+AC_ARG_ENABLE([ubsan], [AS_HELP_STRING([--enable-ubsan], [* Build with UndefinedBehaviorSanitizer])], [ubsan=$enableval], [ubsan=no])
 AC_ARG_ENABLE([plugin-dependencies], [AS_HELP_STRING([--disable-plugin-dependencies], [Do not create best-effort Makefile dependencies for plugins])], [plug_deps=$enableval], [plug_deps=yes])
 
 # Define Features. OpenMP and OpenCL are defined in their respective macros.
@@ -174,7 +175,7 @@ AS_IF([test "x$JTR_FLAG_CHECK_WORKS" = xyes],
    JTR_FLAG_CHECK([-finline-functions], 1)
    AC_SUBST([OPT_INLINE_FLAGS],["${CFLAGS_EX}"])
 
-   # pick -Og or -O1 for debug targets (applies to ASan too)
+   # pick -Og or -O1 for debug targets (applies to ASan/UbSan too)
    CFLAGS_EX=""
    JTR_FLAG_CHECK([-Og], 1)
    if test "x${CFLAGS_EX}" != x ; then
@@ -202,11 +203,25 @@ if test "x$asan" = xyes ; then
    LDFLAGS=${LDFLAGS_BAK}
 fi
 
+   # if user requested  UbSan, make sure we can properly build/link with it.
+   # FIXME: for now, exclude -fsanitize=alignment on all architectures, not just x86
+if test "x$ubsan" = xyes ; then
+   CFLAGS_EX=""
+   LDFLAGS_BAK=${LDFLAGS}
+   JTR_FLAG_CHECK_LINK([-DWITH_UBSAN -fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error], 1)
+   if test "x${CFLAGS_EX}" = x ; then
+      ubsan=no
+   else
+      LDFLAGS="-fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error $LDFLAGS"
+   fi
+   LDFLAGS=${LDFLAGS_BAK}
+fi
+
    # now fill out CFLAGS
    CFLAGS_EX=""
    JTR_FLAG_CHECK([-Wall], 1)
    JTR_FLAG_CHECK([-Wdeclaration-after-statement], 1)
-if test "x$asan" = xyes ; then
+if test "x$asan" = xyes || "x$ubsan" = xyes ; then
    JTR_FLAG_CHECK([-fno-omit-frame-pointer], 1)
 else
    JTR_FLAG_CHECK([-fomit-frame-pointer], 1)
@@ -753,6 +768,13 @@ if test "x$asan" = xyes ; then
    LDFLAGS="-fsanitize=address $LDFLAGS"
 fi
 
+if test "x$ubsan" = xyes ; then
+   CFLAGS=`echo $CFLAGS | sed 's/-g //g; s/-O2 //g'`
+   CFLAGS=`echo $CFLAGS | sed 's/-g$//g; s/-O2$//g'`
+   CFLAGS="-g $O_DEBUG -DWITH_UBSAN -fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error --param=max-vartrack-size=0 $CFLAGS"
+   LDFLAGS="-fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error $LDFLAGS"
+fi
+
 #add ARCH_LITTLE_ENDIAN to command line, IF we know it is big or little
 if test "x$endian" = "xbig"; then
    CFLAGS="$CFLAGS -DARCH_LITTLE_ENDIAN=0"
@@ -940,6 +962,12 @@ else
    asan="disabled"
 fi
 
+if test "x$ubsan" = xyes ; then
+   ubsan="enabled"
+else
+   ubsan="disabled"
+fi
+
 if test "x$enable_int128" = xno; then
    have_int128=disabled
 elif test "x$ac_cv_type_int128" = xyes ||
@@ -980,6 +1008,7 @@ Memory map (share/page large files) ......... ${using_mmap}
 Development options (these may hurt performance when enabled):
 Memdbg memory debugging settings ............ ${memdbg_settings}
 AddressSanitizer ("ASan") ................... ${asan}
+UndefinedBehaviorSanitizer ("UbSan") ........ ${ubsan}
 
 Install missing libraries to get any needed features that were omitted.
 

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -265,6 +265,9 @@ static void listconf_list_build_info(void)
 #ifdef WITH_ASAN
 	cpdbg += sprintf(cpdbg, "\tASan (Address Sanitizer debugging)\n");
 #endif
+#ifdef WITH_UBSAN
+	cpdbg += sprintf(cpdbg, "\tUbSan (Undefined Behavior Sanitizer debugging)\n");
+#endif
 	if (DebuggingOptions != cpdbg) {
 		printf("Built with these debugging options\n%s\n", DebuggingOptions);
 	}

--- a/src/listconf.h
+++ b/src/listconf.h
@@ -35,6 +35,12 @@
 #define ASAN_STRING ""
 #endif
 
+#ifdef WITH_UBSAN
+#define UBSAN_STRING " UbSan"
+#else
+#define UBSAN_STRING ""
+#endif
+
 #if defined(MEMDBG_ON) && defined(MEMDBG_EXTRA_CHECKS)
 #define MEMDBG_STRING " memdbg-ex"
 #elif defined(MEMDBG_ON)


### PR DESCRIPTION
@magnumripper this adds support for -fsanitize=undefined.

I did not push that change into your repo, so that you can review and suggest changes.
But feel free to just pull and fix any issues you see. 

I tested similar changes on top of https://github.com/loverszhaokai/JohnTheRipper/tree/fuzz_option and found several instances of undefined behavior.
For now, I decided to add `-fsanitize-undefined-trap-on-error` together with `-fsanitize=undefined`.
That makes it easier to use gdb and look at the backtrace.
Without `-fsanitize-undefined-trap-on-error`, you get nice error messages, but they might scroll off the screen, unnoticed among other output:
The first message didn't occur with gcc 5.1.1, but with clang 3.5.0:
```
scrypt_fmt.c:179:9: runtime error: index 18446744073709551615 out of bounds for type 'char [512]'
```
The error occurs when the string tmp2 is empty.
@loverszhaokai apparently, `--fuzz` didn't trigger the same problem for an empty tmp4.

The other messages occur both with gcc 5.1.1 and clang 3.5.0:
```
agilekeychain_fmt_plug.c:124:26: runtime error: signed integer overflow: -1773790770 * 2 cannot be represented in type 'int'
agilekeychain_fmt_plug.c:133:24: runtime error: signed integer overflow: -1299679801 * 2 cannot be represented in type 'int'
blockchain_fmt_plug.c:132:23: runtime error: signed integer overflow: -1285418264 * 2 cannot be represented in type 'int'
cloudkeychain_fmt_plug.c:140:22: runtime error: signed integer overflow: -1116077176 * 2 cannot be represented in type 'int'
cloudkeychain_fmt_plug.c:153:22: runtime error: signed integer overflow: -1285418328 * 2 cannot be represented in type 'int'
dmg_fmt_plug.c:263:24: runtime error: signed integer overflow: -1116077172 * 2 cannot be represented in type 'int'
dmg_fmt_plug.c:272:24: runtime error: signed integer overflow: -1116077160 * 2 cannot be represented in type 'int'
dmg_fmt_plug.c:281:24: runtime error: signed integer overflow: -1116077128 * 2 cannot be represented in type 'int'
dmg_fmt_plug.c:290:24: runtime error: signed integer overflow: 2088763392 * 2 cannot be represented in type 'int'
dmg_fmt_plug.c:312:24: runtime error: signed integer overflow: -1116077172 * 2 cannot be represented in type 'int'
dmg_fmt_plug.c:321:24: runtime error: signed integer overflow: -1116077136 * 2 cannot be represented in type 'int'
dmg_fmt_plug.c:330:24: runtime error: signed integer overflow: -1116077144 * 2 cannot be represented in type 'int'
encfs_common_plug.c:41:10: runtime error: signed integer overflow: -1116077172 * 2 cannot be represented in type 'int'
encfs_common_plug.c:52:10: runtime error: signed integer overflow: -1116077148 * 2 cannot be represented in type 'int'
androidfde_fmt_plug.c:148:27: runtime error: signed integer overflow: -1116077176 * 2 cannot be represented in type 'int'
androidfde_fmt_plug.c:157:26: runtime error: signed integer overflow: -1116077176 * 2 cannot be represented in type 'int'
gpg_fmt_plug.c:324:23: runtime error: signed integer overflow: -1285417997 * 2 cannot be represented in type 'int'
gpg_fmt_plug.c:414:24: runtime error: signed integer overflow: -1285418536 * 2 cannot be represented in type 'int'
keystore_fmt_plug.c:121:21: runtime error: signed integer overflow: 2134107022 * 2 cannot be represented in type 'int'
keystore_fmt_plug.c:137:21: runtime error: signed integer overflow: -1887443968 * 2 cannot be represented in type 'int'
kwallet_fmt_plug.c:110:22: runtime error: signed integer overflow: -1285418552 * 2 cannot be represented in type 'int'
mozilla_ng_fmt_plug.c:128:23: runtime error: signed integer overflow: -1116077172 * 2 cannot be represented in type 'int'
mozilla_ng_fmt_plug.c:139:23: runtime error: signed integer overflow: -1116077181 * 2 cannot be represented in type 'int'
mozilla_ng_fmt_plug.c:150:23: runtime error: signed integer overflow: -1116077176 * 2 cannot be represented in type 'int'
mozilla_ng_fmt_plug.c:161:23: runtime error: signed integer overflow: -1116077172 * 2 cannot be represented in type 'int'
putty_fmt_plug.c:153:23: runtime error: signed integer overflow: -1285418232 * 2 cannot be represented in type 'int'
putty_fmt_plug.c:162:23: runtime error: signed integer overflow: -1116077160 * 2 cannot be represented in type 'int'
rar5_common.h:80:23: runtime error: signed integer overflow: -1116077176 * 2 cannot be represented in type 'int'
7z_fmt_plug.c:163:23: runtime error: signed integer overflow: -1285418552 * 2 cannot be represented in type 'int'
ssh_ng_fmt_plug.c:132:22: runtime error: signed integer overflow: -1116077176 * 2 cannot be represented in type 'int'
ssh_ng_fmt_plug.c:141:22: runtime error: signed integer overflow: 2083597198 * 2 cannot be represented in type 'int'
vtp_fmt_plug.c:137:23: runtime error: signed integer overflow: -1486384855 * 2 cannot be represented in type 'int'
vtp_fmt_plug.c:147:23: runtime error: signed integer overflow: -1486384855 * 2 cannot be represented in type 'int'
```


Currently, I always exclude `-fsanitize=alignment`, because that causes false positive messages on x86*:

```
Testing: OpenVMS, Purdy [32/64]... uaf_encode.c:540:13: runtime error: member access within misaligned address 0x00000203e7d4 for type 'struct uaf_hash_info', which requires 8 byte alignment
0x00000203e7d4: note: pointer points here
  e8 cb ac 83 64 90 61 55  0a 32 2a d1 00 00 00 00  00 00 00 00 a5 fb 03 00  8d 96 0b 7e 10 00 00 00
              ^ 
uaf_encode.c:557:30: runtime error: member access within misaligned address 0x00000203e7d4 for type 'struct uaf_hash_info', which requires 8 byte alignment
0x00000203e7d4: note: pointer points here
  e8 cb ac 83 64 90 61 55  0a 32 2a d1 00 00 00 00  00 00 00 00 a5 fb 03 00  8d 96 0b 7e 10 00 00 00
              ^ 
uaf_encode.c:557:20: runtime error: member access within misaligned address 0x00000203e7d4 for type 'struct uaf_hash_info', which requires 8 byte alignment
0x00000203e7d4: note: pointer points here
  e8 cb ac 83 64 90 61 55  0a 32 2a d1 00 00 00 00  00 00 00 00 a5 fb 03 00  8d 96 0b 7e 10 00 00 00
              ^ 
uaf_encode.c:562:13: runtime error: member access within misaligned address 0x00000203e7d4 for type 'struct uaf_hash_info', which requires 8 byte alignment
0x00000203e7d4: note: pointer points here
  e8 cb ac 83 64 90 61 55  0a 32 2a d1 00 00 00 00  00 00 00 00 a5 fb 03 00  8d 96 0b 7e 10 00 00 00
              ^ 
uaf_encode.c:566:10: runtime error: member access within misaligned address 0x00000203e7d4 for type 'struct uaf_hash_info', which requires 8 byte alignment
0x00000203e7d4: note: pointer points here
  e8 cb ac 83 64 90 61 55  0a 32 2a d1 00 00 00 00  00 00 00 00 a5 fb 03 00  8d 96 0b 7e 10 00 00 00
              ^ 
PASS
```

May be it would be better to add `-fno-sanitize=alignment` only if the architecture allows unaligned access without performance penalty.

I also added `-param=max-vartrack-size=0` (unlimited) to avoid two warnings:
```
sse-intrinsics.c: In function ‘SSEmd5body’:
sse-intrinsics.c:114:6: note: variable tracking size limit exceeded with -fvar-tracking-assignments, retrying without
 void SSEmd5body(vtype* _data, unsigned int *out,
      ^
sse-intrinsics.c: In function ‘SSEmd4body’:
sse-intrinsics.c:678:6: note: variable tracking size limit exceeded with -fvar-tracking-assignments, retrying without
 void SSEmd4body(vtype* _data, unsigned int *out, ARCH_WORD_32 *reload_state,
```
May be the ability to debug wouldn't be influenced too much
by just dropping --param=max-vartrack-size=0.

Apparantly, clang doesn't support the combination of
-fsanitize=undefined and -fsanitize-undefined-trap-on-error.
Currently, I don't detect this, resulting in a failing build.
I must have done something wrong when checking whether the compiler supports these options, but obviously I lack the skills to fix that. (I can blame the missing developer docs...)

You can combine `--enable-asan` and `--enable-ubsan`.

I also noticed that compiling sse-intrinsics.o with `-fsanitize=undefined` takes several minutes with gcc.
With clang I never waited long enough. After more than 30 minutes, I interrupted make, compiled sse-intrinsics.o without `-fsanitize=undefined` and resumed make...

