### PR TITLE
Fine tune the OpenCL sha512crypt kernel for GCN on super.

### DIFF
--- a/src/opencl/cryptsha512_kernel_GPU.cl
+++ b/src/opencl/cryptsha512_kernel_GPU.cl
@@ -23,7 +23,7 @@
 #if amd_vliw4(DEVICE_INFO) || amd_vliw5(DEVICE_INFO)
     #define UNROLL_LEVEL	5
 #elif amd_gcn(DEVICE_INFO)
-    #define UNROLL_LEVEL	1
+    #define UNROLL_LEVEL	5
 #elif (nvidia_sm_2x(DEVICE_INFO) || nvidia_sm_3x(DEVICE_INFO))
     #define UNROLL_LEVEL	4
 #elif nvidia_sm_5x(DEVICE_INFO)


### PR DESCRIPTION
* (15.7 Catalyst driver). It is 2x-3x faster now.