### PR TITLE
Cleaning conditional directives that break statements.

### DIFF
--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -53,6 +53,7 @@ static DYNAMIC_primitive_funcp _Funcs_1[] =
 
 #include <string.h>
 #include <time.h>
+#include <stdbool.h>
 
 #if AC_BUILT
 #include "autoconfig.h"
@@ -1131,10 +1132,11 @@ static void set_salt(void *salt)
 	saltlen <<= 3;
 	saltlen += *cpsalt++ - '0';
 #if ARCH_ALLOWS_UNALIGNED
-	if (*((ARCH_WORD_32*)cpsalt) != 0x30303030)
+	bool test = *((ARCH_WORD_32*)cpsalt) != 0x30303030;
 #else
-	if (memcmp(cpsalt, "0000", 4))
+	bool test = memcmp(cpsalt, "0000", 4);
 #endif
+	if (test)
 	{
 		// this is why we used base-8. Takes an extra byte, but there is NO conditional
 		// logic, building this number, and no multiplication. We HAVE added one conditional

--- a/src/episerver_fmt_plug.c
+++ b/src/episerver_fmt_plug.c
@@ -33,6 +33,8 @@
  * Full Unicode support, magnum, August 2012.
  */
 
+#include <stdbool.h>
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_episerver;
 #elif FMT_REGISTERS_H
@@ -329,11 +331,13 @@ static int cmp_all(void *binary, int count)
 	int index = 0;
 	for (; index < count; index++) {
 #ifdef SIMD_COEF_32
-		if (*((uint32_t*)binary) == crypt_out[HASH_IDX_OUT])
+		bool test = *((uint32_t*)binary) == crypt_out[HASH_IDX_OUT];
 #else
-		if (*((ARCH_WORD_32*)binary) == crypt_out[index][0])
+		bool test = *((ARCH_WORD_32*)binary) == crypt_out[index][0];
 #endif
+		if (test) {
 			return 1;
+		}
 	}
 	return 0;
 }

--- a/src/logger.c
+++ b/src/logger.c
@@ -10,6 +10,8 @@
  * There's ABSOLUTELY NO WARRANTY, express or implied.
  */
 
+#include <stdbool.h>
+
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE /* for fileno(3) and fsync(2) */
 #endif
@@ -232,13 +234,15 @@ static int log_time(void)
 {
 	int count1, count2;
 	unsigned int time;
+	bool test;
 
 	count1 = 0;
 #ifndef HAVE_MPI
-	if (options.fork) {
+	test = options.fork;
 #else
-	if (options.fork || mpi_p > 1) {
+	test = options.fork || mpi_p > 1;
 #endif
+	if (test) {
 		count1 = (int)sprintf(log.ptr, "%u ", options.node_min);
 		if (count1 < 0)
 			return count1;


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.