### PR TITLE
Boost 7z formats' many-salts speed a *lot*

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -30,6 +30,9 @@ struct bench_results {
 
 /* Number of ciphertexts computed */
 	int64 crypts;
+
+/* Number of salts actually tested */
+	int salts_done;
 };
 
 /*


### PR DESCRIPTION
It's KDF is effectively unsalted as long as the iteration count doesn't change. Closes #1679.

To see the boost for OpenCL in benchmark, you currently need to use a longer test time, eg. --test=5 (or more, depending on GPU). This is actually needed to see the full boost even with the CPU format.

@zzlei I made this a PR so not to disturb your SIMD work. You get to decide if you want to merge it before your SIMD changes (and rebase your SIMD branch), or after (and we'll manually sort out the conflicts).