### PR TITLE
Fixed wrong header (was immintrin.h - AVX header)

### DIFF
--- a/src/pomelo_plug.c
+++ b/src/pomelo_plug.c
@@ -16,7 +16,7 @@
 
 #ifdef __SSE2__
 
-#include <immintrin.h>
+#include <emmintrin.h>
 #include "memdbg.h"
 
 #define ADD128(x,y)       _mm_add_epi64((x), (y))


### PR DESCRIPTION
emmintrin.h - SSE2 header, while immintrin.h is an AVX header.