### PR TITLE
Previous fix for sha256crypt is necessary for Catalyst 15.7 too.

### DIFF
--- a/src/opencl/cryptsha256_kernel_GPU.cl
+++ b/src/opencl/cryptsha256_kernel_GPU.cl
@@ -411,7 +411,7 @@ inline void sha256_prepare(__constant sha256_salt	 * salt_data,
 
 	sha256_digest(ctx);
 
-#if __GPU__ && DEV_VER_MAJOR == 1729
+#if __GPU__ && (DEV_VER_MAJOR == 1729 || DEV_VER_MAJOR == 1800)
         barrier(CLK_GLOBAL_MEM_FENCE); //TODO: Why?
 #endif
 	sha256_digest_move_R(ctx, alt_result->mem_32, BUFFER_ARRAY);


### PR DESCRIPTION
Sorry, I wasn't aware of it. 
*****

BTW: on super (not sure in which openwall machine you guys are using TS).
```
$ ./jtrts.pl raw-sha256-opencl 
Can't locate JSON/XS.pm in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at ./jtrts.pl line 8.
BEGIN failed--compilation aborted at ./jtrts.pl line 8.
```