### PR TITLE
Faster way to crack MONGODB-CR hashes

### DIFF
--- a/run/dynamic.conf
+++ b/run/dynamic.conf
@@ -1009,6 +1009,23 @@ Func=DynamicFunc__SHA1_crypt_input1_to_output1_FINAL
 Test=$dynamic_1507$d4eaf666d09316f9d61b14753353a73d5fbcf048:test
 Test=$dynamic_1507$9dbe0d0ea16ae0a14c0c81a7c962b5a16e777259:test1
 
+# MONGODB-CR system hashes
+# Input hash format => username:$dynamic_1550$hash
+[List.Generic:dynamic_1550]
+Expression=md5($u.:mongo:.$p) (MONGODB-CR system hash)
+Flag=MGF_USERNAME
+CONST1=:mongo:
+MaxInputLen=23
+MaxInputLenX86=110
+SaltLen=-27
+Func=DynamicFunc__clean_input
+Func=DynamicFunc__append_userid
+Func=DynamicFunc__append_input1_from_CONST1
+Func=DynamicFunc__append_keys
+Func=DynamicFunc__crypt
+Test=$dynamic_1550$08f32db65f837a52cd791bd923a61e95$$Usomeadmin:secret
+Test=$dynamic_1550$819951ad797c3564148a77cbecf3b166$$Uadmin:secret@12345
+
 # ColdFusion 11 hashes (Ivan Novikov <in@wallarm.com>)
 # Hash is password variable from ./lib/password.properties
 # Salt is admin.userid.root.salt variable from ./lib/neo-security.xml


### PR DESCRIPTION
```
$ ../run/john --format=dynamic_1550 --test
Benchmarking: dynamic_1550 [md5($u.:mongo:.$p) (... AVX2 8x3]... DONE
Many salts:	30992K c/s real, 30992K c/s virtual
Only one salt:	22616K c/s real, 22616K c/s virtual
```

```
$ ../run/john --format=mongodb --test
Will run 4 OpenMP threads
Benchmarking: MongoDB, system / network [MD5 32/64]... (4xOMP) DONE
Speed for cost 1 (salt type) of 0 and 1
Raw:	10381K c/s real, 2674K c/s virtual
```