### PR TITLE
Fix aix conversion scripts

### DIFF
--- a/run/aix2john.pl
+++ b/run/aix2john.pl
@@ -23,11 +23,11 @@
 $currentuser="";
 while(<>){
 	chomp;
-	if (m!^(\w+):$!){
+	if (m/^\s*([^:]+):\s*$/){
 		$currentuser=$1;
 		next;
 	}
-	if (m!^\s*password\s+=\s+(\S+)$! and $1 ne "*"){
+	if (m/^\s*password\s+=\s*(\S+)\s*$/ and $1 ne "*"){
 		print "$currentuser:$1\n";
 		$currentuser="";
 		next

--- a/run/aix2john.py
+++ b/run/aix2john.py
@@ -49,25 +49,30 @@ def process_file(filename, is_standard):
 
 
 if __name__ == "__main__":
+
     if len(sys.argv) < 2:
         sys.stderr.write("Usage: %s [-s] -f <AIX passwd file "
             "(/etc/security/passwd)>\n" % sys.argv[0])
         sys.exit(-1)
 
-parser = argparse.ArgumentParser()
-parser.add_argument('-s', action="store_true",
-						default=False,
-						dest="is_standard",
-						help='Use this option if "lpa_options '
-								'= std_hash=true" is activated'
-						)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', action="store_true",
+    						default=False,
+    						dest="is_standard",
+    						help='Use this option if "lpa_options '
+    								'= std_hash=true" is activated'
+    						)
+    
+    parser.add_argument('-f', dest="filename",
+    						default=False,
+    						help='Specify the AIX shadow file filename to read (usually /etc/security/passwd)'
+    						)
+    
+    args = parser.parse_args()
+    
+    if args.filename:
+        process_file(args.filename, args.is_standard)
+    else:   
+        print "Please specify a filename (-f)"
+        sys.exit(-1)
 
-parser.add_argument('-f', dest="filename",
-						default=False,
-						help='Specify the filename to read'
-						)
-
-args = parser.parse_args()
-
-if args.filename:
-    process_file(args.filename, args.is_standard)

--- a/run/aix2john.py
+++ b/run/aix2john.py
@@ -2,6 +2,7 @@
 
 import binascii
 import sys
+import re
 
 try:
 	 import argparse
@@ -20,12 +21,11 @@ def process_file(filename, is_standard):
     username = "?"
 
     for line in fd.readlines():
-        line = line.rstrip('\n')
-        if line.endswith(':'):
+        if re.match('^\s*\S+\s*:\s*$',line):
             username = line.split(':')[0]
 
         if "password = " in line and "smd5" in line:
-            h = line.split("=")[1].lstrip().rstrip()
+            h = line.split("=")[1].strip()
             if len(h) != 37:
                 continue
             if is_standard:
@@ -35,7 +35,7 @@ def process_file(filename, is_standard):
                     h))
 
         elif "password = " in line and "ssha" in line:
-            h = line.split("=")[1].lstrip().rstrip()
+            h = line.split("=")[1].strip()
 
             tc, salt, h = h.split('$')
 
@@ -43,14 +43,14 @@ def process_file(filename, is_standard):
                     tc, salt, h))
 
         elif "password = " in line:  # DES
-            h = line.split("=")[1].lstrip().rstrip()
+            h = line.split("=")[1].strip()
             if h != "*":
                 sys.stdout.write("%s:%s\n" % (username, h))
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        sys.stderr.write("Usage: %s [-s] <AIX passwd file(s) "
+        sys.stderr.write("Usage: %s [-s] -f <AIX passwd file "
             "(/etc/security/passwd)>\n" % sys.argv[0])
         sys.exit(-1)
 
@@ -61,7 +61,13 @@ parser.add_argument('-s', action="store_true",
 						help='Use this option if "lpa_options '
 								'= std_hash=true" is activated'
 						)
+
+parser.add_argument('-f', dest="filename",
+						default=False,
+						help='Specify the filename to read'
+						)
+
 args = parser.parse_args()
 
-for f in remainder:
-    process_file(f, options.is_standard)
+if args.filename:
+    process_file(args.filename, args.is_standard)


### PR DESCRIPTION
# Summary 
This PR is for a couple of small bugfixes around the run/aix2john.pl and run/aix2john.py files. 

# Problem
Consider a demonstration AIX 'shadow' file which, for the purposes of testing, is stored in ~/_aix/etc-security-passwd but would normally live in /etc/security/passwd on an AIX system.

```
$ cat ~/_aix/etc-security-passwd 
guest:
        password = *

stuart: 
        password = i9oX8gKSX2wtQ
        lastupdate = 1448384447

nobody: 
        password = * 
                                         
lpd: 
        password = * 

stufus: 
        password = VIsSD5LXPKxno
        lastupdate = 1448384447
        flags = ADMCHG
```

When looking at the two scripts (which more or less do the same thing), neither appeared to work correctly against this file.

```
$ perl aix2john.pl < ~/_aix/etc-security-passwd 
guest:i9oX8gKSX2wtQ
:VIsSD5LXPKxno

$ python aix2john.py ~/_aix/etc-security-passwd 
usage: aix2john.py [-h] [-s]
aix2john.py: error: unrecognized arguments: ~/_aix/etc-security-passwd
$ python aix2john.py < ~/_aix/etc-security-passwd 
Usage: aix2john.py [-s] <AIX passwd file(s) (/etc/security/passwd)>
```

The problems seemed to be that:
* The pattern matching in both of the perl and python scripts was not tolerant of leading or trailing whitespace.
* The python script's argument parsing code did not seem to work correctly; I think it was because argparse was in use, meaning that it would fail if filenames were just passed on the command line.

I have fixed both versions, making the minimum changes needed.

# Testing

## Python
```
$ python aix2john.py -f ~/_aix/etc-security-passwd
stuart:i9oX8gKSX2wtQ
stufus:VIsSD5LXPKxno
```

## Perl
```
$ perl aix2john.pl < ~/_aix/etc-security-passwd 
stuart:i9oX8gKSX2wtQ
stufus:VIsSD5LXPKxno
```

## Final

For completeness, I just checked that they could both be cracked correctly.

```
$ john /tmp/etc-security-passwd.aix.john 
Using default input encoding: UTF-8
Loaded 2 password hashes with 2 different salts (descrypt, traditional crypt(3) [DES 128/128 AVX-16])
Press 'q' or Ctrl-C to abort, almost any other key for status
password         (stuart)
password         (stufus)
2g 0:00:00:00 DONE 2/3 (2015-11-24 18:19) 42.66g/s 29674p/s 32405c/s 32405C/s 123456..marley
Use the "--show" option to display all of the cracked passwords reliably
Session completed
```