### PR TITLE
Fix for a bug while tuning LWS

### DIFF
--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -1396,8 +1396,12 @@ void opencl_find_best_lws(size_t group_size_limit, int sequential_id,
 	        my_work_group += wg_multiple) {
 
 		global_work_size = gws;
-		if (gws % my_work_group != 0)
+		if (gws % my_work_group != 0) {
+
+			if (GET_EXACT_MULTIPLE(gws, my_work_group) > global_work_size)
+			    continue;
 			global_work_size = GET_EXACT_MULTIPLE(gws, my_work_group);
+		}
 
 		if (options.verbosity > 3)
 			fprintf(stderr, "Testing LWS=" Zu " GWS=" Zu " ...", my_work_group, global_work_size);

--- a/src/opencl/cryptsha512_kernel_GPU.cl
+++ b/src/opencl/cryptsha512_kernel_GPU.cl
@@ -27,7 +27,7 @@
 #elif (nvidia_sm_2x(DEVICE_INFO) || nvidia_sm_3x(DEVICE_INFO))
     #define UNROLL_LEVEL	4
 #elif nvidia_sm_5x(DEVICE_INFO)
-    #define UNROLL_LEVEL	1
+    #define UNROLL_LEVEL	4
 #else
     #define UNROLL_LEVEL	0
 #endif


### PR DESCRIPTION
While tuning LWS:

* There is a GWS value in use. Memory buffers are limited to this GWS value. Suppose it is 768.
* Maximun LWS is, e.g., 1024.

Without this check, a crypt_all(1024) will happen (ops, segmentation fault in some formats on CPU for sure). Allocated buffers are limited to 768 "items".
**********

Please merge the previous PR first.