### PR TITLE
Fix a misleading indentation compiler warning

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -705,12 +705,12 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 				}
 				if (!two_values)
 					sscanf(range[i], "%u", &options.loader.min_cost[i]);
-					if (negative && options.loader.min_cost[i] == 0) {
-						if (john_main_process)
-							fprintf(stderr, "Usage of negative --cost is not valid"
-							                " for value 0\n");
-						error();
-					}
+				if (negative && options.loader.min_cost[i] == 0) {
+					if (john_main_process)
+						fprintf(stderr, "Usage of negative --cost is not valid"
+								" for value 0\n");
+					error();
+				}
 				if (!two_values) {
 					if (negative) {
 						options.loader.max_cost[i] = options.loader.min_cost[i] - 1;


### PR DESCRIPTION
@magnumripper the following seems to be a valid warning, simply de-indenting the "if block" should get rid of this warning. 

```
$ gcc --version
gcc (GCC) 6.1.1 20160621 (Red Hat 6.1.1-3)
Copyright (C) 2016 Free Software Foundation, Inc.
```

```
$ make
...
gcc ...options.c -o options.o
options.c: In function ‘opt_init’:
options.c:706:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (!two_values)
     ^~
options.c:708:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
      if (negative && options.loader.min_cost[i] == 0) {
      ^~
```

I don't actually know what this code does, so a careful review is needed.