### PR TITLE
Add support for cracking FileVault 2

### DIFF
--- a/doc/README.FileVault2
+++ b/doc/README.FileVault2
@@ -1,0 +1,60 @@
+This document is about cracking password protected FileVault 2 encrypted
+volumes with JtR.
+
+First, build the "fvde2john" (https://github.com/kholia/fvde2john) project from
+source. See https://github.com/libyal/libfvde/wiki/Building for help.
+
+
+Second, use the built fvde2john project to extract hash(es) from the encrypted
+FileVault 2 volume.
+
+$ tar -xJf fvde-1.raw.tar.xz  # sample image for testing, from fvde2john project
+
+$ sudo kpartx -v -a fvde-1.raw
+add map loop2p1 (253:5): 0 1048496 linear /dev/loop2 40
+
+$ sudo fvdetools/fvdeinfo -p dummy /dev/mapper/loop2p1  # this extracts the hashes
+fvdeinfo 20160918
+
+$fvde$1$16$e7eebaabacaffe04dd33d22fd09e30e5$41000$e9acbb4bc6dafb74aadb72c576fecf69c2ad45ccd4776d76
+
+
+Here is how to extract hashes without using kpartx,
+
+$ fdisk -l fvde-2.raw
+Disk fvde-2.raw: 512 MiB, 536870912 bytes, 1048576 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: gpt
+Disk identifier: EBED216B-95C5-40D3-9C15-D352C8E9E357
+
+Device      Start     End Sectors  Size Type
+fvde-2.raw1    40 1048535 1048496  512M Apple Core storage
+
+40 (Start) * 512 (Sector size) => 20480 => volume offset
+
+$ ./fvdetools/fvdeinfo -o 20480 fvde-2.raw
+fvdeinfo 20160918
+
+$fvde$1$16$94c438acf87d68c2882d53aafaa4647d$70400$2deb811f803a68e5e1c4d63452f04e1cac4e5d259f2e2999
+$fvde$1$16$94c438acf87d68c2882d53aafaa4647d$70400$2deb811f803a68e5e1c4d63452f04e1cac4e5d259f2e2999
+
+
+Finally, give this hash string to JtR jumbo to crack.
+
+$ cat hash
+$fvde$1$16$e7eebaabacaffe04dd33d22fd09e30e5$41000$e9acbb4bc6dafb74aadb72c576fecf69c2ad45ccd4776d76
+
+$ ../run/john hash -wordlist=wordlist
+Using default input encoding: UTF-8
+Loaded 1 password hash (FVDE, FileVault 2 [PBKDF2-SHA256 AES 256/256 AVX2 8x])
+Will run 4 OpenMP threads
+Press 'q' or Ctrl-C to abort, almost any other key for status
+openwall         (?)
+
+
+For more help with fvde2john, see the following URLs,
+
+https://github.com/libyal/libfvde/wiki
+https://github.com/libyal/libfvde/wiki/Troubleshooting

--- a/src/fvde_common.h
+++ b/src/fvde_common.h
@@ -1,0 +1,29 @@
+/*
+ * Common code for the FileVault 2 (FVDE) format.
+ */
+
+#include "formats.h"
+
+#define SALTLEN                 16
+#define BLOBLEN                 24
+#define FORMAT_NAME             "FileVault 2"
+#define FORMAT_TAG              "$fvde$"
+#define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
+
+typedef struct {
+	int salt_length;
+	unsigned char salt[SALTLEN];
+	unsigned int iterations;
+	union blob {  // wrapped kek
+		uint64_t qword[BLOBLEN/8];
+		unsigned char chr[BLOBLEN];
+	} blob;
+} fvde_custom_salt;
+
+extern struct fmt_tests fvde_tests[];
+
+// exported 'common' functions
+int fvde_common_valid(char *ciphertext, struct fmt_main *self);
+void *fvde_common_get_salt(char *ciphertext);
+unsigned int fvde_common_iteration_count(void *salt);
+int fvde_common_decrypt(fvde_custom_salt *cur_salt, unsigned char *key);

--- a/src/fvde_common_plug.c
+++ b/src/fvde_common_plug.c
@@ -1,0 +1,150 @@
+/*
+ * Common code for the FileVault 2 format.
+ */
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "fvde_common.h"
+#include "hmac_sha.h"
+#include "memdbg.h"
+#include "johnswap.h"
+#include "aes.h"
+
+struct fmt_tests fvde_tests[] = {
+	// https://github.com/kholia/fvde2john/blob/master/fvde-1.raw.tar.xz
+	{"$fvde$1$16$e7eebaabacaffe04dd33d22fd09e30e5$41000$e9acbb4bc6dafb74aadb72c576fecf69c2ad45ccd4776d76", "openwall"},
+	// external disk encrypted by macOS 10.12.2
+	{"$fvde$1$16$94c438acf87d68c2882d53aafaa4647d$70400$2deb811f803a68e5e1c4d63452f04e1cac4e5d259f2e2999", "password123"},
+	{NULL}
+};
+
+/*
+ * Unwrap data using AES Key Wrap (RFC3394)
+ *
+ * Translated from "AESUnwrap" function in aeswrap.py from https://github.com/dinosec/iphone-dataprotection project.
+ *
+ * The C implementation "aes_key_unwrap" in ramdisk_tools/bsdcrypto/key_wrap.c doesn't look any better.
+ *
+ * "libfvde_encryption_aes_key_unwrap" isn't great to look at either.
+ */
+int fvde_common_decrypt(fvde_custom_salt *cur_salt, unsigned char *key)
+{
+	uint64_t *C = cur_salt->blob.qword; // len(C) == 3
+	int n = 2;  // len(C) - 1
+	uint64_t R[3]; // n + 1 = 3
+	union {
+		uint64_t qword[2];
+		unsigned char stream[16];
+	} todecrypt;
+	int i, j;
+	AES_KEY akey;
+	uint64_t A = C[0];
+
+	AES_set_decrypt_key(key, 128, &akey);
+
+	for (i = 0; i < n + 1; i++)
+		R[i] = C[i];
+
+	for (j = 5; j >= 0; j--) { // 5 is fixed!
+		for (i = 2; i >=1; i--) { // i = n
+			todecrypt.qword[0] = JOHNSWAP64(A ^ (n*j+i));
+			todecrypt.qword[1] = JOHNSWAP64(R[i]);
+			AES_ecb_encrypt(todecrypt.stream, todecrypt.stream, &akey, AES_DECRYPT);
+			A = JOHNSWAP64(todecrypt.qword[0]);
+			R[i] = JOHNSWAP64(todecrypt.qword[1]);
+		}
+	}
+
+	if (A == 0xa6a6a6a6a6a6a6a6ULL)
+		return 1; // success!
+
+	return 0;
+}
+
+int fvde_common_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *keeptr, *p;
+	int value, extra;
+	int salt_length;
+
+	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH) != 0)
+		return 0;
+
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+
+	ctcopy += TAG_LENGTH;
+	if ((p = strtokm(ctcopy, "$")) == NULL) // version, for future purposes
+		goto err;
+	if (!isdec(p))
+		goto err;
+	value = atoi(p);
+	if (value != 1)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // salt length
+		goto err;
+	if (!isdec(p))
+		goto err;
+	salt_length = atoi(p);
+	if (salt_length != SALTLEN)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // salt
+		goto err;
+	if (hexlenl(p, &extra) != salt_length * 2 || extra)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // iterations
+		goto err;
+	if (!isdec(p))
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // wrapped kek, "blob"
+		goto err;
+	if (hexlenl(p, &extra) != BLOBLEN * 2 || extra)
+		goto err;
+
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *fvde_common_get_salt(char *ciphertext)
+{
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	int i;
+	char *p;
+	static fvde_custom_salt *cs;
+
+	cs = mem_calloc_tiny(sizeof(fvde_custom_salt), MEM_ALIGN_WORD);
+
+	ctcopy += TAG_LENGTH;
+	p = strtokm(ctcopy, "$"); // version
+	p = strtokm(NULL, "$"); // salt length
+	cs->salt_length = atoi(p);
+	p = strtokm(NULL, "$"); // salt
+	for (i = 0; i < cs->salt_length; i++)
+		cs->salt[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "$"); // iterations
+	cs->iterations = atoi(p);
+	p = strtokm(NULL, "$"); // blob
+	for (i = 0; i < BLOBLEN; i++)
+		cs->blob.chr[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	for (i = 0; i < BLOBLEN / 8; i++)
+		 cs->blob.qword[i] = JOHNSWAP64(cs->blob.qword[i]);
+
+	MEM_FREE(keeptr);
+
+	return (void *)cs;
+}
+
+unsigned int fvde_common_iteration_count(void *salt)
+{
+	fvde_custom_salt *cs = salt;
+
+	return (unsigned int) cs->iterations;
+}

--- a/src/fvde_fmt_plug.c
+++ b/src/fvde_fmt_plug.c
@@ -1,0 +1,219 @@
+/* JtR format to crack FileVault 2 hashes.
+ *
+ * This software is Copyright (c) 2017, Dhiru Kholia <kholia at kth.se> and it
+ * is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * Big thanks to Omar Choudary, Felix Grobert and Joachim Metz for making this
+ * format possible.
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_fvde;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_fvde);
+#else
+
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#ifdef _OPENMP
+#include <omp.h>
+#ifndef OMP_SCALE
+#define OMP_SCALE               8
+#endif
+#endif
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "options.h"
+#include "johnswap.h"
+#include "pbkdf2_hmac_sha256.h"
+#include "jumbo.h"
+#include "memdbg.h"
+#include "fvde_common.h"
+
+#define FORMAT_LABEL            "FVDE"
+#define FORMAT_NAME             "FileVault 2"
+#ifdef SIMD_COEF_32
+#define ALGORITHM_NAME          "PBKDF2-SHA256 AES " SHA256_ALGORITHM_NAME
+#else
+#if ARCH_BITS >= 64
+#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 64/" ARCH_BITS_STR " " SHA2_LIB
+#else
+#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR " " SHA2_LIB
+#endif
+#endif
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define BINARY_SIZE             0
+#define PLAINTEXT_LENGTH        125
+#define SALT_SIZE               sizeof(*cur_salt)
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              sizeof(int)
+#ifdef SIMD_COEF_32
+#define MIN_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA256
+#define MAX_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA256
+#else
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+#endif
+
+#if defined (_OPENMP)
+static int omp_t = 1;
+#endif
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static int *cracked, cracked_count;
+static fvde_custom_salt *cur_salt;
+
+static void init(struct fmt_main *self)
+{
+
+#if defined (_OPENMP)
+	omp_t = omp_get_max_threads();
+	self->params.min_keys_per_crypt *= omp_t;
+	omp_t *= OMP_SCALE;
+	self->params.max_keys_per_crypt *= omp_t;
+#endif
+	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);
+	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);
+	cracked_count = self->params.max_keys_per_crypt;
+}
+
+static void done(void)
+{
+	MEM_FREE(cracked);
+	MEM_FREE(saved_key);
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (fvde_custom_salt *)salt;
+}
+
+static void fvde_set_key(char *key, int index)
+{
+	int saved_len = strlen(key);
+	if (saved_len > PLAINTEXT_LENGTH)
+		saved_len = PLAINTEXT_LENGTH;
+	memcpy(saved_key[index], key, saved_len);
+	saved_key[index][saved_len] = 0;
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index = 0;
+
+	memset(cracked, 0, sizeof(cracked[0])*cracked_count);
+
+#ifdef _OPENMP
+#pragma omp parallel for
+	for (index = 0; index < count; index += MAX_KEYS_PER_CRYPT)
+#endif
+	{
+		unsigned char master[MAX_KEYS_PER_CRYPT][16];
+		int i;
+#ifdef SIMD_COEF_32
+		int lens[MAX_KEYS_PER_CRYPT];
+		unsigned char *pin[MAX_KEYS_PER_CRYPT], *pout[MAX_KEYS_PER_CRYPT];
+		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i) {
+			lens[i] = strlen(saved_key[index+i]);
+			pin[i] = (unsigned char*)saved_key[index+i];
+			pout[i] = master[i];
+		}
+		pbkdf2_sha256_sse((const unsigned char**)pin, lens, cur_salt->salt, cur_salt->salt_length, cur_salt->iterations, pout, 16, 0);
+#else
+		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i)
+			pbkdf2_sha256((unsigned char *)saved_key[index+i], strlen(saved_key[index+i]), cur_salt->salt, cur_salt->salt_length, cur_salt->iterations, master[i], 16, 0);
+#endif
+		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i) {
+			cracked[index+i] = fvde_common_decrypt(cur_salt, master[i]);
+		}
+	}
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+	for (index = 0; index < count; index++)
+		if (cracked[index])
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return cracked[index];
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main fmt_fvde = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		{
+			"iteration count",
+		},
+		{ FORMAT_TAG },
+		fvde_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		fvde_common_valid,
+		fmt_default_split,
+		fmt_default_binary,
+		fvde_common_get_salt,
+		{
+			fvde_common_iteration_count,
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		fvde_set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */


### PR DESCRIPTION
The heavy lifting is done by the https://github.com/kholia/fvde2john project which is a hacked up version of https://github.com/libyal/libfvde project. Big thanks to Omar Choudary, Felix Grobert and Joachim Metz for making this format possible.

See https://github.com/kholia/fvde2john/blob/master/README.txt for usage instructions. I can add these usage instructions to our repository too.

Is the name "FVDE" okay or do you have a better naming idea?