### PR TITLE
GWS should be multiple of processors count not multiple of CUs.

### DIFF
--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -2536,8 +2536,9 @@ void opencl_list_devices(void)
 
 			long_entries = get_processors_count(sequence_nr);
 			if (!cpu && ocl_device_list[sequence_nr].cores_per_MP > 1)
-				printf("    Stream processors:      "LLu" "
+				printf("    %s      "LLu" "
 				       " (%d x %d)\n",
+					gpu_nvidia(device_info[sequence_nr]) ? "CUDA cores:       " : "Stream processors:",
 				       (unsigned long long)long_entries,
 				       entries, ocl_device_list[sequence_nr].cores_per_MP);
 			printf("    Speed index:            %u\n",

--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -1575,6 +1575,21 @@ static char *human_speed(unsigned long long int speed)
 	return out;
 }
 
+unsigned int lcm(unsigned int x, unsigned int y)
+{
+	unsigned int tmp, a, b;
+
+	a = MAX(x, y);
+	b = MIN(x, y);
+
+	while (b) {
+		tmp = b;
+		b = a % b;
+		a = tmp;
+	}
+	return x / a * y;
+}
+
 void opencl_find_best_gws(int step, unsigned long long int max_run_time,
                           int sequential_id, unsigned int rounds, int have_lws)
 {
@@ -1583,11 +1598,11 @@ void opencl_find_best_gws(int step, unsigned long long int max_run_time,
 	unsigned long long speed, best_speed = 0, raw_speed;
 	cl_ulong run_time, min_time = CL_ULONG_MAX;
 	unsigned long long int save_duration_time = duration_time;
-	cl_uint core_count = get_max_compute_units(sequential_id);
+	cl_uint core_count = get_processors_count(sequential_id);
 
 	if (have_lws) {
 		if (core_count > 2)
-			optimal_gws *= core_count;
+			optimal_gws = lcm(core_count, optimal_gws);
 		default_value = optimal_gws;
 	} else {
 		soft_limit = local_work_size * core_count * 128;


### PR DESCRIPTION
It is a bad idea to pick CUs as the seed number. One might fail to use all CUDA cores/Stream processors.
*********

BTW: the new lcm() function can be placed in some generic functions file. If we will merge this, I can do the move and an -amend.