### PR TITLE
Trigger command when password found

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -32,11 +32,11 @@ Save = 60
 # Beep when a password is found (who needs this anyway?)
 Beep = N
 
-# Shell script to be executed when a password is cracked.
+# Command to be executed when a password is found
 # If set, the following parameters will be passed when executing command: 
 #   $1 - Login
 #   $2 - Plain password
-ExecOnCrackedPassword = /home/akoss/dev/c/JohnTheRipper-bleeding-jumbo/run/success.sh
+#ExecOnCrackedPassword = ./password_found.sh
 
 # if set to Y then dynamic format will always work with bare hashes. Normally
 # dynamic only uses bare hashes if a single dynamic type is selected with

--- a/run/john.conf
+++ b/run/john.conf
@@ -31,6 +31,13 @@ Idle = Y
 Save = 60
 # Beep when a password is found (who needs this anyway?)
 Beep = N
+
+# Shell script to be executed when a password is cracked.
+# If set, the following parameters will be passed when executing command: 
+#   $1 - Login
+#   $2 - Plain password
+ExecOnCrackedPassword = /home/akoss/dev/c/JohnTheRipper-bleeding-jumbo/run/success.sh
+
 # if set to Y then dynamic format will always work with bare hashes. Normally
 # dynamic only uses bare hashes if a single dynamic type is selected with
 # the -format=  (so -format=dynamic_0 would use valid bare hashes).

--- a/run/password_found.sh
+++ b/run/password_found.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This is a sample shell script which is triggered when a password is found. You can configure john to 
+# execute it by uncommenting "ExecOnCrackedPassword" key in john.conf
+
+echo "Password found for $1: $2"

--- a/src/logger.c
+++ b/src/logger.c
@@ -433,7 +433,7 @@ void log_guess(char *login, char *uid, char *ciphertext, char *rep_plain,
 	if (cfg_beep)
 		write_loop(fileno(stderr), "\007", 1);
 
-	if (strlen(cfg_exec_on_cracked_password)) {
+	if (cfg_exec_on_cracked_password != NULL && strlen(cfg_exec_on_cracked_password)) {
 		snprintf(command, sizeof(command), "%s %s %s", cfg_exec_on_cracked_password, login, rep_plain);
 		command_retval = system(command);
 		if (command_retval == -1) {

--- a/src/logger.c
+++ b/src/logger.c
@@ -434,7 +434,7 @@ void log_guess(char *login, char *uid, char *ciphertext, char *rep_plain,
 		write_loop(fileno(stderr), "\007", 1);
 
 	if (strlen(cfg_exec_on_cracked_password)) {
-		sprintf(command, "%s %s %s", cfg_exec_on_cracked_password, login, rep_plain);
+		snprintf(command, sizeof(command), "%s %s %s", cfg_exec_on_cracked_password, login, rep_plain);
 		command_retval = system(command);
 		if (command_retval == -1) {
 			printf("Command '%s' failed.", command);


### PR DESCRIPTION
Adding new configuration key in john.conf: ExecOnCrackedPassword
If this configuration is enabled, the value of this parameter (it should be a command) will be executed when a password is found, passing the login name and the cracked password as parameters.