### PR TITLE
fix-rarjohn

### DIFF
--- a/src/rar2john.c
+++ b/src/rar2john.c
@@ -829,7 +829,7 @@ static int process_file5(const char *archive_name) {
 	if (memcmp(Magic, "\x52\x61\x72\x21\x1a\x07\x01\x00", 8)) { /* handle SFX archives */
 		if (memcmp(Magic, "MZ", 2) == 0) {
 			/* jump to "Rar!" signature */
-			while (!feof(fp)) {
+			while (1) {
 				count = fread(buf, 1, CHUNK_SIZE, fp);
 				if( (pos = (char*)memmem(buf, count, "\x52\x61\x72\x21\x1a\x07\x01\x00", 8))) {
 					diff = count - (pos - buf);
@@ -838,6 +838,8 @@ static int process_file5(const char *archive_name) {
 					found = 1;
 					break;
 				}
+                if (feof(fp)) //We shold examine the EOF before seek back
+                    break;
 				jtr_fseek64(fp, -7, SEEK_CUR);
 			}
             if (!found)


### PR DESCRIPTION
    I think I found a bug in a special case of  infinite loop in the source file of src/rar2john.c.
    In the function rar_process_file(),here is the origin code:
/* jump to "Rar!" signature */
			while (!feof(fp)) {
    				count = fread(buf, 1, CHUNK_SIZE, fp);
    				if( (pos = memmem(buf, count, "\x52\x61\x72\x21\x1a\x07\x00", 7))) {
    					diff = count - (pos - buf);
    					jtr_fseek64(fp, - diff, SEEK_CUR);
    					jtr_fseek64(fp, 7, SEEK_CUR);
    					found = 1;
    					break;
				}
    				jtr_fseek64(fp, -6, SEEK_CUR);
			}
    We shoule examine the EOF before 				jtr_fseek64(fp, -6, SEEK_CUR); otherwise,it may cause infinite loop in some case.for example,it didn't find the  "Rar!" signature *...
    Because the code above examines the EOF everytime after  				jtr_fseek64(fp, -6, SEEK_CUR);,So it will nerver found the ture EOF.
    We should examine the EOF everytime before seek back:
/* jump to "Rar!" signature */
			while (1) {
    				count = fread(buf, 1, CHUNK_SIZE, fp);
    				if( (pos = memmem(buf, count, "\x52\x61\x72\x21\x1a\x07\x00", 7))) {
					    diff = count - (pos - buf);
					    jtr_fseek64(fp, - diff, SEEK_CUR);
    					jtr_fseek64(fp, 7, SEEK_CUR);
    					found = 1;
    					break;
				}
				    if (feof(fp))
        					break;
				    jtr_fseek64(fp, -6, SEEK_CUR);
			}