### PR TITLE
Make sure wpapcap2john initialises allocated memory with zeros.

### DIFF
--- a/src/wpapcap2john.c
+++ b/src/wpapcap2john.c
@@ -458,6 +458,21 @@ static void alloc_error()
 	exit(EXIT_FAILURE);
 }
 
+// Dynamically allocate more memory for input data.
+// Make sure newly allocated memory is initialized with zeros.
+static void allocate_more_mem(void)
+{
+	size_t old_max = max_essids;
+
+	max_essids *= 2;
+	wpa = realloc(wpa, sizeof(WPA4way_t) * max_essids);
+	unVerified = realloc(unVerified, sizeof(char*) * max_essids);
+	if (!wpa || !unVerified)
+		alloc_error();
+	memset(wpa + old_max, 0, sizeof(WPA4way_t) * old_max);
+	memset(unVerified + old_max, 0, sizeof(char*) * old_max);
+}
+
 static void ManualBeacon(char *essid_bssid)
 {
 	char *essid = essid_bssid;
@@ -475,15 +490,8 @@ static void ManualBeacon(char *essid_bssid)
 	        bssid, essid);
 	strcpy(wpa[nwpa].essid, essid);
 	strcpy(wpa[nwpa].bssid, bssid);
-	if (++nwpa >= max_essids) {
-		max_essids *= 2;
-		wpa = realloc(wpa, sizeof(WPA4way_t) * max_essids);
-		unVerified = realloc(unVerified, sizeof(char*) * max_essids);
-		if (!wpa || !unVerified)
-			alloc_error();
-		memset(wpa + max_essids / 2, 0, sizeof(WPA4way_t) * max_essids / 2);
-		memset(unVerified + max_essids / 2, 0, sizeof(char*) * max_essids / 2);
-	}
+	if (++nwpa >= max_essids)
+		allocate_more_mem();
 }
 
 static void HandleBeacon(uint16 subtype)
@@ -521,15 +529,8 @@ static void HandleBeacon(uint16 subtype)
 	fprintf(stderr, "Learned BSSID %s ESSID '%s' from %s\n",
 	        bssid, essid, subtype == 5 ? "probe response" : "beacon");
 
-	if (++nwpa >= max_essids) {
-		max_essids *= 2;
-		wpa = realloc(wpa, sizeof(WPA4way_t) * max_essids);
-		unVerified = realloc(unVerified, sizeof(char*) * max_essids);
-		if (!wpa || !unVerified)
-			alloc_error();
-		memset(wpa + max_essids / 2, 0, sizeof(WPA4way_t) * max_essids / 2);
-		memset(unVerified + max_essids / 2, 0, sizeof(char*) * max_essids / 2);
-	}
+	if (++nwpa >= max_essids)
+		allocate_more_mem();
 }
 
 static void Handle4Way(int bIsQOS)

--- a/src/wpapcap2john.c
+++ b/src/wpapcap2john.c
@@ -481,8 +481,8 @@ static void ManualBeacon(char *essid_bssid)
 		unVerified = realloc(unVerified, sizeof(char*) * max_essids);
 		if (!wpa || !unVerified)
 			alloc_error();
-		memset(wpa + sizeof(WPA4way_t) * max_essids / 2, 0, sizeof(WPA4way_t) * max_essids / 2);
-		memset(unVerified + sizeof(char*) * max_essids / 2, 0, sizeof(char*) * max_essids / 2);
+		memset(wpa + max_essids / 2, 0, sizeof(WPA4way_t) * max_essids / 2);
+		memset(unVerified + max_essids / 2, 0, sizeof(char*) * max_essids / 2);
 	}
 }
 
@@ -527,8 +527,8 @@ static void HandleBeacon(uint16 subtype)
 		unVerified = realloc(unVerified, sizeof(char*) * max_essids);
 		if (!wpa || !unVerified)
 			alloc_error();
-		memset(wpa + sizeof(WPA4way_t) * max_essids / 2, 0, sizeof(WPA4way_t) * max_essids / 2);
-		memset(unVerified + sizeof(char*) * max_essids / 2, 0, sizeof(char*) * max_essids / 2);
+		memset(wpa + max_essids / 2, 0, sizeof(WPA4way_t) * max_essids / 2);
+		memset(unVerified + max_essids / 2, 0, sizeof(char*) * max_essids / 2);
 	}
 }
 

--- a/src/wpapcap2john.c
+++ b/src/wpapcap2john.c
@@ -460,7 +460,7 @@ static void alloc_error()
 
 // Dynamically allocate more memory for input data.
 // Make sure newly allocated memory is initialized with zeros.
-static void allocate_more_mem(void)
+static void allocate_more_memory(void)
 {
 	size_t old_max = max_essids;
 
@@ -491,7 +491,7 @@ static void ManualBeacon(char *essid_bssid)
 	strcpy(wpa[nwpa].essid, essid);
 	strcpy(wpa[nwpa].bssid, bssid);
 	if (++nwpa >= max_essids)
-		allocate_more_mem();
+		allocate_more_memory();
 }
 
 static void HandleBeacon(uint16 subtype)
@@ -530,7 +530,7 @@ static void HandleBeacon(uint16 subtype)
 	        bssid, essid, subtype == 5 ? "probe response" : "beacon");
 
 	if (++nwpa >= max_essids)
-		allocate_more_mem();
+		allocate_more_memory();
 }
 
 static void Handle4Way(int bIsQOS)

--- a/src/wpapcap2john.c
+++ b/src/wpapcap2john.c
@@ -481,6 +481,8 @@ static void ManualBeacon(char *essid_bssid)
 		unVerified = realloc(unVerified, sizeof(char*) * max_essids);
 		if (!wpa || !unVerified)
 			alloc_error();
+		memset(wpa + sizeof(WPA4way_t) * max_essids / 2, 0, max_essids / 2);
+		memset(unVerified + sizeof(char*) * max_essids / 2, 0, max_essids / 2);
 	}
 }
 
@@ -525,6 +527,8 @@ static void HandleBeacon(uint16 subtype)
 		unVerified = realloc(unVerified, sizeof(char*) * max_essids);
 		if (!wpa || !unVerified)
 			alloc_error();
+		memset(wpa + sizeof(WPA4way_t) * max_essids / 2, 0, max_essids / 2);
+		memset(unVerified + sizeof(char*) * max_essids / 2, 0, max_essids / 2);
 	}
 }
 
@@ -822,8 +826,8 @@ int main(int argc, char **argv)
 	int i;
 	char *base;
 
-	wpa = malloc(sizeof(WPA4way_t) * max_essids);
-	unVerified = malloc(sizeof(char*) * max_essids);
+	wpa = calloc(max_essids, sizeof(WPA4way_t));
+	unVerified = calloc(max_essids, sizeof(char*));
 
 	if (sizeof(struct ivs2_filehdr) != 2  || sizeof(struct ivs2_pkthdr) != 4 ||
 	    sizeof(struct ivs2_WPA_hdsk) != 356 || sizeof(hccap_t) != 356+36) {

--- a/src/wpapcap2john.c
+++ b/src/wpapcap2john.c
@@ -481,8 +481,8 @@ static void ManualBeacon(char *essid_bssid)
 		unVerified = realloc(unVerified, sizeof(char*) * max_essids);
 		if (!wpa || !unVerified)
 			alloc_error();
-		memset(wpa + sizeof(WPA4way_t) * max_essids / 2, 0, max_essids / 2);
-		memset(unVerified + sizeof(char*) * max_essids / 2, 0, max_essids / 2);
+		memset(wpa + sizeof(WPA4way_t) * max_essids / 2, 0, sizeof(WPA4way_t) * max_essids / 2);
+		memset(unVerified + sizeof(char*) * max_essids / 2, 0, sizeof(char*) * max_essids / 2);
 	}
 }
 
@@ -527,8 +527,8 @@ static void HandleBeacon(uint16 subtype)
 		unVerified = realloc(unVerified, sizeof(char*) * max_essids);
 		if (!wpa || !unVerified)
 			alloc_error();
-		memset(wpa + sizeof(WPA4way_t) * max_essids / 2, 0, max_essids / 2);
-		memset(unVerified + sizeof(char*) * max_essids / 2, 0, max_essids / 2);
+		memset(wpa + sizeof(WPA4way_t) * max_essids / 2, 0, sizeof(WPA4way_t) * max_essids / 2);
+		memset(unVerified + sizeof(char*) * max_essids / 2, 0, sizeof(char*) * max_essids / 2);
 	}
 }
 


### PR DESCRIPTION
### Summary
I noticed that in the latest git revision ```wpapcap2john``` doesn't actually print hashes when procesing a capture file. Or, if a capture file contains many handshakes, it prints hashes for only some of them (but sometimes for none at all). I reproduced the issue using the [example capture file from Wireshark wiki:](https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=view&target=wpa-Induction.pcap)
```
$ ./wpapcap2john wpa-Induction.pcap

wpa-Induction.pcap: Radiotap headers stripped
Learned BSSID 00:0C:41:82:B2:55 ESSID 'Coherer' from beacon

1 ESSIDS processed
```

Expected result was to see the messages "Key1/Key2 hit...", then "Key3/Key4 hit..." and hash printed before "1 ESSID processed".

It looks like the program doesn't process some handshakes because [this condition](https://github.com/magnumripper/JohnTheRipper/blob/98e0672d2ff9ef83d96fc0aaf8593f0ab8fe1444/src/wpapcap2john.c#L553) is true when ```.fully_cracked``` is some non-zero random memory garbage (visible in the debug prints below):

```
$ ./wpapcap2john wpa-Induction.pcap

wpa-Induction.pcap: Radiotap headers stripped
Learned BSSID 00:0C:41:82:B2:55 ESSID 'Coherer' from beacon
DBG: Handle4Way: wpa[0].fully_cracked=318580955
DBG: Handle4Way: wpa[0].fully_cracked=318580955
DBG: Handle4Way: wpa[0].fully_cracked=318580955
DBG: Handle4Way: wpa[0].fully_cracked=318580955

1 ESSIDS processed
```

The fix is to ensure that the dynamically allocated memory is initialised with zeros. In my suggested fix initial allocation is done with ```calloc()```, and the new areas of memory acquired with ```realloc()``` are zero-initialised using ```memset()```.

I also moved the memory reallocation code used by both ```HandleBeacon()``` and ```ManualBeacon()``` to a separate function.

### Other Information

This bug was introduced by commit 98e0672.
