### PR TITLE
minGW: fix for a memdbg bug introduced in b701bc0

### DIFF
--- a/src/memory.h
+++ b/src/memory.h
@@ -172,6 +172,14 @@ char *strdup_MSVC(const char *str);
 		(ptr) = NULL; \
 	} \
 }
+#else
+#define MEM_FREE(ptr) \
+{ \
+	if ((ptr)) { \
+		MEMDBG_free(((const void*)ptr),__FILE__,__LINE__); \
+		(ptr) = NULL; \
+	} \
+}
 #endif
 
 #else


### PR DESCRIPTION
I missed the else part.

****

The news are: we can now build, do some real cracking, and succeed a `--test-full` run on Windows using HEAD **without** tricks.

```
john -test-full=0
[...]
All 359 formats passed self-tests!
```

```
john --list=build-info
Version: 1.8.0-jumbo-1-5476-g6a58e5d
Build: mingw64 64-bit SSE2-ac
SIMD: SSE2, interleaving: MD4:3 MD5:3 SHA1:1 SHA256:1 SHA512:1
$JOHN is 
Format interface version: 14
Max. number of reported tunable costs: 3
Rec file version: REC4
Charset file version: CHR3
CHARSET_MIN: 1 (0x01)
CHARSET_MAX: 255 (0xff)
CHARSET_LENGTH: 24
SALT_HASH_SIZE: 1048576
Max. Markov mode level: 400
Max. Markov mode password length: 30
gcc version: 5.3.0
Crypto library: OpenSSL
OpenSSL library version: 01000207f
OpenSSL 1.0.2g  1 Mar 2016
GMP library version: 6.1.0
File locking: NOT supported by this build - do not run concurrent sessions!
fseek(): fseeko64
ftell(): ftello64
fopen(): fopen64
memmem(): JtR internal
```

```
john --list=build-info
Version: 1.8.0-jumbo-1-5476-g6a58e5d
Build: mingw32 32-bit SSE2-ac
SIMD: SSE2, interleaving: MD4:3 MD5:3 SHA1:2 SHA256:1 SHA512:1
$JOHN is 
Format interface version: 14
Max. number of reported tunable costs: 3
Rec file version: REC4
Charset file version: CHR3
CHARSET_MIN: 1 (0x01)
CHARSET_MAX: 255 (0xff)
CHARSET_LENGTH: 24
SALT_HASH_SIZE: 1048576
Max. Markov mode level: 400
Max. Markov mode password length: 30
gcc version: 5.3.0
Crypto library: OpenSSL
OpenSSL library version: 01000207f
OpenSSL 1.0.2g  1 Mar 2016
GMP library version: 6.1.0
File locking: NOT supported by this build - do not run concurrent sessions!
fseek(): fseeko64
ftell(): ftello64
fopen(): fopen64
memmem(): JtR internal
```