### PR TITLE
Add support for sha512 in pfx-ng format

### DIFF
--- a/run/pfxng2john.py
+++ b/run/pfxng2john.py
@@ -67,6 +67,8 @@ def parse_pkcs12(filename):
             mac_algo_numeric = 1
         elif mac_algo == "sha256":
             mac_algo_numeric = 256
+        elif mac_algo == "sha512":
+            mac_algo_numeric = 512
         else:
             sys.stderr.write("mac_algo %s is not supported yet!\n" % mac_algo)
             return

--- a/src/pkcs12_plug.c
+++ b/src/pkcs12_plug.c
@@ -43,29 +43,36 @@ extern int mbedtls_pkcs12_derivation_sha256( unsigned char *data, size_t datalen
 		unsigned char *pwd, size_t pwdlen, const unsigned char *salt,
 		size_t saltlen, int md_type, int id, int iterations );
 
+int mbedtls_pkcs12_derivation_sha512( unsigned char *data, size_t datalen, const
+		unsigned char *pwd, size_t pwdlen, const unsigned char *salt,
+		size_t saltlen, int md_type, int id, int iterations );
+
 int pkcs12_pbe_derive_key( int md_type, int iterations, int id, const unsigned
 		char *pwd,  size_t pwdlen, const unsigned char *salt, size_t
 		saltlen, unsigned char *key, size_t keylen)
 {
-    size_t i;
-    unsigned char unipwd[PKCS12_MAX_PWDLEN * 2 + 2], *cp=unipwd;
+	size_t i;
+	unsigned char unipwd[PKCS12_MAX_PWDLEN * 2 + 2], *cp=unipwd;
 
-    if( pwdlen > PKCS12_MAX_PWDLEN )
-        return -1;
+	if( pwdlen > PKCS12_MAX_PWDLEN )
+		return -1;
 
-    for( i = 0; i < pwdlen; i++ ) {
+	for( i = 0; i < pwdlen; i++ ) {
+		*cp++ = 0;
+		*cp++ = pwd[i];
+	}
 	*cp++ = 0;
-        *cp++ = pwd[i];
-    }
-    *cp++ = 0;
-    *cp = 0;
+	*cp = 0;
 
-    if (md_type == 0)
-	mbedtls_pkcs12_derivation(key, keylen, unipwd, pwdlen * 2 + 2, salt,
-			saltlen, md_type, id, iterations);
-    else if (md_type == 256)
-	mbedtls_pkcs12_derivation_sha256(key, keylen, unipwd, pwdlen * 2 + 2, salt,
-			saltlen, md_type, id, iterations);
+	if (md_type == 0)
+		mbedtls_pkcs12_derivation(key, keylen, unipwd, pwdlen * 2 + 2, salt,
+				saltlen, md_type, id, iterations);
+	else if (md_type == 256)
+		mbedtls_pkcs12_derivation_sha256(key, keylen, unipwd, pwdlen * 2 + 2, salt,
+				saltlen, md_type, id, iterations);
+	else if (md_type == 512)
+		mbedtls_pkcs12_derivation_sha512(key, keylen, unipwd, pwdlen * 2 + 2, salt,
+				saltlen, md_type, id, iterations);
 
     return 0;
 }
@@ -223,6 +230,95 @@ int mbedtls_pkcs12_derivation_sha256( unsigned char *data, size_t datalen, const
             SHA256_Init(&md_ctx);
             SHA256_Update(&md_ctx, hash_output, hlen);
             SHA256_Final(hash_output, &md_ctx);
+        }
+
+        use_len = ( datalen > hlen ) ? hlen : datalen;
+        memcpy( p, hash_output, use_len );
+        datalen -= use_len;
+        p += use_len;
+
+        if( datalen == 0 )
+            break;
+
+        // Concatenating copies of hash_output into hash_block (B)
+        pkcs12_fill_buffer( hash_block, v, hash_output, hlen );
+
+        // B += 1
+        for( i = v; i > 0; i-- )
+            if( ++hash_block[i - 1] != 0 )
+                break;
+
+        // salt_block += B
+        c = 0;
+        for( i = v; i > 0; i-- )
+        {
+            j = salt_block[i - 1] + hash_block[i - 1] + c;
+            c = (unsigned char) (j >> 8);
+            salt_block[i - 1] = j & 0xFF;
+        }
+
+        // pwd_block  += B
+        c = 0;
+        for( i = v; i > 0; i-- )
+        {
+            j = pwd_block[i - 1] + hash_block[i - 1] + c;
+            c = (unsigned char) (j >> 8);
+            pwd_block[i - 1] = j & 0xFF;
+        }
+    }
+
+    return 0;
+}
+
+int mbedtls_pkcs12_derivation_sha512( unsigned char *data, size_t datalen, const
+		unsigned char *pwd, size_t pwdlen, const unsigned char *salt,
+		size_t saltlen, int md_type, int id, int iterations )
+{
+    unsigned int j;
+
+    unsigned char diversifier[128];
+    unsigned char salt_block[128], pwd_block[128], hash_block[128];
+    unsigned char hash_output[1024];
+    unsigned char *p;
+    unsigned char c;
+
+    size_t hlen, use_len, v, i;
+
+    SHA512_CTX md_ctx;
+
+    // This version only allows max of 64 bytes of password or salt
+    if( datalen > 128 || pwdlen > 64 || saltlen > 64 )
+        return -1; // MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA
+
+    hlen = 64; // for SHA-512
+
+    if( hlen <= 32 )
+        v = 64;
+    else
+        v = 128;
+
+    memset( diversifier, (unsigned char) id, v );
+
+    pkcs12_fill_buffer( salt_block, v, salt, saltlen );
+    pkcs12_fill_buffer( pwd_block,  v, pwd,  pwdlen  );
+
+    p = data;
+    while( datalen > 0 )
+    {
+        // Calculate hash( diversifier || salt_block || pwd_block )
+        SHA512_Init( &md_ctx );
+
+        SHA512_Update( &md_ctx, diversifier, v );
+        SHA512_Update( &md_ctx, salt_block, v );
+        SHA512_Update( &md_ctx, pwd_block, v );
+        SHA512_Final( hash_output, &md_ctx );
+
+        // Perform remaining ( iterations - 1 ) recursive hash calculations
+        for( i = 1; i < (size_t) iterations; i++ )
+        {
+            SHA512_Init(&md_ctx);
+            SHA512_Update(&md_ctx, hash_output, hlen);
+            SHA512_Final(hash_output, &md_ctx);
         }
 
         use_len = ( datalen > hlen ) ? hlen : datalen;


### PR DESCRIPTION
This is a bit hacky but it works.

pkcs12_plug.c uses a weird combination of spaces and tabs for indentation. We need a separate commit to fix that. I should have been more careful while checking in the file.

I have replaced spaces with tabs in `pkcs12_pbe_derive_key` function.