### PR TITLE
OpenCL: make errors non-fatal for a "--test" run

### DIFF
--- a/src/common-opencl.h
+++ b/src/common-opencl.h
@@ -122,6 +122,7 @@ typedef struct {
 extern int platform_id;
 extern int default_gpu_selected;
 extern int ocl_autotune_running;
+extern int volatile bench_running;
 extern size_t ocl_max_lws;
 
 extern cl_device_id devices[MAX_GPU_DEVICES];
@@ -236,7 +237,7 @@ void opencl_process_event(void);
 			        get_error_name(__err), __FILE__, __LINE__, message); \
 			else if (options.verbosity > VERB_LEGACY) \
 				fprintf(stderr, " %s\n", get_error_name(__err)); \
-			if (!ocl_autotune_running) \
+			if (!(ocl_autotune_running || bench_running)) \
 				error(); \
 			else \
 				return -1; \


### PR DESCRIPTION
All CI tests passed.

- undesired consequences are a possibility.
