### PR TITLE
leet: avoid crash while processing dynamic_82 type hashes

### DIFF
--- a/src/leet_cc_fmt_plug.c
+++ b/src/leet_cc_fmt_plug.c
@@ -145,6 +145,9 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	if (q - p > 256)
 		return 0;
 
+	if (q - p == 0)
+		return 0;
+
 	q = strrchr(ciphertext, '$') + 1;
 	if (strlen(q) != BINARY_SIZE * 2)
 		goto err;


### PR DESCRIPTION
dynamic_82 hashes with 64-byte salts trigger a crash in leet format due
to promiscuous valid function.

[crasher.txt](https://github.com/magnumripper/JohnTheRipper/files/684861/crasher.txt) (example hash which triggers a crash).
