### PR TITLE
Fix sha512crypt-opencl failing self tests on NVIDIA OpenCL driver 361

### DIFF
--- a/src/opencl/cryptsha512_kernel_GPU.cl
+++ b/src/opencl/cryptsha512_kernel_GPU.cl
@@ -160,6 +160,8 @@ inline void sha512_block(sha512_ctx * ctx) {
     #pragma unroll 2
 #elif defined(NVIDIA_STUPID_BUG_1) && DEV_VER_MAJOR == 361 && DEV_VER_MINOR == 28
     #pragma unroll 16
+#else
+	#pragma unroll
 #endif
     for (uint i = 16U; i < 80U; i++) {
 	w[i & 15] = w[(i - 16) & 15] + w[(i - 7) & 15] + sigma1(w[(i - 2) & 15]) + sigma0(w[(i - 15) & 15]);
@@ -467,6 +469,7 @@ void kernel_preprocess(
 	uint32_t total = 0;
 	uint32_t j = generator_index[i];
 
+	#pragma unroll
 	for (uint32_t k = 0; k < 8; k++)
 	   work_memory[OFFSET(i, k)] = 0;
 

--- a/src/opencl_sha2_common.h
+++ b/src/opencl_sha2_common.h
@@ -78,13 +78,13 @@ __constant int generator_index[] = {
 #endif
 
 // Start documenting NVIDIA OpenCL bugs.
-#if gpu_nvidia(DEVICE_INFO)
-#define NVIDIA_STUPID_BUG_1    1
-#endif
+///#if gpu_nvidia(DEVICE_INFO)
+///#define NVIDIA_STUPID_BUG_1    1
+///#endif
 
 // Start documenting AMD OpenCL bugs.
-#if amd_vliw5(DEVICE_INFO) || amd_vliw4(DEVICE_INFO)
-//amd_vliw4() is a guess.
+///#if amd_vliw5(DEVICE_INFO) || amd_vliw4(DEVICE_INFO)
+///amd_vliw4() is a guess.
 
 ///Needed (at least) in 14.9 and 15.7
 ///TODO: can't remove the [unroll]. (At least) HD 6770.
@@ -92,7 +92,7 @@ __constant int generator_index[] = {
 ///  #pragma unroll 2
 ///#endif
 ///for (uint i = 16U; i < 80U; i++) {
-#define AMD_STUPID_BUG_1    1
+///#define AMD_STUPID_BUG_1    1
 
 ///TODO: can't use a valid command twice on sha256crypt. (At least) HD 6770.
 ///Fixed (back in 14.12). Kept for future reference.
@@ -101,7 +101,7 @@ __constant int generator_index[] = {
 ///  #ifdef AMD_STUPID_BUG_2
 ///    #define SWAP_V(n)    bitselect(rotate(n, 24U), rotate(n, 8U), 0x00FF00FFU)
 /// ----------------------
-//#define AMD_STUPID_BUG_2
+///#define AMD_STUPID_BUG_2
 
 ///TODO: can't use constant. (At least) HD 6770.
 ///Fixed. Kept for future reference.
@@ -109,7 +109,7 @@ __constant int generator_index[] = {
 ///inline void sha512_prepare(__constant   sha512_salt     * salt_data,
 /// ----------------------
 ///#define AMD_STUPID_BUG_3
-#endif
+///#endif
 
 //Functions.
 /* Macros for reading/writing chars from int32's (from rar_kernel.cl) */


### PR DESCRIPTION
Is this a reasonable solution for #2215 ?

It works on super (which uses CUDA 8). I bet no new problems introduced.
****

In this change:
1. if there is a known problem, we do something.
2. otherwise, let the compiler do its best.

