### PR TITLE
OpenCL build works without any installed device (WIP).

### DIFF
--- a/src/common-opencl.h
+++ b/src/common-opencl.h
@@ -140,6 +140,7 @@ extern cl_event *profilingEvent, *firstEvent, *lastEvent;
 extern cl_event *multi_profilingEvent[MAX_EVENTS];
 
 extern int device_info[MAX_GPU_DEVICES];
+extern int none_opencl_device;
 
 #define LWS_CONFIG_NAME         "_LWS"
 #define GWS_CONFIG_NAME         "_GWS"
@@ -148,7 +149,10 @@ extern int device_info[MAX_GPU_DEVICES];
 
 size_t opencl_read_source(char *kernel_filename, char **kernel_source);
 
-/* Passive init: enumerate platforms and devices and parse options */
+/* Passive init: enumerate platforms and devices */
+void start_opencl_environment(void);
+
+/* Parse --device parameter. Initialize requested devices. */
 void opencl_preinit(void);
 
 /* Tear-down. Safe to call even if no device was used */
@@ -161,7 +165,10 @@ void opencl_done(void);
  */
 unsigned int opencl_get_vector_width(int sequential_id, int size);
 
-/* Returns number of selected devices */
+/* Returns the number of all available devices */
+int get_number_of_available_devices(void);
+
+/* Returns the number of devices in use (listed in --device list) */
 int get_number_of_devices_in_use(void);
 
 /* Initialize a specific device. If necessary, parse command line and get

--- a/src/john.c
+++ b/src/john.c
@@ -347,6 +347,10 @@ static void john_register_one(struct fmt_main *format)
 			return;
 	}
 
+#if defined(HAVE_OPENCL)
+	if (strstr(format->params.label, "-opencl") && none_opencl_device)
+		return;
+#endif
 	fmt_register(format);
 }
 
@@ -1473,6 +1477,11 @@ static void john_init(char *name, int argc, char **argv)
 #endif
 #if HAVE_OPENCL || HAVE_CUDA
 	gpu_device_list[0] = gpu_device_list[1] = -1;
+
+#if defined(HAVE_OPENCL)
+	/* Build a list of all OpenCL devices. */
+	start_opencl_environment();
+#endif
 #endif
 	/* Process configuration options that depend on cfg_init() */
 	john_load_conf();

--- a/src/options.c
+++ b/src/options.c
@@ -350,8 +350,11 @@ static void print_usage(char *name)
 		exit(0);
 
 	printf(JOHN_USAGE, name);
-#if defined(HAVE_OPENCL) || defined(HAVE_CUDA)
+#if defined(HAVE_CUDA)
 	printf("%s", JOHN_USAGE_GPU);
+#elif defined(HAVE_OPENCL)
+	if (!none_opencl_device)
+		printf("%s", JOHN_USAGE_GPU);
 #endif
 	printf("%s", JOHN_USAGE_FORMAT);
 	exit(0);
@@ -370,7 +373,8 @@ void opt_print_hidden_usage(void)
 	printf(", cuda");
 #endif
 #ifdef HAVE_OPENCL
-	printf(", opencl");
+	if (!none_opencl_device)
+		printf(", opencl");
 #endif
 #endif
 #ifdef _OPENMP
@@ -409,8 +413,10 @@ void opt_print_hidden_usage(void)
 	puts("--internal-codepage=NAME  codepage used in rules/masks (see doc/ENCODING)");
 	puts("--target-encoding=NAME    output encoding (used by format, see doc/ENCODING)");
 #ifdef HAVE_OPENCL
-	puts("--force-scalar            (OpenCL) force scalar mode");
-	puts("--force-vector-width=N    (OpenCL) force vector width N");
+	if (!none_opencl_device) {
+		puts("--force-scalar            (OpenCL) force scalar mode");
+		puts("--force-vector-width=N    (OpenCL) force vector width N");
+	}
 #endif
 #if HAVE_LIBGMP || HAVE_INT128 || HAVE___INT128 || HAVE___INT128_T
 	puts("\nPRINCE mode options:");


### PR DESCRIPTION
* It allows a user to run an OpenCL build of JtR without any driver installed or GPU connected (still requires the OpenCL ICD Loader).
* It handles the removal of all GPUs without requiring a JtR rebuild.

@magnumripper, your opinion about merge-ability of the patch:
* In the past we were, actually, opening the requested --device on john_init(). So, a 100% CPU format will be using resources on GPU.
* Now, we are only querying what is available (as we could do about memory, files, ...).
* Even the -format=CLASS can be solved. 