### PR TITLE
Avoid strcpy if key is already aligned in set_key()

### DIFF
--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -199,7 +199,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)&(key[4]);
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)strcpy(buf_aligned, key + 4);
+	const uint64_t *wkey = (uint64_t*)(is_aligned(key+4, sizeof(uint64_t)) ?
+	                                   (key+4) : strcpy(buf_aligned, key+4));
 #endif
 	ARCH_WORD_64 *keybuffer = &((ARCH_WORD_64 *)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
 	ARCH_WORD_64 *keybuf_word = keybuffer;

--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -199,8 +199,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)&(key[4]);
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const uint64_t *wkey = (uint64_t*)(is_aligned(key+4, sizeof(uint64_t)) ?
-	                                   (key+4) : strcpy(buf_aligned, key+4));
+	const ARCH_WORD_64 *wkey = is_aligned(key+4, sizeof(uint64_t)) ?
+			(ARCH_WORD_64*)(key+4) : (ARCH_WORD_64*)strcpy(buf_aligned, key+4);
 #endif
 	ARCH_WORD_64 *keybuffer = &((ARCH_WORD_64 *)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
 	ARCH_WORD_64 *keybuf_word = keybuffer;

--- a/src/XSHA_fmt_plug.c
+++ b/src/XSHA_fmt_plug.c
@@ -283,7 +283,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuffer = &saved_key[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32 + SIMD_COEF_32];
 	ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/citrix_ns_fmt_plug.c
+++ b/src/citrix_ns_fmt_plug.c
@@ -189,7 +189,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuf_word = (ARCH_WORD_32*)&saved_key[0][GETPOS(SALT_SIZE ^ 3, index)];
 	unsigned int len;

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -1199,7 +1199,13 @@ static void set_key(char *key, int index)
 #ifdef SIMD_COEF_32
 		if (dynamic_use_sse==1) {
 			// code derived from rawMD5_fmt_plug.c code from magnum
+#if ARCH_ALLOWS_UNALIGNED
 			const ARCH_WORD_32 *key32 = (ARCH_WORD_32*)key;
+#else
+			char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
+			const ARCH_WORD_32 *key32 = is_aligned(key, sizeof(uint32_t)) ?
+					(uint32_t*)key : (uint32_t*)strcpy(buf_aligned, key);
+#endif
 			unsigned int idx = ( ((unsigned int)index)/SIMD_COEF_32);
 			ARCH_WORD_32 *keybuffer = &input_buf[idx].w[index&(SIMD_COEF_32-1)];
 			ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/mssql05_fmt_plug.c
+++ b/src/mssql05_fmt_plug.c
@@ -192,12 +192,7 @@ static void done(void)
 static void set_key(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const unsigned char *key = (unsigned char*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const unsigned char *key = (unsigned char*)strcpy(buf_aligned, _key);
-#endif
 	unsigned int *keybuf_word = (unsigned int*)&saved_key[GETPOS(3, index)];
 	unsigned int len, temp2;
 
@@ -248,12 +243,7 @@ key_cleaning:
 static void set_key_CP(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const unsigned char *key = (unsigned char*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const unsigned char *key = (unsigned char*)strcpy(buf_aligned, _key);
-#endif
 	unsigned int *keybuf_word = (unsigned int*)&saved_key[GETPOS(3, index)];
 	unsigned int len, temp2;
 
@@ -301,12 +291,7 @@ key_cleaning_enc:
 static void set_key_utf8(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const UTF8 *source = (UTF8*)_key;
-#else
-	UTF8 *buf_aligned[PLAINTEXT_LENGTH*3 + 1] JTR_ALIGN(sizeof(uint32_t));
-	const UTF8 *source = memcpy(buf_aligned, _key, strlen8((UTF8*)_key)*3 + 1);
-#endif
 	unsigned int *keybuf_word = (unsigned int*)&saved_key[GETPOS(3, index)];
 	UTF32 chl, chh = 0x80;
 	unsigned int len;

--- a/src/mysqlSHA1_fmt_plug.c
+++ b/src/mysqlSHA1_fmt_plug.c
@@ -160,7 +160,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuf_word = (ARCH_WORD_32*)&saved_key[GETPOS(3, index)];
 	unsigned int len;

--- a/src/nt2_fmt_plug.c
+++ b/src/nt2_fmt_plug.c
@@ -316,12 +316,7 @@ static void *get_binary(char *ciphertext)
 static void set_key(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const unsigned char *key = (unsigned char*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const unsigned char *key = (unsigned char*)strcpy(buf_aligned, _key);
-#endif
 	unsigned int *keybuf_word = buf_ptr[index];
 	unsigned int len, temp2;
 
@@ -379,12 +374,7 @@ key_cleaning:
 static void set_key_CP(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const unsigned char *key = (unsigned char*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const unsigned char *key = (unsigned char*)strcpy(buf_aligned, _key);
-#endif
 	unsigned int *keybuf_word = buf_ptr[index];
 	unsigned int len, temp2;
 
@@ -429,12 +419,7 @@ key_cleaning_enc:
 static void set_key_utf8(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const UTF8 *source = (UTF8*)_key;
-#else
-	UTF8 *buf_aligned[PLAINTEXT_LENGTH*3 + 1] JTR_ALIGN(sizeof(uint32_t));
-	const UTF8 *source = memcpy(buf_aligned, _key, strlen8((UTF8*)_key)*3 + 1);
-#endif
 	unsigned int *keybuf_word = buf_ptr[index];
 	UTF32 chl, chh = 0x80;
 	unsigned int len = 0;

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -712,12 +712,7 @@ static void set_salt(void *salt)
 static void set_key_ansi(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const uchar *key = (uchar*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uchar *key = (uchar*)strcpy(buf_aligned, _key);
-#endif
 	unsigned int *keybuf_word = (unsigned int*)&saved_key[GETPOS(0, index)];
 	unsigned int len, temp2;
 
@@ -775,12 +770,7 @@ key_cleaning:
 static void set_key_CP(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const uchar *key = (uchar*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uchar *key = (uchar*)strcpy(buf_aligned, _key);
-#endif
 	unsigned int *keybuf_word = (unsigned int*)&saved_key[GETPOS(0, index)];
 	unsigned int len, temp2;
 
@@ -827,12 +817,7 @@ key_cleaning_enc:
 static void set_key_utf8(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const UTF8 *source = (UTF8*)_key;
-#else
-	UTF8 *buf_aligned[PLAINTEXT_LENGTH*3 + 1] JTR_ALIGN(sizeof(uint32_t));
-	const UTF8 *source = memcpy(buf_aligned, _key, strlen8((UTF8*)_key)*3 + 1);
-#endif
 	unsigned int *keybuf_word = (unsigned int*)&saved_key[GETPOS(0, index)];
 	UTF32 chl, chh = 0x80;
 	unsigned int len = 0;

--- a/src/oracle11_fmt_plug.c
+++ b/src/oracle11_fmt_plug.c
@@ -212,7 +212,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuf_word = (unsigned int*)&saved_key[GETPOS_WORD(0, index)];
 	unsigned int len;

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -238,7 +238,8 @@ static void set_key(char *_key, int index)
 	const ARCH_WORD_32 *key = (ARCH_WORD_32*)_key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *key = (ARCH_WORD_32*)strcpy(buf_aligned, _key);
+	const ARCH_WORD_32 *key = (uint32_t*)(is_aligned(_key, sizeof(uint32_t)) ?
+	                                      _key : strcpy(buf_aligned, _key));
 #endif
 	ARCH_WORD_32 *keybuffer = &((ARCH_WORD_32*)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*MD4_BUF_SIZ*SIMD_COEF_32];
 	ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -222,7 +222,8 @@ static void set_key(char *_key, int index)
 	const ARCH_WORD_32 *key = (ARCH_WORD_32*)_key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *key = (ARCH_WORD_32*)strcpy(buf_aligned, _key);
+	const ARCH_WORD_32 *key = (uint32_t*)(is_aligned(_key, sizeof(uint32_t)) ?
+	                                      _key : strcpy(buf_aligned, _key));
 #endif
 	ARCH_WORD_32 *keybuffer = &((ARCH_WORD_32*)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*MD5_BUF_SIZ*SIMD_COEF_32];
 	ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/rawSHA1_fmt_plug.c
+++ b/src/rawSHA1_fmt_plug.c
@@ -145,7 +145,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuffer = &((ARCH_WORD_32*)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
 	ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/rawSHA1_linkedIn_fmt_plug.c
+++ b/src/rawSHA1_linkedIn_fmt_plug.c
@@ -141,7 +141,8 @@ static void set_key(char *key, int index) {
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuffer = &saved_key[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
 	ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -238,7 +238,8 @@ static void set_key(char *key, int index) {
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuffer = &((ARCH_WORD_32 *)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
 	ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -200,7 +200,8 @@ static void set_key(char *key, int index) {
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuffer = &((ARCH_WORD_32 *)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
 	ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -238,7 +238,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)strcpy(buf_aligned, key);
+	const ARCH_WORD_64 *wkey = (uint64_t*)(is_aligned(key, sizeof(uint64_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_64 *keybuffer = &((ARCH_WORD_64*)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
 	ARCH_WORD_64 *keybuf_word = keybuffer;

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -238,8 +238,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const ARCH_WORD_64 *wkey = (uint64_t*)(is_aligned(key, sizeof(uint64_t)) ?
-	                                       key : strcpy(buf_aligned, key));
+	const ARCH_WORD_64 *wkey = is_aligned(key, sizeof(uint64_t)) ?
+			(ARCH_WORD_64*)key : (ARCH_WORD_64*)strcpy(buf_aligned, key);
 #endif
 	ARCH_WORD_64 *keybuffer = &((ARCH_WORD_64*)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
 	ARCH_WORD_64 *keybuf_word = keybuffer;

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -197,8 +197,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const ARCH_WORD_64 *wkey = (uint64_t*)(is_aligned(key, sizeof(uint64_t)) ?
-	                                       key : strcpy(buf_aligned, key));
+	const ARCH_WORD_64 *wkey = is_aligned(key, sizeof(uint64_t)) ?
+			(ARCH_WORD_64*)key : (ARCH_WORD_64*)strcpy(buf_aligned, key);
 #endif
 	ARCH_WORD_64 *keybuffer = &((ARCH_WORD_64*)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
 	ARCH_WORD_64 *keybuf_word = keybuffer;

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -197,7 +197,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)strcpy(buf_aligned, key);
+	const ARCH_WORD_64 *wkey = (uint64_t*)(is_aligned(key, sizeof(uint64_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_64 *keybuffer = &((ARCH_WORD_64*)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
 	ARCH_WORD_64 *keybuf_word = keybuffer;

--- a/src/rawmd5u_fmt_plug.c
+++ b/src/rawmd5u_fmt_plug.c
@@ -215,12 +215,7 @@ static void *get_binary(char *ciphertext)
 static void set_key(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const unsigned char *key = (unsigned char*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const unsigned char *key = (unsigned char*)strcpy(buf_aligned, _key);
-#endif
 	unsigned int *keybuf_word = buf_ptr[index];
 	unsigned int len, temp2;
 
@@ -277,12 +272,7 @@ key_cleaning:
 static void set_key_CP(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const unsigned char *key = (unsigned char*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const unsigned char *key = (unsigned char*)strcpy(buf_aligned, _key);
-#endif
 	unsigned int *keybuf_word = buf_ptr[index];
 	unsigned int len, temp2;
 
@@ -328,12 +318,7 @@ key_cleaning_enc:
 static void set_key_utf8(char *_key, int index)
 {
 #ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
 	const UTF8 *source = (UTF8*)_key;
-#else
-	UTF8 *buf_aligned[PLAINTEXT_LENGTH*3 + 1] JTR_ALIGN(sizeof(uint32_t));
-	const UTF8 *source = memcpy(buf_aligned, _key, strlen8((UTF8*)_key)*3 + 1);
-#endif
 	unsigned int *keybuf_word = buf_ptr[index];
 	UTF32 chl, chh = 0x80;
 	unsigned int len = 0;

--- a/src/salted_sha1_fmt_plug.c
+++ b/src/salted_sha1_fmt_plug.c
@@ -212,7 +212,8 @@ static void set_key(char *key, int index)
 	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const ARCH_WORD_32 *wkey = (ARCH_WORD_32*)strcpy(buf_aligned, key);
+	const ARCH_WORD_32 *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_32 *keybuffer = &((ARCH_WORD_32*)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
 	ARCH_WORD_32 *keybuf_word = keybuffer;

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -197,7 +197,8 @@ static void set_key(char *key, int index) {
 	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)strcpy(buf_aligned, key);
+	const ARCH_WORD_64 *wkey = (uint64_t*)(is_aligned(key, sizeof(uint64_t)) ?
+	                                       key : strcpy(buf_aligned, key));
 #endif
 	ARCH_WORD_64 *keybuffer = &((ARCH_WORD_64 *)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
 	ARCH_WORD_64 *keybuf_word = keybuffer;

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -197,8 +197,8 @@ static void set_key(char *key, int index) {
 	const ARCH_WORD_64 *wkey = (ARCH_WORD_64*)key;
 #else
 	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const ARCH_WORD_64 *wkey = (uint64_t*)(is_aligned(key, sizeof(uint64_t)) ?
-	                                       key : strcpy(buf_aligned, key));
+	const ARCH_WORD_64 *wkey = is_aligned(key, sizeof(uint64_t)) ?
+			(ARCH_WORD_64*)key : (ARCH_WORD_64*)strcpy(buf_aligned, key);
 #endif
 	ARCH_WORD_64 *keybuffer = &((ARCH_WORD_64 *)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
 	ARCH_WORD_64 *keybuf_word = keybuffer;


### PR DESCRIPTION
as discussed in https://github.com/magnumripper/JohnTheRipper/pull/1693