### PR TITLE
Fix keyring crypt_all() which causes the cmp_all() always return 1

### DIFF
--- a/src/keyring_fmt_plug.c
+++ b/src/keyring_fmt_plug.c
@@ -328,11 +328,11 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i) {
 			if (verify_decrypted_buffer(buffers[i], cur_salt->crypto_size)) {
 				cracked[index+i] = 1;
-			}
 #ifdef _OPENMP
 #pragma omp atomic
 #endif
-			any_cracked |= 1;
+				any_cracked |= 1;
+			}
 		}
 		MEM_FREE(buffers);
 	}


### PR DESCRIPTION
See http://www.openwall.com/lists/john-dev/2015/08/22/2