### PR TITLE
Dynamic compiler: Add max-length and zero-length test vectors.

### DIFF
--- a/src/dynamic_compiler.h
+++ b/src/dynamic_compiler.h
@@ -27,6 +27,9 @@ extern void dynamic_compile_done();
 extern DC_HANDLE dynamic_compile_library(const char *expr, uint32_t crc32);
 
 #define DC_MAGIC 0x654d7baf
+#define DC_NUM_VECTORS 5
+
+extern const char *dyna_line[DC_NUM_VECTORS];
 
 /* this structure is WHAT is pointed to by a DC_HANDLE */
 typedef struct DC_struct {
@@ -37,9 +40,7 @@ typedef struct DC_struct {
 	char *pExtraParams;
 	char *pScript;
 	char *pSignature;
-	char *pLine1;
-	char *pLine2;
-	char *pLine3;
+	char *pLine[DC_NUM_VECTORS];
 } DC_struct;
 
 #endif // __DYNAMIC_COMPILER_H__

--- a/src/dynamic_compiler_fmt_plug.c
+++ b/src/dynamic_compiler_fmt_plug.c
@@ -195,19 +195,26 @@ static void link_funcs() {
 		fmt_CompiledDynamic.params.benchmark_length = -1;
 	else
 		fmt_CompiledDynamic.params.benchmark_length = 0;
-	if ((pPriv->pSetup->flags&MGF_PASSWORD_UPCASE)==MGF_PASSWORD_UPCASE) {
+	if (pPriv->pSetup->flags&MGF_PASSWORD_UPCASE) {
 		tests[0].plaintext = "ABC";
 		tests[1].plaintext = "JOHN";
 		tests[2].plaintext= "PASSWEIRD";
 		for (i = 0; i < pPriv->pSetup->MaxInputLen; i++)
 			max_vector[i] = 'A' + (i % 26);
 		max_vector[i] = 0;
-	} else {
+	} else if (pPriv->pSetup->flags&MGF_PASSWORD_LOCASE) {
 		tests[0].plaintext = "abc";
 		tests[1].plaintext = "john";
 		tests[2].plaintext= "passweird";
 		for (i = 0; i < pPriv->pSetup->MaxInputLen; i++)
 			max_vector[i] = 'a' + (i % 26);
+		max_vector[i] = 0;
+	} else {
+		tests[0].plaintext = "abc";
+		tests[1].plaintext = "john";
+		tests[2].plaintext= "passweird";
+		for (i = 0; i < pPriv->pSetup->MaxInputLen; i++)
+			max_vector[i] = 'A' + (i % 26) + ((i % 52) > 25 ? 0x20 : 0);
 		max_vector[i] = 0;
 	}
 	tests[3].plaintext = max_vector;


### PR DESCRIPTION
@jfoug that was some bad hard-coding you did there again. I changed the number of test vectors to a macro in the header, and fixed all code to adopt except within that debug `big_gen_one()` stuff (marked with FIXME).

But something is not right. Please review, and see if you can find whatever little problem remains. Either there is something wrong with my changes, or the max-length tests actually found a real bug immediately.

This looks right to me:
```
$ ../run/john -test -form:dynamic='md4($s.$p),debug'
push
app_sh
.
app_p
f4h

crc32 = 75D868CA
pExpr=md4($s.$p)
extraParams=,debug
signature=@dynamic=md4($s.$p),debug@
line0=@dynamic=md4($s.$p)@46738b902316f5625b8c2dafb25559d0$719a288e
line1=@dynamic=md4($s.$p)@929234abc284b595cd96d85aeddcb42d$3d85c237
line2=@dynamic=md4($s.$p)@e89299858a82e1c4910fcf4446516401$7184f1d5
line3=@dynamic=md4($s.$p)@f3ccd788277509feff0a5cac743d8920$85b68792
line4=@dynamic=md4($s.$p)@f28bb23f42e6db4b9689aed7e83ef1de$83213d35
##############################################################
#  Dynamic script for expression md4($s.$p),debug
##############################################################
Expression=dynamic=md4($s.$p)
#  Flags for this format
Flag=MGF_FLAT_BUFFERS
Flag=MGF_SALTED
#  Lengths used in this format
SaltLen=-32
MaxInputLenX86=110
MaxInputLen=110
#  The functions in the script
Func=DynamicFunc__clean_input_kwik
Func=DynamicFunc__append_salt
Func=DynamicFunc__append_keys
Func=DynamicFunc__MD4_crypt_input1_to_output1_FINAL
#  The test hashes that validate this script
Test=@dynamic=md4($s.$p)@46738b902316f5625b8c2dafb25559d0$719a288e:abc
Test=@dynamic=md4($s.$p)@929234abc284b595cd96d85aeddcb42d$3d85c237:john
Test=@dynamic=md4($s.$p)@e89299858a82e1c4910fcf4446516401$7184f1d5:passweird
Test=@dynamic=md4($s.$p)@f3ccd788277509feff0a5cac743d8920$85b68792:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEF
Test=@dynamic=md4($s.$p)@f28bb23f42e6db4b9689aed7e83ef1de$83213d35:
```

But the max-length test vector fails:
```
$ ../run/john -test -form:dynamic='md4($s.$p)'
NOTE: This is a debug build, speed will be lower than normal
Benchmarking: dynamic=md4($s.$p) [128/128 AVX 4x3]... FAILED (cmp_all(4))
```

Also, there may be some problem with MaxInputLen vs. MaxInputLen_X86 somewhere, I'm not quite sure.


Another problem: I don't get why this (the default format) doesn't get the two new test vectors:
```
$ ../run/john -test -form:dynamic='md5($p),debug'
Code from dynamic_compiler_lib.c

crc32 = 09ABB6B4
pExpr=dynamic=md5($p)
extraParams=
signature=@dynamic=md5($p)@
line0=@dynamic=md5($p)@900150983cd24fb0d6963f7d28e17f72
line1=@dynamic=md5($p)@527bd5b5d689e2c32ae974c6229ff785
line2=@dynamic=md5($p)@9dc1dc3f8499ab3bbc744557acf0a7fb
##############################################################
#  Dynamic script for expression dynamic=md5($p)
##############################################################
Expression=dynamic=md5($p)
#  Flags for this format
Flag=MGF_KEYS_INPUT
#  Lengths used in this format
MaxInputLenX86=110
MaxInputLen=55
#  The functions in the script
Func=DynamicFunc__crypt_md5
#  The test hashes that validate this script
Test=@dynamic=md5($p)@900150983cd24fb0d6963f7d28e17f72:abc
Test=@dynamic=md5($p)@527bd5b5d689e2c32ae974c6229ff785:john
Test=@dynamic=md5($p)@9dc1dc3f8499ab3bbc744557acf0a7fb:passweird
```
I did add them to the hard-coded initial arrays.