### PR TITLE
Dynamic type for PostgreSQL stored MD5 hashes

### DIFF
--- a/run/dynamic.conf
+++ b/run/dynamic.conf
@@ -37,6 +37,7 @@
 # dynamic_1031: gost($p) (hash truncated to length 32)
 # dynamic_1032: sha1_64(utf16($p)) (Peoplesoft)
 # dynamic_1033: sha1_64(utf16($p).$s)
+# dynamic_1034: md5($p.$u) (PostgreSQL MD5)
 # dynamic_1300: md5(md5_raw($p))
 # dynamic_1350: md5(md5($s.$p):$s)
 # dynamic_1400: sha1(utf16($p)) (Microsoft CREDHIST)
@@ -765,6 +766,20 @@ Func=DynamicFunc__SHA1_crypt_input1_to_output1_FINAL
 Test=$dynamic_1033$D7C1gHanUq1xE96HpEQitzAhNB8$FyKXs6zU:password
 Test=$dynamic_1033$sh+Q50Cp4vERzDkJcaaKIv8zubM=$M1RxMCTZ:password2
 Test=$dynamic_1033$DfM7ryjrNamyG0wRS6CwheZS6Mo$3swBL4qn:
+
+################################################################
+# Dynamic type for md5($p.$u) for PostgreSQL accounts MD5 hashes
+# Note: like dynamic_1015 by without salt
+################################################################
+[List.Generic:dynamic_1034]
+Expression=md5($p.$u) (PostgreSQL MD5)
+Flag=MGF_USERNAME
+Func=DynamicFunc__clean_input
+Func=DynamicFunc__append_keys
+Func=DynamicFunc__append_userid
+Func=DynamicFunc__crypt_md5
+Test=$dynamic_1034$bd6fd49a627ecdbe4031b2d52d5748ab:openwall:postgres
+Test=$dynamic_1034$32e12f215ba27cb750c9e093ce4b5127:password:postgres
 
 [List.Generic:dynamic_1300]
 MaxInputLen=55

--- a/run/dynamic.conf
+++ b/run/dynamic.conf
@@ -20,7 +20,7 @@
 # dynamic_1012: md5($p.md5($s)) (WebEdition CMS)
 # dynamic_1013: md5($p.PMD5(username)) (WebEdition CMS)
 # dynamic_1014: md5($p.$s) (long salt)
-# dynamic_1015: md5(md5($p.$u).$s)
+# dynamic_1015: md5(md5($p.$u).$s) (PostgreSQL 'pass the hash')
 # dynamic_1018: md5(sha1(sha1($p)))
 # dynamic_1019: md5(sha1(sha1(md5($p))))
 # dynamic_1020: md5(sha1(md5($p)))
@@ -449,8 +449,13 @@ Test=$dynamic_1014$8bfccd9d67ec0bcdc38e9ae3c19a2903$FinishingwitHEX$:secret
 Test=$dynamic_1014$bf239357f3aa95508a53fe41b7e5f2e3$inthem$HEXiddle6:secret
 Test=$dynamic_1014$e463b65f14643afd970c7ea7e7efeb0f$123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890:12345678901234567890123456789012
 
+####################################################################
+# Dynamic type for md5(md5($p.$u).$s) for PostgreSQL 'pass the hash' weakness
+# See also dynamic_1034 for PostgreSQL MD5
+# http://www.openwall.com/lists/oss-security/2015/03/03/12
+####################################################################
 [List.Generic:dynamic_1015]
-Expression=md5(md5($p.$u).$s)
+Expression=md5(md5($p.$u).$s) (PostgreSQL 'pass the hash')
 Flag=MGF_SALTED
 Flag=MGF_USERNAME
 MaxInputLen=31
@@ -767,10 +772,10 @@ Test=$dynamic_1033$D7C1gHanUq1xE96HpEQitzAhNB8$FyKXs6zU:password
 Test=$dynamic_1033$sh+Q50Cp4vERzDkJcaaKIv8zubM=$M1RxMCTZ:password2
 Test=$dynamic_1033$DfM7ryjrNamyG0wRS6CwheZS6Mo$3swBL4qn:
 
-################################################################
-# Dynamic type for md5($p.$u) for PostgreSQL accounts MD5 hashes
-# Note: like dynamic_1015 by without salt
-################################################################
+####################################################################
+# Dynamic type for md5($p.$u) for PostgreSQL stored MD5 hashes
+# See also dynamic_1015 for PostgreSQL 'pass the hash' (with salt)
+####################################################################
 [List.Generic:dynamic_1034]
 Expression=md5($p.$u) (PostgreSQL MD5)
 Flag=MGF_USERNAME


### PR DESCRIPTION
Seems nobody published such a type already, whereas JtR cracks mysql(-sha1) and oracle hashes.
I've successfully used that new type today on real life databases hashes.
Might it be usefull for anybody else...