### PR TITLE
For sm_5x, vector operators do a better job in OpenCL sha512crypt.

### DIFF
--- a/src/opencl/cryptsha512_kernel_GPU.cl
+++ b/src/opencl/cryptsha512_kernel_GPU.cl
@@ -13,7 +13,7 @@
 
 #include "opencl_cryptsha512.h"
 
-#if gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR < 1729
+#if (gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR < 1729) || nvidia_sm_5x(DEVICE_INFO)
     #define VECTOR_USAGE
 #endif
 


### PR DESCRIPTION
* Tested on super.

Not a big deal, but good enough.