### PR TITLE
Add --enable-tsan

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -524,7 +524,7 @@ int benchmark_all(void)
 AGAIN:
 #endif
 	total = failed = 0;
-#if defined(WITH_ASAN) || defined(WITH_UBSAN) || defined(DEBUG)
+#if defined(WITH_ASAN) || defined(WITH_UBSAN) || defined(WITH_TSAN) || defined(DEBUG)
 	if (benchmark_time)
 		puts("NOTE: This is a debug build, speed will be lower than normal");
 #endif

--- a/src/configure
+++ b/src/configure
@@ -756,6 +756,7 @@ with_flock
 enable_memdbg
 enable_asan
 enable_ubsan
+enable_tsan
 enable_plugin_dependencies
 enable_openmp_for_fast_formats
 enable_mpi
@@ -1387,6 +1388,7 @@ Optional Features:
   --enable-memdbg         Enable memdbg memory debugging (safe level)
   --enable-asan           * Build with AddressSanitizer
   --enable-ubsan          * Build with UndefinedBehaviorSanitizer
+  --enable-tsan           * Build with ThreadSanitizer
   --disable-plugin-dependencies
                           Do not create best-effort Makefile dependencies for
                           plugins
@@ -3525,6 +3527,13 @@ if test "${enable_ubsan+set}" = set; then :
   enableval=$enable_ubsan; ubsan=$enableval
 else
   ubsan=no
+fi
+
+# Check whether --enable-tsan was given.
+if test "${enable_tsan+set}" = set; then :
+  enableval=$enable_tsan; tsan=$enableval
+else
+  tsan=no
 fi
 
 # Check whether --enable-plugin-dependencies was given.
@@ -5978,6 +5987,67 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
    LDFLAGS=${LDFLAGS_BAK}
 fi
 
+# if user requested  TSan, make sure we can properly build/link with it.
+# TSan cannot be combined with ASan
+if test "x$tsan" = xyes ; then
+   CFLAGS_EX=""
+   LDFLAGS_BAK=${LDFLAGS}
+     if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -DWITH_TSAN -fsanitize=thread" >&5
+$as_echo_n "checking if $CC supports -DWITH_TSAN -fsanitize=thread... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -DWITH_TSAN -fsanitize=thread"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -DWITH_TSAN -fsanitize=thread"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   if test "x${CFLAGS_EX}" = x ; then
+      tsan=no
+   else
+      LDFLAGS="-fsanitize=thread $LDFLAGS"
+   fi
+   LDFLAGS=${LDFLAGS_BAK}
+fi
+
+
    # now fill out CFLAGS
    CFLAGS_EX=""
      if test "1" = 1; then :
@@ -6072,7 +6142,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-if test "x$asan" = xyes || test "x$ubsan" = xyes ; then
+if test "x$asan" = xyes || test "x$ubsan" = xyes || test "x$tsan" = xyes; then
      if test "1" = 1; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -fno-omit-frame-pointer" >&5
 $as_echo_n "checking if $CC supports -fno-omit-frame-pointer... " >&6; }
@@ -13539,6 +13609,13 @@ if test "x$ubsan" = xyes ; then
    LDFLAGS="-fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error $LDFLAGS"
 fi
 
+if test "x$tsan" = xyes ; then
+   CFLAGS=`echo $CFLAGS | sed 's/-g //g; s/-O2 //g'`
+   CFLAGS=`echo $CFLAGS | sed 's/-g$//g; s/-O2$//g'`
+   CFLAGS="-g $O_DEBUG -DWITH_TSAN -fsanitize=thread $CFLAGS"
+   LDFLAGS="-fsanitize=thread $LDFLAGS"
+fi
+
 #add ARCH_LITTLE_ENDIAN to command line, IF we know it is big or little
 if test "x$endian" = "xbig"; then
    CFLAGS="$CFLAGS -DARCH_LITTLE_ENDIAN=0"
@@ -15160,6 +15237,12 @@ else
    ubsan="disabled"
 fi
 
+if test "x$tsan" = xyes ; then
+   tsan="enabled"
+else
+   tsan="disabled"
+fi
+
 if test "x$enable_int128" = xno; then
    have_int128=disabled
 elif test "x$ac_cv_type_int128" = xyes ||
@@ -15200,6 +15283,7 @@ Development options (these may hurt performance when enabled):
 Memdbg memory debugging settings ............ ${memdbg_settings}
 AddressSanitizer ("ASan") ................... ${asan}
 UndefinedBehaviorSanitizer ("UbSan") ........ ${ubsan}
+ThreadSanitizer ("TSan)" .................... ${tsan}
 
 Install missing libraries to get any needed features that were omitted.
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -67,6 +67,7 @@ AC_ARG_WITH(flock, [AS_HELP_STRING([--with-flock],[use flock() file locking inst
 AC_ARG_ENABLE([memdbg], [AC_HELP_STRING([--enable-memdbg], [Enable memdbg memory debugging (safe level)])], [memdbg=$enableval], [memdbg=no])
 AC_ARG_ENABLE([asan], [AS_HELP_STRING([--enable-asan], [* Build with AddressSanitizer])], [asan=$enableval], [asan=no])
 AC_ARG_ENABLE([ubsan], [AS_HELP_STRING([--enable-ubsan], [* Build with UndefinedBehaviorSanitizer])], [ubsan=$enableval], [ubsan=no])
+AC_ARG_ENABLE([tsan], [AS_HELP_STRING([--enable-tsan], [* Build with ThreadSanitizer])], [tsan=$enableval], [tsan=no])
 AC_ARG_ENABLE([plugin-dependencies], [AS_HELP_STRING([--disable-plugin-dependencies], [Do not create best-effort Makefile dependencies for plugins])], [plug_deps=$enableval], [plug_deps=yes])
 
 # Define Features. OpenMP and OpenCL are defined in their respective macros.
@@ -217,11 +218,26 @@ if test "x$ubsan" = xyes ; then
    LDFLAGS=${LDFLAGS_BAK}
 fi
 
+# if user requested  TSan, make sure we can properly build/link with it.
+# TSan cannot be combined with ASan
+if test "x$tsan" = xyes ; then
+   CFLAGS_EX=""
+   LDFLAGS_BAK=${LDFLAGS}
+   JTR_FLAG_CHECK_LINK([-DWITH_TSAN -fsanitize=thread], 1)
+   if test "x${CFLAGS_EX}" = x ; then
+      tsan=no
+   else
+      LDFLAGS="-fsanitize=thread $LDFLAGS"
+   fi
+   LDFLAGS=${LDFLAGS_BAK}
+fi
+
+
    # now fill out CFLAGS
    CFLAGS_EX=""
    JTR_FLAG_CHECK([-Wall], 1)
    JTR_FLAG_CHECK([-Wdeclaration-after-statement], 1)
-if test "x$asan" = xyes || test "x$ubsan" = xyes ; then
+if test "x$asan" = xyes || test "x$ubsan" = xyes || test "x$tsan" = xyes; then
    JTR_FLAG_CHECK([-fno-omit-frame-pointer], 1)
 else
    JTR_FLAG_CHECK([-fomit-frame-pointer], 1)
@@ -775,6 +791,13 @@ if test "x$ubsan" = xyes ; then
    LDFLAGS="-fsanitize=undefined -fno-sanitize=alignment -fsanitize-undefined-trap-on-error $LDFLAGS"
 fi
 
+if test "x$tsan" = xyes ; then
+   CFLAGS=`echo $CFLAGS | sed 's/-g //g; s/-O2 //g'`
+   CFLAGS=`echo $CFLAGS | sed 's/-g$//g; s/-O2$//g'`
+   CFLAGS="-g $O_DEBUG -DWITH_TSAN -fsanitize=thread $CFLAGS"
+   LDFLAGS="-fsanitize=thread $LDFLAGS"
+fi
+
 #add ARCH_LITTLE_ENDIAN to command line, IF we know it is big or little
 if test "x$endian" = "xbig"; then
    CFLAGS="$CFLAGS -DARCH_LITTLE_ENDIAN=0"
@@ -968,6 +991,12 @@ else
    ubsan="disabled"
 fi
 
+if test "x$tsan" = xyes ; then
+   tsan="enabled"
+else
+   tsan="disabled"
+fi
+
 if test "x$enable_int128" = xno; then
    have_int128=disabled
 elif test "x$ac_cv_type_int128" = xyes ||
@@ -1009,6 +1038,7 @@ Development options (these may hurt performance when enabled):
 Memdbg memory debugging settings ............ ${memdbg_settings}
 AddressSanitizer ("ASan") ................... ${asan}
 UndefinedBehaviorSanitizer ("UbSan") ........ ${ubsan}
+ThreadSanitizer ("TSan)" .................... ${tsan}
 
 Install missing libraries to get any needed features that were omitted.
 

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -274,6 +274,10 @@ static void listconf_list_build_info(void)
 #ifdef WITH_UBSAN
 	cpdbg += sprintf(cpdbg, "\tUbSan (Undefined Behavior Sanitizer debugging)\n");
 #endif
+#ifdef WITH_TSAN
+        cpdbg += sprintf(cpdbg, "\tTSan (Thread Sanitizer debugging)\n");
+#endif
+
 	if (DebuggingOptions != cpdbg) {
 		printf("Built with these debugging options\n%s\n", DebuggingOptions);
 	}

--- a/src/listconf.h
+++ b/src/listconf.h
@@ -41,6 +41,13 @@
 #define UBSAN_STRING ""
 #endif
 
+#ifdef WITH_TSAN
+#define TSAN_STRING " TSan"
+#else
+#define TSAN_STRING ""
+#endif
+
+
 #if defined(MEMDBG_ON) && defined(MEMDBG_EXTRA_CHECKS)
 #define MEMDBG_STRING " memdbg-ex"
 #elif defined(MEMDBG_ON)


### PR DESCRIPTION
TODO: avoid trying to combine --enable-asan and --enable-tsan,
since -fsanitize=address and -fsanitize=thread cannot be combined

TODO: -enable-tsan shouldn't be allowed for --disable-openmp or
when the compiler doesn't support -fopenmp

@magnumripper please also see the comments in the pull request I closed:
https://github.com/magnumripper/JohnTheRipper/pull/1486
