### PR TITLE
Modified keepass2john and keepass_fmt_plug.c

### DIFF
--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -157,6 +157,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	uint32_t key_transf_rounds;
 	unsigned char buffer[LINE_BUFFER_SIZE];
 	long long filesize = 0;
+	long long filesize_keyfile = 0;
 	long long datasize;
 	int algorithm = -1;
 	char *dbname;
@@ -207,7 +208,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 			fprintf(stderr, "! %s : %s\n", keyfile, strerror(errno));
 			return;
 		}
-		filesize = (long long)get_file_size(keyfile);
+		filesize_keyfile = (long long)get_file_size(keyfile);
 	}
 
 	dbname = strip_suffixes(basename(encryptedDatabase), extension, 1);
@@ -241,13 +242,13 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 
 		printf("*0*%s", dbname); /* data is not inline */
 	}
-	if (keyfile && sizeof(buffer) > filesize) {
-		printf("*1*"LLd"*", filesize); /* inline keyfile content */
-		if (fread(buffer, filesize, 1, kfp) != 1)
+	if (keyfile && sizeof(buffer) > filesize_keyfile) {
+		printf("*1*"LLd"*", filesize_keyfile); /* inline keyfile content */
+		if (fread(buffer, filesize_keyfile, 1, kfp) != 1)
 			warn_exit("%s: Error: read failed: %s.",
 				encryptedDatabase, strerror(errno));
 
-		print_hex(buffer, filesize);
+		print_hex(buffer, filesize_keyfile);
 	}
 	printf("\n");
 }

--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -254,7 +254,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	}
 
 	if (keyfile) {
-		buffer = (unsigned char*) malloc(filesize_keyfile * sizeof(char));
+		buffer = (unsigned char*) malloc (filesize_keyfile * sizeof(char));
 		printf("*1*64*"); /* inline keyfile content */
 		if (fread(buffer, filesize_keyfile, 1, kfp) != 1)
 			warn_exit("%s: Error: read failed: %s.",
@@ -326,7 +326,7 @@ static void process_database(char* encryptedDatabase)
 		fclose(fp);
 		return;
 	}
-		uVersion = fget32(fp);
+	uVersion = fget32(fp);
 	if ((uVersion & FileVersionCriticalMask) > (FileVersion32 & FileVersionCriticalMask)) {
 		fprintf(stderr, "! %s : Unknown format: File version unsupported\n", encryptedDatabase);
 		fclose(fp);
@@ -336,8 +336,8 @@ static void process_database(char* encryptedDatabase)
 	while (!endReached)
 	{
 		unsigned char btFieldID = fgetc(fp);
-				uint16_t uSize = fget16(fp);
-				enum Kdb4HeaderFieldID kdbID;
+		uint16_t uSize = fget16(fp);
+		enum Kdb4HeaderFieldID kdbID;
 		unsigned char *pbData = NULL;
 
 		if (uSize > 0)
@@ -415,6 +415,12 @@ static void process_database(char* encryptedDatabase)
 		fprintf(stderr, "! %s : parsing failed, please open a bug if target is valid KeepPass database.\n", encryptedDatabase);
 		goto bailout;
 	}
+
+	if (keyfile) {
+		// abort();  // TODO
+ 		fprintf(stderr, "Keyfile support in KeepPass 2 is yet to be implemented!\n");
+ 		return;
+ 	}
 
 	dbname = strip_suffixes(basename(encryptedDatabase),extension, 1);
 	printf("%s:$keepass$*2*%ld*%ld*",dbname, transformRounds, dataStartOffset);

--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -4,6 +4,9 @@
  * Support for cracking KeePass databases, which use key file(s), was added by
  * m3g9tr0n (Spiros Fraganastasis) and Dhiru Kholia in September of 2014.
  *
+ * Support for all types of keyfile within Keepass 1.x added by Fist0urs
+ * <eddy.maaalou at gmail.com>
+ *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
@@ -32,7 +35,7 @@ john_register_one(&fmt_KeePass);
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
-#define OMP_SCALE               1
+#define OMP_SCALE		1
 #endif
 #endif
 #include "memdbg.h"
@@ -92,7 +95,7 @@ static struct custom_salt {
 
 static void transform_key(char *masterkey, struct custom_salt *csp, unsigned char *final_key)
 {
-        // First, hash the masterkey
+		// First, hash the masterkey
 	SHA256_CTX ctx;
 	unsigned char hash[32];
 	unsigned char temphash[32];
@@ -110,29 +113,19 @@ static void transform_key(char *masterkey, struct custom_salt *csp, unsigned cha
 	if(AES_set_encrypt_key(csp->transf_randomseed, 256, &akey) < 0) {
 		fprintf(stderr, "AES_set_encrypt_key failed!\n");
 	}
-	/* keyfile handling (only tested for KeePass 1.x files) */
+	/* keyfile handling (only working for KeePass 1.x files) */
 	if (cur_salt->have_keyfile) {
-		SHA256_CTX composite_ctx;  // for keyfile handling
-		SHA256_CTX keyfile_ctx;
-
+		SHA256_CTX composite_ctx;
 		SHA256_Init(&composite_ctx);
 		SHA256_Update(&composite_ctx, hash, 32);
 
-		if (cur_salt->keyfilesize != 32 && cur_salt->keyfilesize != 64) {
-			SHA256_Init(&keyfile_ctx);
-			SHA256_Update(&keyfile_ctx, cur_salt->keyfile, cur_salt->keyfilesize);
-			SHA256_Final(temphash, &keyfile_ctx);
-		} else if(cur_salt->keyfilesize == 32) {
-			memcpy(temphash, cur_salt->keyfile, 32);
-		} else if (cur_salt->keyfilesize == 64) { /* do hex decoding */
-			abort();  // TODO
-		}
+		memcpy(temphash, cur_salt->keyfile, 32);
 
 		SHA256_Update(&composite_ctx, temphash, 32);
 		SHA256_Final(hash, &composite_ctx);
 	}
 
-        // Next, encrypt the created hash
+		// Next, encrypt the created hash
 	i = csp->key_transf_rounds >> 2;
 	while (i--) {
 		AES_encrypt(hash, hash, &akey);
@@ -149,12 +142,12 @@ static void transform_key(char *masterkey, struct custom_salt *csp, unsigned cha
 		AES_encrypt(hash, hash, &akey);
 		AES_encrypt(hash+16, hash+16, &akey);
 	}
-        // Finally, hash it again...
+		// Finally, hash it again...
 	SHA256_Init(&ctx);
 	SHA256_Update(&ctx, hash, 32);
 	SHA256_Final(hash, &ctx);
 
-        // ...and hash the result together with the randomseed
+		// ...and hash the result together with the randomseed
 	SHA256_Init(&ctx);
 	if(csp->version == 1) {
 		SHA256_Update(&ctx, csp->final_randomseed, 16);
@@ -176,7 +169,7 @@ static void init(struct fmt_main *self)
 	self->params.max_keys_per_crypt *= omp_t;
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
-	                       sizeof(*saved_key));
+						   sizeof(*saved_key));
 	any_cracked = 0;
 	cracked_size = sizeof(*cracked) * self->params.max_keys_per_crypt;
 	cracked = mem_calloc(cracked_size, 1);
@@ -256,20 +249,20 @@ static int valid(char *ciphertext, struct fmt_main *self)
 				goto err;
 			if (hexlenl(p) / 2 != contentsize)
 				goto err;
-			p = strtokm(NULL, "*");
-			if (p)
-				goto err;
 		}
 		p = strtokm(NULL, "*");
+		// keyfile handling
 		if (p) {
-			// keyfile handling
-			if ((p = strtokm(NULL, "*")) == NULL)
-				goto err;
-			res = hexlenl(p);
-			if ((p = strtokm(NULL, "*")) == NULL)
-				goto err;
-			if (res != 32 || hexlenl(p) != 64)
-				goto err;
+			res = atoi(p);
+			if (res == 1) {
+				if ((p = strtokm(NULL, "*")) == NULL)
+					goto err;
+				res = atoi(p);
+				if ((p = strtokm(NULL, "*")) == NULL)
+					goto err;
+				if (res != 64 &&  strlen(p) != 64)
+					goto err;
+			}
 		}
 	}
 	else {
@@ -335,7 +328,7 @@ static void *get_salt(char *ciphertext)
 			p = strtokm(NULL, "*");
 			cs.keyfilesize = atoi(p);
 			p = strtokm(NULL, "*");
-			for (i = 0; i < cs.keyfilesize; i++)
+			for (i = 0; i < 32 /*cs.keyfilesize*/; i++)
 				cs.keyfile[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
 					+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
 			cs.have_keyfile = 1;

--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -95,7 +95,7 @@ static struct custom_salt {
 
 static void transform_key(char *masterkey, struct custom_salt *csp, unsigned char *final_key)
 {
-		// First, hash the masterkey
+	// First, hash the masterkey
 	SHA256_CTX ctx;
 	unsigned char hash[32];
 	unsigned char temphash[32];
@@ -125,7 +125,7 @@ static void transform_key(char *masterkey, struct custom_salt *csp, unsigned cha
 		SHA256_Final(hash, &composite_ctx);
 	}
 
-		// Next, encrypt the created hash
+	// Next, encrypt the created hash
 	i = csp->key_transf_rounds >> 2;
 	while (i--) {
 		AES_encrypt(hash, hash, &akey);
@@ -142,12 +142,12 @@ static void transform_key(char *masterkey, struct custom_salt *csp, unsigned cha
 		AES_encrypt(hash, hash, &akey);
 		AES_encrypt(hash+16, hash+16, &akey);
 	}
-		// Finally, hash it again...
+	// Finally, hash it again...
 	SHA256_Init(&ctx);
 	SHA256_Update(&ctx, hash, 32);
 	SHA256_Final(hash, &ctx);
 
-		// ...and hash the result together with the randomseed
+	// ...and hash the result together with the randomseed
 	SHA256_Init(&ctx);
 	if(csp->version == 1) {
 		SHA256_Update(&ctx, csp->final_randomseed, 16);
@@ -169,7 +169,7 @@ static void init(struct fmt_main *self)
 	self->params.max_keys_per_crypt *= omp_t;
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
-						   sizeof(*saved_key));
+				sizeof(*saved_key));
 	any_cracked = 0;
 	cracked_size = sizeof(*cracked) * self->params.max_keys_per_crypt;
 	cracked = mem_calloc(cracked_size, 1);
@@ -328,7 +328,7 @@ static void *get_salt(char *ciphertext)
 			p = strtokm(NULL, "*");
 			cs.keyfilesize = atoi(p);
 			p = strtokm(NULL, "*");
-			for (i = 0; i < 32 /*cs.keyfilesize*/; i++)
+			for (i = 0; i < 32; i++)
 				cs.keyfile[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
 					+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
 			cs.have_keyfile = 1;


### PR DESCRIPTION
 - keepass2john now handle all different kinds of keyfiles within Keepass 1.x and produces an unique type of output + corrected an existing bug which made impossible to parse keyfile correctly.

- keepass_fmt_plug.c was modified so that it could handle all kind of keyfiles within Keepass 1.x + removed a SHA256 round that is now pre-computed in keepass2john.

**- EDIT: added support for keyfiles within Keepass 2.x. Only one thing remains: keyfiles in xml format (yet to be implemented)**

2 cases have been tested, one with a keepass-created keyfile and one with a 2MB existing file. Both cases work.

I would suggest to wait @kholia review as until today I was not aware of how keyfiles work in keepass and he is the one who implemented this format.

Cheers
