### PR TITLE
fix: add a missing include in common.h

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -18,6 +18,7 @@
 #if !defined(_OPENCL_COMPILER)
 #include "arch.h"
 #include "memory.h"
+#include "stdint.h"
 #endif
 
 #ifndef MAX


### PR DESCRIPTION
It is not clear to me how the include "tree" should work inside JtR. Despite that:
- if this patch fixes the remaining problems on CI, I will merge it;
- it is safe;

Short list of concerns now:
- [x] Clang
- [x] CircleCI