### PR TITLE
Added hex masks to rules. lower, upper and mixed case hex classes and…

### DIFF
--- a/doc/RULES
+++ b/doc/RULES
@@ -81,6 +81,9 @@ than that of "l" (length).
 ?d	matches digits [0-9]
 ?a	matches letters [a-zA-Z]
 ?x	matches letters and digits [a-zA-Z0-9]
+?h	matches hex lower case [0-9a-f]
+?i	matches hex upper case [0-9A-F]
+?j	matches hex cased [0-9a-fA-F]
 ?o	matches control characters
 ?y	matches valid characters
 ?z	matches all characters

--- a/src/rules.c
+++ b/src/rules.c
@@ -358,6 +358,10 @@ static void rules_init_classes(void)
 	rules_init_class('?', "?");
 	rules_init_class('b', (char *)&eightbitchars);
 	rules_init_class('Z', "");
+	// new hex classes added in jumbo 11/11/2016
+	rules_init_class('h', "0123456789abcdef");
+	rules_init_class('i', "0123456789ABCDEF");
+	rules_init_class('j', "0123456789abcdefABCDEF");
 
 	// Load user-defined character classes ?0 .. ?9 from john.conf
 	for(i='0'; i <= '9'; i++) {


### PR DESCRIPTION


This is a pretty trival code change. EASY to test validity.

Here is a simple john-local.conf file to easily test and see that the new classes and anti-classes are working perfectly, and that no additional code is needed.

This branch is merge ready:

$ cat john-local.conf
[List.Rules:test]
/?h \Az"?h"
/?H \Az"?H"
/?i \Az"?i"
/?I \Az"?I"
/?j \Az"?j"
/?J \Az"?J"
