### PR TITLE
Be more resilient on --list=opencl-devices

### DIFF
--- a/src/listconf.c
+++ b/src/listconf.c
@@ -398,7 +398,6 @@ void listconf_parse_late(void)
 #if HAVE_OPENCL
 	if (!strcasecmp(options.listconf, "opencl-devices"))
 	{
-		opencl_preinit();
 		opencl_list_devices();
 		exit(EXIT_SUCCESS);
 	}


### PR DESCRIPTION
On a broken OpenCL system, JtR needs to be able to output as much information as possible.
https://github.com/magnumripper/JohnTheRipper/issues/2422



