### PR TITLE
CUDA: more cosmetic cleanups

### DIFF
--- a/src/listconf.c
+++ b/src/listconf.c
@@ -84,7 +84,7 @@ static void listconf_list_options()
 	puts("help[:WHAT], subformats, inc-modes, rules, externals, ext-modes, ext-hybrids,");
 	puts("ext-filters, ext-filters-only, build-info, hidden-options, encodings,");
 	puts("formats, format-details, format-all-details, format-methods[:WHICH],");
-	// With "opencl-devices, cuda-devices, <conf section name>" added,
+	// With "opencl-devices, <conf section name>" added,
 	// the resulting line will get too long
 	puts("format-tests, sections, parameters:SECTION, list-data:SECTION,");
 #if HAVE_OPENCL

--- a/src/mscash_common_plug.c
+++ b/src/mscash_common_plug.c
@@ -8,7 +8,7 @@
  * There's ABSOLUTELY NO WARRANTY, express or implied.
  *
  *  Functions and data which is common among the mscash and mscash2 crackers
- *  (CPU, OpenCL, Cuda)
+ *  (CPU, OpenCL)
  */
 
 #include <stdio.h>


### PR DESCRIPTION
Missed changes

And this line in common.h (nvcc) (?)
```
#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || defined(__INTEL_COMPILER) || __NVCC__
```