### PR TITLE
Making login/plain password argument passing optional (when executing password_found.sh)

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -34,9 +34,16 @@ Beep = N
 
 # Command to be executed when a password is found
 # If set, the following parameters will be passed when executing command:
-#   $1 - Login
-#   $2 - Plain password
+#   Login - if "PassArgLogin" config parameter is Y
+#   Plain password - if "PassArgPassword" config parameter is Y
+#
+# Security notes:
+# If you are using this option, please make sure that unprivilegized users can not modify 
+# the target script. Also, please note that if you switch "PassArgPassword" parameter to Y, 
+# sensitive information might appear in "ps" command output.
 #ExecOnCrackedPassword = $JOHN/password_found.sh
+#PassArgLogin = Y
+#PassArgPassword = N
 
 # if set to Y then dynamic format will always work with bare hashes. Normally
 # dynamic only uses bare hashes if a single dynamic type is selected with

--- a/run/password_found.sh
+++ b/run/password_found.sh
@@ -2,5 +2,8 @@
 
 # This is a sample shell script which is triggered when a password is found. You can configure john to 
 # execute it by uncommenting "ExecOnCrackedPassword" key in john.conf
+# 
+# Note: john would pass login name as first argument if "PassArgLogin" is set to Y in john.conf (default), and 
+# plain password as second argument, if "PassArgPassword" is set to Y.
 
-echo "Password found for $1: $2"
+echo "Password found for user $1" # and password is $2

--- a/run/password_found.sh
+++ b/run/password_found.sh
@@ -3,7 +3,24 @@
 # This is a sample shell script which is triggered when a password is found. You can configure john to 
 # execute it by uncommenting "ExecOnCrackedPassword" key in john.conf
 # 
-# Note: john would pass login name as first argument if "PassArgLogin" is set to Y in john.conf (default), and 
-# plain password as second argument, if "PassArgPassword" is set to Y.
+# Note: john would pass login name if "PassArgLogin" is set to Y in john.conf (default), and 
+# plain password, if "PassArgPassword" is set to Y.
 
-echo "Password found for user $1" # and password is $2
+
+while getopts ":l:p:" opt; do
+    case $opt in
+	l) login="$OPTARG"
+	;;
+	p) passwd="$OPTARG"
+	;;
+    esac
+done
+
+echo "Password found"
+if [ ! -z "$login" ]; then
+    echo "  login: $login"
+fi
+
+if [ ! -z "$passwd" ]; then
+    echo "  password: $passwd"
+fi

--- a/src/logger.c
+++ b/src/logger.c
@@ -441,12 +441,22 @@ void log_guess(char *login, char *uid, char *ciphertext, char *rep_plain,
 		char *command;
 		size_t len;
 		int command_retval;
+		int cfg_pass_login = cfg_get_bool(SECTION_OPTIONS, NULL, "PassArgLogin", 0);
+		int cfg_pass_plain_pwd = cfg_get_bool(SECTION_OPTIONS, NULL, "PassArgPassword", 0);
 
-		len = strlen(cfg_exec_on_cracked_password) + strlen(login) +
-			strlen(rep_plain) + 3;
+		len = strlen(cfg_exec_on_cracked_password) + 1;
+		if (cfg_pass_login) 
+			len += strlen(login) + 1;
+		if (cfg_pass_plain_pwd) 
+			len += strlen(rep_plain) + 1;
+		
 		command = mem_alloc(len);
-		snprintf(command, len, "%s %s %s",
-		         cfg_exec_on_cracked_password, login, rep_plain);
+		snprintf(command, len, "%s", cfg_exec_on_cracked_password);
+		if (cfg_pass_login)
+			sprintf(command, "%s %s", command, login);
+		if (cfg_pass_plain_pwd)
+			sprintf(command, "%s %s", command, rep_plain);
+
 		command_retval = system(command);
 		if (command_retval == -1) {
 			fprintf(stderr, "Failed spawning '%s'.", command);

--- a/src/logger.c
+++ b/src/logger.c
@@ -62,6 +62,8 @@
 
 static char *cfg_exec_on_cracked_password;
 static int cfg_beep;
+static int cfg_pass_login;
+static int cfg_pass_plain_pwd;
 static int cfg_log_passwords;
 static int cfg_showcand;
 
@@ -298,6 +300,10 @@ void log_init(char *log_name, char *pot_name, char *session)
 
 	cfg_exec_on_cracked_password = cfg_get_param(SECTION_OPTIONS, NULL,
 	                                             "ExecOnCrackedPassword");
+
+	cfg_pass_login = cfg_get_bool(SECTION_OPTIONS, NULL, "PassArgLogin", 0);
+	cfg_pass_plain_pwd = cfg_get_bool(SECTION_OPTIONS, NULL, "PassArgPassword", 0);
+
 	if (cfg_exec_on_cracked_password) {
 		cfg_exec_on_cracked_password =
 			str_alloc_copy(path_expand(cfg_exec_on_cracked_password));
@@ -441,21 +447,23 @@ void log_guess(char *login, char *uid, char *ciphertext, char *rep_plain,
 		char *command;
 		size_t len;
 		int command_retval;
-		int cfg_pass_login = cfg_get_bool(SECTION_OPTIONS, NULL, "PassArgLogin", 0);
-		int cfg_pass_plain_pwd = cfg_get_bool(SECTION_OPTIONS, NULL, "PassArgPassword", 0);
 
-		len = strlen(cfg_exec_on_cracked_password) + 1;
-		if (cfg_pass_login) 
-			len += strlen(login) + 1;
-		if (cfg_pass_plain_pwd) 
-			len += strlen(rep_plain) + 1;
-		
+		len = strlen(cfg_exec_on_cracked_password) 
+			+ (cfg_pass_login ? strlen(login) + 4 : 0) 
+			+ (cfg_pass_plain_pwd ? strlen(rep_plain) + 4 : 0);
+
 		command = mem_alloc(len);
-		snprintf(command, len, "%s", cfg_exec_on_cracked_password);
-		if (cfg_pass_login)
-			sprintf(command, "%s %s", command, login);
-		if (cfg_pass_plain_pwd)
-			sprintf(command, "%s %s", command, rep_plain);
+		strncpy(command, cfg_exec_on_cracked_password, len);
+	
+		if (cfg_pass_login) {
+			strncat(command, " -l ", len);
+			strncat(command, login, len);
+		}
+
+		if (cfg_pass_plain_pwd) {
+			strncat(command, " -p ", len);
+			strncat(command, rep_plain, len);
+		}
 
 		command_retval = system(command);
 		if (command_retval == -1) {


### PR DESCRIPTION
For security purposes, default settings are harmless: trigger is switched off + plain password passing is switched off.