### PR TITLE
Enable oldoffice's source() function, storing mitm hash. This calls for use of dyna_salt. Closes #736.

### DIFF
--- a/src/opencl/oldoffice_kernel.cl
+++ b/src/opencl/oldoffice_kernel.cl
@@ -19,6 +19,7 @@
 #include "opencl_sha1.h"
 
 typedef struct {
+	dyna_salt dsalt;
 	int type;
 	uint salt[16/4];
 	uint verifier[16/4]; /* or encryptedVerifier */


### PR DESCRIPTION
@jfoug could you please look at this (or check out this topic branch and try it) and tell me why the heck it segfaults with the dyna salt? I must be doing something wrong but I simply can't see what!