### PR TITLE
Include the last [1] WHQL certified driver for the 2nd generation of legacy hardware [2].

### DIFF
--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -261,6 +261,7 @@ static char *opencl_driver_info(int sequential_id)
 		{1702, 3},
 		{1729, 3},
 		{1800, 5},
+		{1800, 8},
 		{1800, 11},
 		{1912, 5},
 		{0, 0}
@@ -280,6 +281,7 @@ static char *opencl_driver_info(int sequential_id)
 		"15.5 beta [not recommended]",
 		"15.5",
 		"15.7 [recommended]",
+		"15.7.1",
 		"15.9 [recommended]",
 		"15.11",
 		""


### PR DESCRIPTION
[1] From now on only beta quality software will be provided (if provided, of course).
[2] Radeon™ HD 8000 – HD 8400, HD 7000 – HD 7600, HD 6000, and HD 5000 Series.

BTW: Crimson is useless on Linux if one is trying OpenCL on legacy hardware. This might be the case on Windows.
PS: 15.7.1 is a windows only version. The last available driver for Linux is 15.9.