### PR TITLE
Add dump-apex-hashes.sql script to README.apex

### DIFF
--- a/doc/README.apex
+++ b/doc/README.apex
@@ -45,7 +45,22 @@ ADMIN
 F96D32CBB2FBE17732C3BBAB91C14F3A
 10
 
-NOTE: dump-apex-hashes.sql script is in src/unused directory
+...
+
+$ cat dump-apex-hashes.sql
+set colsep ','
+set echo off
+set feedback off
+set linesize 1000
+set pagesize 0
+set sqlprompt ''
+set trimspool on
+set headsep off
+set termout off
+alter session set current_schema = APEX_040200;
+spool "apex-hashes.txt"
+select user_name,web_password2,security_group_id from wwv_flow_fnd_user;
+spool off
 
 """
 


### PR DESCRIPTION
The dump-apex-hashes.sql script was recently removed from the "unused" directory. This commit adds the removed script into the documentation file itself.