### PR TITLE
Fix the rename-to-exe logic for the MinGW build

### DIFF
--- a/src/CircleCI-MinGW.sh
+++ b/src/CircleCI-MinGW.sh
@@ -36,11 +36,12 @@ mingw64 make -sj4
 if [ "x$?" != "x0" ] ; then exit 1 ; fi
 mv ../run/john ../run/john.exe
 
-# the mingw build does not name many exe files correctly.  Fix that.  Also strip all exe files for distro.
 cd ../run
-for f in `ls -l | grep wxr | grep -v [\.][epr] | cut -c 46-` ; do mv $f $f.exe ; done
-for f in benchmark-unify mailer makechr relbench ; do mv $f.exe $f ; done
+# the mingw build does not name many exe files correctly, fix that.
+for f in genmkvpwd mkvcalcproba calc_stat tgtsnarf raw2dyna uaf2john wpapcap2john cprepair ; do mv $f $f.exe ; done
 for f in *.exe ; do x86_64-w64-mingw32-strip $f ; done
+# remove opencl kernels and ztex stuff for mingw builds
+rm -rf kernels ztex
 cd ../src
 
 basepath="/usr/x86_64-w64-mingw32/sys-root/mingw/bin"
@@ -59,7 +60,7 @@ find ../run
 
 v=`git rev-parse --short HEAD`
 cd ..
-mkdir /base/builds
+mkdir -p /base/builds
 zip -r /base/builds/JtR-MinGW-${v}.zip run/ doc/ README.md README README-jumbo
 
 # crazy testing!
@@ -71,7 +72,7 @@ echo "[Disabled:Formats]" > john-local.conf
 # if [ "x$?" != "x0" ] ; then exit 1 ; fi
 
 # now build a non-SIMD 64 bit exe and test it
-dnf install -y openssl openssl-devel zlib-devel gmp-devel libpcap-devel
+# dnf install -y openssl openssl-devel zlib-devel gmp-devel libpcap-devel
 echo ""
 echo ""
 echo ""
@@ -92,7 +93,7 @@ echo "[Disabled:Formats]" > john-local.conf
 if [ "x$?" != "x0" ] ; then exit 1 ; fi
 
 # now build a non-SIMD 32 bit exe and test it
-dnf install -y glibc-headers.i686 glibc.i686 glibc-devel.i686 libgcc.i686 openssl-devel.i686 gmp-devel.i686 libpcap-devel.i686
+# dnf install -y glibc-headers.i686 glibc.i686 glibc-devel.i686 libgcc.i686 openssl-devel.i686 gmp-devel.i686 libpcap-devel.i686
 echo ""
 echo ""
 echo ""

--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -1905,7 +1905,7 @@ john.com: john.asm
 	$(LD) SIPdump.o memdbg.o $(LDFLAGS) -lpcap $(OMPFLAGS) -o ../run/SIPdump
 
 ../run/vncpcap2john: vncpcap2john.o
-	$(CC) -Wall vncpcap2john.o memdbg.o -lpcap $(OMPFLAGS) -o ../run/vncpcap2john
+	$(CC) $(JOHN_CFLAGS) -Wall vncpcap2john.o memdbg.o -lpcap $(OMPFLAGS) -o ../run/vncpcap2john
 
 ../run/uaf2john: uaf2john.o uaf_encode.o
 	$(LD) $(LDFLAGS) uaf2john.o uaf_encode.o memdbg.o $(OMPFLAGS) -o ../run/uaf2john


### PR DESCRIPTION
This renaming is breaking quite a few things.

This PR tries to fix https://github.com/magnumripper/JohnTheRipper/issues/2397 to some extent.