### PR TITLE
Add support for cracking Windows BitLocker passwords

### DIFF
--- a/doc/README.BitLocker
+++ b/doc/README.BitLocker
@@ -1,0 +1,50 @@
+This document is about cracking password protected BitLocker encrypted
+volumes with JtR.
+
+First, build the "bitlocker2john" (https://github.com/kholia/bitlocker2john) project from
+source. See https://github.com/libyal/libbde/wiki/Building for help.
+
+
+Second, use the built bitlocker2john project to extract hash(es) from the encrypted
+BitLocker volume.
+
+
+$ fdisk -l bitlocker-1.raw
+Disk bitlocker-1.raw: 256 MiB, 268435456 bytes, 524288 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0xfd0b8218
+
+Device           Boot Start    End Sectors  Size Id Type
+bitlocker-1.raw1        128 518271  518144  253M  7 HPFS/NTFS/exFAT
+
+128 (Start) * 512 (Sector size) => 65536 => volume offset
+
+$ ./bdetools/bdeinfo -o 65536 bitlocker-1.raw -p dummy
+bdeinfo 20170204
+
+$bitlocker$0$16$73926f843bbb41ea2a89a28b114a1a24$1048576$12$30a81ef90c9dd20103000000$60$942f852f2dc4ba8a589f35e750f33a5838d3bdc1ed77893e02ae1ac866f396f8635301f36010e0fcef0949078338f549ddb70e15c9a598e80c905baa
+
+Finally, give this hash string to JtR jumbo to crack.
+
+$ cat hash
+$bitlocker$0$16$73926f843bbb41ea2a89a28b114a1a24$1048576$12$30a81ef90c9dd20103000000$60$942f852f2dc4ba8a589f35e750f33a5838d3bdc1ed77893e02ae1ac866f396f8635301f36010e0fcef0949078338f549ddb70e15c9a598e80c905baa
+
+$ ../run/john hash -wordlist=wordlist
+Loaded 1 password hash (BitLocker, BitLocker [Iterated-SHA512 AES 64/64])
+Will run 4 OpenMP threads
+Press 'q' or Ctrl-C to abort, almost any other key for status
+password@123     (?)
+
+
+For more help with bitlocker2john, see the following URLs,
+
+https://github.com/libyal/libbde/wiki
+https://github.com/libyal/libbde/wiki/Troubleshooting
+
+
+Samples BitLocker images for testing are available at,
+
+https://github.com/kholia/libbde/tree/bitlocker2john/samples

--- a/src/aes_ccm.h
+++ b/src/aes_ccm.h
@@ -1,3 +1,5 @@
+#include "stdint.h"
+
 #define MBEDTLS_ERR_CCM_BAD_INPUT      -0x000D /**< Bad input parameters to function. */
 #define MBEDTLS_ERR_CCM_AUTH_FAILED    -0x000F /**< Authenticated decryption failed. */
 
@@ -5,3 +7,7 @@ int aes_ccm_auth_decrypt(const unsigned char *key, int bits, size_t length,
 		const unsigned char *iv, size_t iv_len, const unsigned char
 		*add, size_t add_len, const unsigned char *input, unsigned char
 		*output, const unsigned char *tag, size_t tag_len);
+
+int libcaes_crypt_ccm(unsigned char *key, int bits, int mode, const uint8_t
+		*nonce, size_t nonce_size, const uint8_t *input_data, size_t
+		input_data_size, uint8_t *output_data, size_t output_data_size);

--- a/src/bitlocker_common.h
+++ b/src/bitlocker_common.h
@@ -1,0 +1,27 @@
+/*
+ * Common code for the BitLocker format.
+ */
+
+#include "formats.h"
+
+#define SALTLEN                 16
+#define IVLEN                   12  // nonce length
+#define FORMAT_NAME             "BitLocker"
+#define FORMAT_TAG              "$bitlocker$"
+#define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
+
+typedef struct {
+	int salt_length;
+	int data_size;
+	unsigned char salt[SALTLEN];
+	unsigned int iterations;
+	unsigned char data[256];
+	unsigned char iv[IVLEN]; // nonce
+} bitlocker_custom_salt;
+
+extern struct fmt_tests bitlocker_tests[];
+
+// exported 'common' functions
+int bitlocker_common_valid(char *ciphertext, struct fmt_main *self);
+void *bitlocker_common_get_salt(char *ciphertext);
+unsigned int bitlocker_common_iteration_count(void *salt);

--- a/src/bitlocker_common_plug.c
+++ b/src/bitlocker_common_plug.c
@@ -1,0 +1,133 @@
+/*
+ * Common code for the BitLocker format.
+ */
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "bitlocker_common.h"
+#include "hmac_sha.h"
+#include "memdbg.h"
+#include "johnswap.h"
+
+struct fmt_tests bitlocker_tests[] = {
+	// Windows 10 generated BitLocker image
+	{"$bitlocker$0$16$134bd2634ba580adc3758ca5a84d8666$1048576$12$9080903a0d9dd20103000000$60$0c52fdd87f17ac55d4f4b82a00b264070f36a84ead6d4cd330368f7dddfde1bdc9f5d08fa526dae361b3d64875f76a077fe9c67f44e08d56f0131bb2", "openwall@123"},
+	// Windows 10
+	{"$bitlocker$0$16$73926f843bbb41ea2a89a28b114a1a24$1048576$12$30a81ef90c9dd20103000000$60$942f852f2dc4ba8a589f35e750f33a5838d3bdc1ed77893e02ae1ac866f396f8635301f36010e0fcef0949078338f549ddb70e15c9a598e80c905baa", "password@123"},
+	// Windows 8.1
+	{"$bitlocker$0$16$5e0686b4e7ce8a861b75bab3e8f1d424$1048576$12$90928da8c019d00103000000$60$ee5ce06cdc89b9fcdcd24bb854842fc8b715bb36c86c19e73ddb8a409718cac412f0416a51b1e0472fad8edb34d9208dd874dcadbf4779aaf01dfa74", "openwall@123"},
+	// Windows 8.1
+	{"$bitlocker$0$16$7b5c9407857f6d590a0d4dcf56d503a6$1048576$12$b02d06c0c019d00103000000$60$1af24981790bd0cc0d00b86b9893c0fdc63b20f0631e85f206b2af3c2c64f77bac2ec9379a4df51967c82033ed9661bace0e63c7dec4f9ef0cc27c5a", "openwall@12345"},
+	// Windows 10 "BitLocker To Go"
+	{"$bitlocker$0$16$9079aaee7be0923b529f069012f30b13$1048576$12$40ea50c2b79fd20103000000$60$caca601f042fae0eb697593e559760f8209d495ed0b61eda9c83a79f0abb3f598853b6f89cdffd3b5b66b90b321b822c90c8ef5dac464ef6edd06881", "weakpassword12345"},
+	{NULL}
+};
+
+int bitlocker_common_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *keeptr, *p;
+	int value, extra;
+	int salt_length;
+
+	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH) != 0)
+		return 0;
+
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+
+	ctcopy += TAG_LENGTH;
+	if ((p = strtokm(ctcopy, "$")) == NULL) // version, for future purposes
+		goto err;
+	if (!isdec(p))
+		goto err;
+	value = atoi(p);
+	if (value != 0)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // salt length
+		goto err;
+	if (!isdec(p))
+		goto err;
+	salt_length = atoi(p);
+	if (salt_length != SALTLEN)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // salt
+		goto err;
+	if (hexlenl(p, &extra) != salt_length * 2 || extra)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // iterations
+		goto err;
+	if (!isdec(p))
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // nonce length
+		goto err;
+	if (!isdec(p))
+		goto err;
+	value = atoi(p);
+	if (value != 12) // iv or nonce length is known to be 12 for aes-ccm mode in bitlocker
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // nonce
+		goto err;
+	if (hexlenl(p, &extra) != value * 2 || extra)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL)   // length of data encrypted by aes_ccm key
+		goto err;
+	if (!isdec(p))
+		goto err;
+	value = atoi(p);
+	if ((p = strtokm(NULL, "$")) == NULL)   // data encrypted by aEs_ccm key, contains encrypted volume master key (vmk)
+		goto err;
+	if (hexlenl(p, &extra) != value * 2 || extra)
+		goto err;
+
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *bitlocker_common_get_salt(char *ciphertext)
+{
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	int i;
+	char *p;
+	static bitlocker_custom_salt *cs;
+
+	cs = mem_calloc_tiny(sizeof(bitlocker_custom_salt), MEM_ALIGN_WORD);
+
+	ctcopy += TAG_LENGTH;
+	p = strtokm(ctcopy, "$"); // version
+	p = strtokm(NULL, "$"); // salt length
+	cs->salt_length = atoi(p);
+	p = strtokm(NULL, "$"); // salt
+	for (i = 0; i < cs->salt_length; i++)
+		cs->salt[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "$"); // iterations
+	cs->iterations = atoi(p);
+	p = strtokm(NULL, "$"); // nonce length
+	p = strtokm(NULL, "$"); // nonce
+	for (i = 0; i < IVLEN; i++)
+		cs->iv[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "$"); // data_size
+	cs->data_size = atoi(p);
+	p = strtokm(NULL, "$"); // data
+	for (i = 0; i < cs->data_size; i++)
+		cs->data[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+
+	MEM_FREE(keeptr);
+
+	return (void *)cs;
+}
+
+unsigned int bitlocker_common_iteration_count(void *salt)
+{
+	bitlocker_custom_salt *cs = salt;
+
+	return (unsigned int) cs->iterations;
+}

--- a/src/bitlocker_fmt_plug.c
+++ b/src/bitlocker_fmt_plug.c
@@ -1,0 +1,278 @@
+/* JtR format to crack BitLocker hashes.
+ *
+ * This software is Copyright (c) 2017, Dhiru Kholia <kholia at kth.se> and it
+ * is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * Big thanks to Joachim Metz and Elena Ago for making this format possible.
+ *
+ * http://jessekornblum.com/publications/di09.pdf (Implementing BitLocker Drive
+ * Encryption for Forensic Analysis) by Jesse D. Kornblum is a useful reference.
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_bitlocker;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_bitlocker);
+#else
+
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#ifdef _OPENMP
+#include <omp.h>
+#ifndef OMP_SCALE
+#define OMP_SCALE               1
+#endif
+#endif
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "unicode.h"
+#include "options.h"
+#include "johnswap.h"
+#include "aes.h"
+#include "aes_ccm.h"
+#include "sha.h"
+#include "sha.h"
+#include "jumbo.h"
+#include "memdbg.h"
+#include "bitlocker_common.h"
+
+#define FORMAT_LABEL            "BitLocker"
+#if ARCH_BITS >= 64
+#define ALGORITHM_NAME          "Iterated-SHA256 AES 64/" ARCH_BITS_STR
+#else
+#define ALGORITHM_NAME          "Iterated-SHA256 AES 32/" ARCH_BITS_STR
+#endif
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define BINARY_SIZE             0
+#define PLAINTEXT_LENGTH        125
+#define SALT_SIZE               sizeof(*cur_salt)
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              sizeof(int)
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+
+#if defined (_OPENMP)
+static int omp_t = 1;
+#endif
+static UTF16 (*saved_key)[PLAINTEXT_LENGTH + 1];
+static int *cracked, cracked_count;
+static bitlocker_custom_salt *cur_salt;
+
+static void init(struct fmt_main *self)
+{
+#if defined (_OPENMP)
+	omp_t = omp_get_max_threads();
+	self->params.min_keys_per_crypt *= omp_t;
+	omp_t *= OMP_SCALE;
+	self->params.max_keys_per_crypt *= omp_t;
+#endif
+	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);
+	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);
+	cracked_count = self->params.max_keys_per_crypt;
+}
+
+static void done(void)
+{
+	MEM_FREE(cracked);
+	MEM_FREE(saved_key);
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (bitlocker_custom_salt *)salt;
+}
+
+static void bitlocker_set_key(char *key, int index)
+{
+	/* Convert key to UTF-16LE (--encoding aware) */
+	enc_to_utf16(saved_key[index], PLAINTEXT_LENGTH, (UTF8*)key, strlen(key));
+}
+
+static char *get_key(int index)
+{
+	return (char*)utf16_to_enc(saved_key[index]);
+}
+
+// borrowed from libbde project
+struct libbde_password_key_data
+{
+        // the last calculated SHA256 hash
+        uint8_t last_sha256_hash[32];
+
+        // the initial calculated SHA256 hash
+        uint8_t initial_sha256_hash[32];
+
+        uint8_t salt[16];
+
+        uint64_t iteration_count;
+};
+
+// derived from libbde's libbde_password_calculate_key
+static void bitlocker_kdf(unsigned char *password_hash, unsigned char *out)
+{
+	struct libbde_password_key_data pkd;
+	SHA256_CTX ctx;
+
+	memset(&pkd, 0, sizeof(struct libbde_password_key_data));
+	memcpy(pkd.initial_sha256_hash, password_hash, 32);
+	memcpy(pkd.salt, cur_salt->salt, cur_salt->salt_length);
+
+	for (pkd.iteration_count = 0; pkd.iteration_count < cur_salt->iterations; pkd.iteration_count++) {
+		SHA256_Init(&ctx);
+		SHA256_Update(&ctx, &pkd, sizeof(struct libbde_password_key_data));
+		SHA256_Final(pkd.last_sha256_hash, &ctx);
+	}
+
+	memcpy(out, pkd.last_sha256_hash, 32); // this is the aes-ccm key
+}
+
+#ifdef BITLOCKER_DEBUG
+static void print_hex(unsigned char *str, int len)
+{
+	int i;
+	for (i = 0; i < len; ++i)
+		printf("%02x", str[i]);
+	printf("\n");
+}
+#endif
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index = 0;
+
+	memset(cracked, 0, sizeof(cracked[0])*cracked_count);
+
+#ifdef _OPENMP
+#pragma omp parallel for
+	for (index = 0; index < count; index += MAX_KEYS_PER_CRYPT)
+#endif
+	{
+		unsigned char *passwordBuf;
+		int passwordBufSize, i;
+		unsigned char out[MAX_KEYS_PER_CRYPT][32];
+		SHA256_CTX ctx;
+		unsigned char output[256] = { 0 };
+		uint32_t data_size = 0;
+		uint32_t version = 0;
+		unsigned char *vmk_blob = NULL; // contains volume master key
+		unsigned char v1, v2;
+
+		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i) {
+			// do double-sha256 of password encoded in "utf-16-le"
+			passwordBuf = (unsigned char*)saved_key[index+i];
+			passwordBufSize = strlen16((UTF16*)passwordBuf) * 2;
+			SHA256_Init(&ctx);
+			SHA256_Update(&ctx, passwordBuf, passwordBufSize);
+			SHA256_Final(out[i], &ctx);
+			SHA256_Init(&ctx);
+			SHA256_Update(&ctx, out[i], 32);
+			SHA256_Final(out[i], &ctx);
+			// run bitlocker kdf
+			bitlocker_kdf(out[i], out[i]);
+			libcaes_crypt_ccm(out[i], 256, 0, cur_salt->iv, IVLEN, // 0 -> decrypt mode
+					cur_salt->data, cur_salt->data_size,
+					output, cur_salt->data_size);
+			// do known plaintext attack (kpa), version and
+			// data_size checks come from libbde, v1 and v2 (vmk_blob)
+			// checks come from e-ago
+			version = output[20] | (output[21] << 8);
+			data_size = output[16] | (output[17] << 8);
+			vmk_blob = &output[16]; // the actual volume master key is at offset 28
+			v1 = vmk_blob[8];
+			v2 = vmk_blob[9];
+			if (version == 1 && data_size == 0x2c && v1 <= 0x05 && v2 == 0x20)
+				cracked[index+i] = 1;
+			else {
+				cracked[index+i] = 0;
+#ifdef BITLOCKER_DEBUG
+				print_hex(output, cur_salt->data_size);
+#endif
+			}
+		}
+	}
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+	for (index = 0; index < count; index++)
+		if (cracked[index])
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return cracked[index];
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main fmt_bitlocker = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+		{
+			"iteration count",
+		},
+		{ FORMAT_TAG },
+		bitlocker_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		bitlocker_common_valid,
+		fmt_default_split,
+		fmt_default_binary,
+		bitlocker_common_get_salt,
+		{
+			bitlocker_common_iteration_count,
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		bitlocker_set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */


### PR DESCRIPTION
Hi,

This PR adds support for cracking Windows BitLocker passwords.

+ Tested with Windows 8.1 and 10 BitLocker volumes

+ AES CBC and XTS modes are supported

+ BitLocker To Go is supported

This PR introduces a new reliable `bitlocker2john` tool which works with all the sample images we have. The hashes produced by this new tool have the information required for Elena's BitCracker to work too, once it is trivially modified.

I will work with Elena Ago to see if we can improve and use her version of the `bitlocker2john` tool.

Big thanks to Joachim Metz and Elena Ago for making this format possible.

https://github.com/kholia/libbde/tree/bitlocker2john/samples has BitLocker encrypted images available for testing. 