### PR TITLE
CI: improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,18 @@ matrix:
   - compiler: clang
     env: ASAN="" OPENCL="yes"
 
-  - env: ASAN="--enable-asan" FRESH="yes"
+  - env: ASAN="--enable-asan" TEST="fresh test"
+
+  - env: ASAN="" TEST="TS --restore"
 
   allow_failures:
-  - env: ASAN="--enable-asan" FRESH="yes"
+  - env: ASAN="--enable-asan" TEST="fresh test"
+
+  - env: ASAN="" TEST="TS --restore"
 
   fast_finish: true
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev
-  - sudo apt-get install fglrx-dev opencl-headers || true
   - export OMP_NUM_THREADS=4
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 language: c
 dist: trusty
-branches:
-  except:
-    gh-pages
-compiler:
-  - gcc
-  - clang
-env:
-  # Default build. Release.
-  # Debug build
+services: docker
 
 env:
   global:
@@ -17,19 +9,28 @@ env:
    - secure: "FJ1/E5vVttd4+cFLQVdFt4rHNX28aGIvAWXduy6ZqQgZbfa0omsHcZXAq0t1qFz14ryTxEtxqY/aXw6OSG+t6a8OyrOi9jEdTIUpEDCyPvdZ299injPt1SiJRxzoDNo1CquwUE20y2pFOnTpVp6bIkH49o0oAxBijtb5fDj54KY="
 
 matrix:
+  include:
+  - compiler: gcc
+    env: ASAN="--enable-asan" OPENCL="yes"
+
+  - compiler: clang
+    env: ASAN="" OPENCL="yes"
+
+  - env: ASAN="--enable-asan" FRESH="yes"
+
   allow_failures:
+  - env: ASAN="--enable-asan" FRESH="yes"
+
+  fast_finish: true
 
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev
   - sudo apt-get install fglrx-dev opencl-headers || true
   - export OMP_NUM_THREADS=4
+
 script:
-  - cd src 
-  - if [[ "$CC" == "gcc" ]]; then ./configure --enable-asan; fi
-  - if [[ "$CC" == "clang" ]]; then ./configure; fi
-  - make -sj4 
-  - ../.travis/test.sh
+  - .travis/check.sh
 
 addons:
   coverity_scan:

--- a/.travis/check.sh
+++ b/.travis/check.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-if [[ "$FRESH" != "yes" ]]; then
+if [[ -z "$TEST" ]]; then
     cd src
+
+    # Prepare environment
+    sudo apt-get update -qq
+    sudo apt-get install libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev
+    sudo apt-get install fglrx-dev opencl-headers || true
 
     # Configure and build
     ./configure $ASAN
@@ -9,24 +14,53 @@ if [[ "$FRESH" != "yes" ]]; then
 
     ../.travis/test.sh
 
-else
-   docker run -v $HOME:/root -v $(pwd):/cwd ubuntu:latest sh -c ' \
+elif [[ "$TEST" == "fresh test" ]]; then
+    # ASAN using a 'recent' compiler
+    docker run -v $HOME:/root -v $(pwd):/cwd ubuntu:latest sh -c " \
       cd /cwd/src; \
       apt-get update -qq; \
       apt-get install -y build-essential libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev libbz2-dev; \
       ./configure --enable-asan; \
       make -sj4; \
-      ASAN="fresh" ../.travis/test.sh
-  '
+      export OPENCL="""$OPENCL"""; \
+      PROBLEM='slow' ../.travis/test.sh
+   "
 
-#   docker run -v $HOME:/root -v $(pwd):/cwd centos:latest sh -c ' \
-#      cd /cwd/src; \
-#      yum update -y; \
-#      yum groupinstall -y 'Development Tools'; \
-#      yum install -y openssl-devel gmp-devel libpcap-devel pkgconfig libnet-devel bzip2-devel; \
-#      ./configure --enable-asan; \
-#      make -sj4; \
-#      ../.travis/test.sh
-#  '
+elif [[ "$TEST" == "TS --restore" ]]; then
+    # Test Suite run
+    cd src
+
+    # Prepare environment
+    sudo apt-get update -qq
+    sudo apt-get install libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev
+
+    # Configure and build
+    ./configure
+    make -sj4
+
+    cd ..
+    git clone --depth 1 https://github.com/magnumripper/jtrTestSuite.git tests
+    cd tests
+    #export PERL_MM_USE_DEFAULT=1
+    (echo y;echo o conf prerequisites_policy follow;echo o conf commit)|cpan
+    cpan install Digest::MD5
+    ./jtrts.pl --restore
+
+elif [[ "$TEST" == "TS docker" ]]; then
+    # Test Suite run
+    docker run -v $HOME:/root -v $(pwd):/cwd ubuntu:xenial sh -c ' \
+      cd /cwd/src; \
+      apt-get update -qq; \
+      apt-get install -y build-essential libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev libbz2-dev git; \
+      ./configure; \
+      make -sj4; \
+      cd ..; \
+      git clone --depth 1 https://github.com/magnumripper/jtrTestSuite.git tests; \
+      cd tests; \
+      cpan install Digest::MD5; \
+      ./jtrts.pl --restore
+    '
+else
+    echo  "Nothing to do!!"
 fi
 

--- a/.travis/check.sh
+++ b/.travis/check.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [[ "$FRESH" != "yes" ]]; then
+    cd src
+
+    # Configure and build
+    ./configure $ASAN
+    make -sj4
+
+    ../.travis/test.sh
+
+else
+   docker run -v $HOME:/root -v $(pwd):/cwd ubuntu:latest sh -c ' \
+      cd /cwd/src; \
+      apt-get update -qq; \
+      apt-get install -y build-essential libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev libbz2-dev; \
+      ./configure --enable-asan; \
+      make -sj4; \
+      ASAN="fresh" ../.travis/test.sh
+  '
+
+#   docker run -v $HOME:/root -v $(pwd):/cwd centos:latest sh -c ' \
+#      cd /cwd/src; \
+#      yum update -y; \
+#      yum groupinstall -y 'Development Tools'; \
+#      yum install -y openssl-devel gmp-devel libpcap-devel pkgconfig libnet-devel bzip2-devel; \
+#      ./configure --enable-asan; \
+#      make -sj4; \
+#      ../.travis/test.sh
+#  '
+fi
+

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -7,5 +7,13 @@ echo 'XSHA512-free-opencl = Y' >> john-local.conf
 echo 'gpg-opencl = Y' >> john-local.conf
 
 # Proper testing. Trusty AMD GPU drivers on Travis are fragile
-../run/john -test-full=0 --format=cpu
-../run/john -test-full=0 --format=opencl
+if test "$ASAN" = "fresh" ; then
+    ../run/john -test=0 --format=cpu
+else
+    ../run/john -test-full=0 --format=cpu
+fi
+
+if test -z "$ASAN" -o "$OPENCL" = "yes" ; then
+    ../run/john -test-full=0 --format=opencl
+fi
+

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -7,13 +7,13 @@ echo 'XSHA512-free-opencl = Y' >> john-local.conf
 echo 'gpg-opencl = Y' >> john-local.conf
 
 # Proper testing. Trusty AMD GPU drivers on Travis are fragile
-if test "$ASAN" = "fresh" ; then
+if test "$PROBLEM" = "slow" ; then
     ../run/john -test=0 --format=cpu
 else
     ../run/john -test-full=0 --format=cpu
 fi
 
-if test -z "$ASAN" -o "$OPENCL" = "yes" ; then
+if test "$OPENCL" = "yes" ; then
     ../run/john -test-full=0 --format=opencl
 fi
 


### PR DESCRIPTION
Instead of https://github.com/magnumripper/JohnTheRipper/pull/2302 and https://github.com/magnumripper/JohnTheRipper/pull/2304, I was tempted to use this approach:

In the PR you can see (just an example from a remote past):
- gcc (ASAN) and clang (without ASAN) evaluating the build
- gcc (ASAN) on a recent compiler (in case of problems, it won't fail the CI build)
- TS on gcc on 16.04 LTS (in case of problems, it won't fail the CI build)

Thinking about  5fc8e78,  if JtR is failing because of ASAN, the new "infra" allow to 'fix' the build, e.g.:
- evaluate the build using gcc and clang on a stable OS **without** ASAN 
- test gcc (or clang) with ASAN only on a recent compiler - without a build fail.
- TS and whatever  - without a build fail.
