### PR TITLE
Fix (or workaround?) for sha256crypt running on AMD 15.5 driver.

### DIFF
--- a/src/opencl/cryptsha256_kernel_GPU.cl
+++ b/src/opencl/cryptsha256_kernel_GPU.cl
@@ -410,6 +410,10 @@ inline void sha256_prepare(__constant sha256_salt	 * salt_data,
 	ctx_update_G(ctx, pass, passlen);
 
 	sha256_digest(ctx);
+
+#if __GPU__ && DEV_VER_MAJOR == 1729
+        barrier(CLK_GLOBAL_MEM_FENCE); //TODO: Why?
+#endif
 	sha256_digest_move_R(ctx, alt_result->mem_32, BUFFER_ARRAY);
 	init_ctx(ctx);
 

--- a/src/opencl/sha256_kernel.cl
+++ b/src/opencl/sha256_kernel.cl
@@ -30,11 +30,8 @@ inline void _memcpy(               uint32_t * dest,
                     __global const uint32_t * src,
                              const uint32_t   len) {
 
-#if UNROLL_LEVEL > 0
-    #pragma unroll
-#endif
-    for (uint32_t i = 0; i < BUFFER_SIZE + 4; i += 4)
-        *dest++ = select(0U, *src++, i < len);
+    for (uint32_t i = 0; i < len; i += 4)
+        *dest++ = *src++;
 }
 
 inline void sha256_block(	  const uint32_t * const buffer,
@@ -140,6 +137,11 @@ void kernel_crypt(
 	//Ajust keys to it start position.
 	keys_buffer += (base >> 6);
     }
+    //Clear the buffer.
+    #pragma unroll
+    for (uint32_t i = 0; i < 15; i++)
+        w[i] = 0;
+
     //Get password.
     _memcpy(w, keys_buffer, total);
 

--- a/src/opencl/sha512_ng_kernel.cl
+++ b/src/opencl/sha512_ng_kernel.cl
@@ -31,11 +31,8 @@ inline void _memcpy(               uint32_t * dest,
                     __global const uint32_t * src,
                              const uint32_t   len) {
 
-#if UNROLL_LEVEL > 0
-    #pragma unroll
-#endif
-    for (uint32_t i = 0; i < 120; i += 4)
-        *dest++ = select(0U, *src++, i < len);
+    for (uint32_t i = 0; i < len; i += 4)
+        *dest++ = *src++;
 }
 
 inline void sha512_block(	  const uint64_t * const buffer,
@@ -142,6 +139,11 @@ void kernel_crypt_raw(
 	//Ajust keys to it start position.
 	keys_buffer += (base >> 6);
     }
+    //Clear the buffer.
+    #pragma unroll
+    for (uint32_t i = 0; i < 15; i++)
+        w[i] = 0;
+
     //Get password.
     _memcpy((uint32_t *) w, keys_buffer, total);
 
@@ -193,6 +195,11 @@ void kernel_crypt_xsha(
     }
     //Get salt information.
     w[0] = salt->salt;
+
+    //Clear the buffer.
+    #pragma unroll
+    for (uint32_t i = 1; i < 15; i++)
+        w[i] = 0;
 
     //Get password.
     _memcpy(((uint32_t *) w) + 1, keys_buffer, total);

--- a/src/opencl_rawsha256_fmt_plug.c
+++ b/src/opencl_rawsha256_fmt_plug.c
@@ -353,10 +353,10 @@ static void set_key(char * _key, int index)
 
 	saved_idx[index] = (key_idx << 6) | len;
 
-	while (len > 4) {
+	do {
 		plaintext[key_idx++] = *key++;
 		len -= 4;
-	}
+	} while (len > 4);
 
 	if (len > 0)
 		plaintext[key_idx++] = *key;

--- a/src/opencl_rawsha512_ng_fmt_plug.c
+++ b/src/opencl_rawsha512_ng_fmt_plug.c
@@ -420,10 +420,10 @@ static void set_key(char * _key, int index)
 
 	saved_idx[index] = (key_idx << 6) | len;
 
-	while (len > 4) {
+	do {
 		plaintext[key_idx++] = *key++;
 		len -= 4;
-	}
+	} while (len > 4);
 
 	if (len > 0)
 		plaintext[key_idx++] = *key;


### PR DESCRIPTION
In fact, I failed to see an error. But this fixes it 

BTW: I guess one of the Openwall's machines has this driver version, so I can test it there.