### PR TITLE
fix build against libressl

### DIFF
--- a/src/hmac_sha_plug.c
+++ b/src/hmac_sha_plug.c
@@ -42,7 +42,7 @@ void JTR_hmac_sha1(const unsigned char *key, int key_len, const unsigned char *d
 
 	if (key_len > 64) {
 		uint32_t *p = (uint32_t*)buf;
-		SHA_Init(&ctx);
+		SHA1_Init(&ctx);
 		SHA1_Update(&ctx, key, key_len);
 		SHA1_Final(buf, &ctx);
 		p[0] ^= 0x36363636; p[1] ^= 0x36363636; p[2] ^= 0x36363636; p[3] ^= 0x36363636; p[4] ^= 0x36363636;
@@ -53,14 +53,14 @@ void JTR_hmac_sha1(const unsigned char *key, int key_len, const unsigned char *d
 		for (i = 0; i < HMAC_SHA32_COUNT; ++i)
 			pW[i] ^= HMAC_SHA_IPAD_XOR;
 	}
-	SHA_Init(&ctx);
+	SHA1_Init(&ctx);
 	SHA1_Update(&ctx, buf, 64);
 	if (data_len)
 		SHA1_Update(&ctx, data, data_len);
 	SHA1_Final(local_digest, &ctx);
 	for (i = 0; i < HMAC_SHA32_COUNT; ++i)
 		pW[i] ^= HMAC_SHA_OPAD_XOR;
-	SHA_Init(&ctx);
+	SHA1_Init(&ctx);
 	SHA1_Update(&ctx, buf, 64);
 	SHA1_Update(&ctx, local_digest, 20);
 	if (digest_len >= 20)


### PR DESCRIPTION
libressl deprecated the SHA_* functions and kept only the SHA1_* ones.
since they do the same (the existing code even mixed  calls to them up!)
let's just use the SHA1 ones everywhere so we're compatible with openssl
and libressl.