### PR TITLE
Adjust gpg-opencl auto-tune max duration.

### DIFF
--- a/src/opencl_gpg_fmt_plug.c
+++ b/src/opencl_gpg_fmt_plug.c
@@ -174,7 +174,7 @@ static void reset(struct db_main *db)
 		                       sizeof(gpg_password), 0, db);
 
 		// Auto tune execution from shared/included code.
-		autotune_run(self, 1, 0, 1000);
+		autotune_run(self, 1, 0, 300);
 	}
 }
 


### PR DESCRIPTION
- I saw no regressions on super (even on dev=0)