### PR TITLE
OpenCL: fix for a non SIMD build

### DIFF
--- a/src/opencl_rawsha256_fmt_plug.c
+++ b/src/opencl_rawsha256_fmt_plug.c
@@ -128,9 +128,8 @@ static uint32_t *crypt_one(int index) {
 	SHA256_Update(&ctx, key, len);
 	SHA256_Final((unsigned char *) (hash), &ctx);
 
-#ifdef SIMD_COEF_32
 	alter_endianity_to_BE(hash, DIGEST_SIZE / sizeof(uint32_t));
-#endif
+
 	return hash;
 }
 
@@ -702,7 +701,7 @@ static int cmp_exact(char *source, int index)
 #ifdef DEBUG
 	fprintf(stderr, "Stressing CPU\n");
 #endif
-	binary = (uint32_t *) sha256_common_binary(source);
+	binary = (uint32_t *) sha256_common_binary_BE(source);
 
 	full_hash = crypt_one(index);
 	return !memcmp(binary, (void *) full_hash, BINARY_SIZE);
@@ -774,7 +773,7 @@ struct fmt_main fmt_opencl_rawsha256 = {
 		sha256_common_prepare,
 		sha256_common_valid,
 		sha256_common_split,
-		sha256_common_binary,
+		sha256_common_binary_BE,
 		fmt_default_salt,
 		{NULL},
 		fmt_default_source,

--- a/src/opencl_rawsha512_gpl_fmt_plug.c
+++ b/src/opencl_rawsha512_gpl_fmt_plug.c
@@ -137,9 +137,8 @@ static uint64_t *crypt_one(int index) {
 	SHA512_Update(&ctx, key, len);
 	SHA512_Final((unsigned char *) (hash), &ctx);
 
-#ifdef SIMD_COEF_64
 	alter_endianity_to_BE64(hash, DIGEST_SIZE / sizeof(uint64_t));
-#endif
+
 	return hash;
 }
 
@@ -155,9 +154,8 @@ static uint64_t *crypt_one_x(int index) {
 	SHA512_Update(&ctx, key, len);
 	SHA512_Final((unsigned char *) (hash), &ctx);
 
-#ifdef SIMD_COEF_64
 	alter_endianity_to_BE64(hash, DIGEST_SIZE / sizeof(uint64_t));
-#endif
+
 	return hash;
 }
 
@@ -791,7 +789,7 @@ static int cmp_exact_raw(char *source, int index)
 #ifdef DEBUG
 	fprintf(stderr, "Stressing CPU\n");
 #endif
-	binary = (uint64_t *) sha512_common_binary(source);
+	binary = (uint64_t *) sha512_common_binary_BE(source);
 
 	full_hash = crypt_one(index);
 	return !memcmp(binary, (void *) full_hash, BINARY_SIZE);
@@ -805,7 +803,7 @@ static int cmp_exact_x(char *source, int index)
 #ifdef DEBUG
 	fprintf(stderr, "Stressing CPU\n");
 #endif
-	binary = (uint64_t *) sha512_common_binary_xsha512(source);
+	binary = (uint64_t *) sha512_common_binary_xsha512_BE(source);
 
 	full_hash = crypt_one_x(index);
 	return !memcmp(binary, (void *) full_hash, BINARY_SIZE);
@@ -874,7 +872,7 @@ struct fmt_main fmt_opencl_rawsha512_gpl = {
 		fmt_default_prepare,
 		sha512_common_valid,
 		sha512_common_split,
-		sha512_common_binary,
+		sha512_common_binary_BE,
 		fmt_default_salt,
 		{NULL},
 		fmt_default_source,
@@ -937,7 +935,7 @@ struct fmt_main fmt_opencl_xsha512_gpl = {
 		sha512_common_prepare_xsha512,
 		sha512_common_valid_xsha512,
 		sha512_common_split_xsha512,
-		sha512_common_binary_xsha512,
+		sha512_common_binary_xsha512_BE,
 		get_salt,
 		{NULL},
 		fmt_default_source,

--- a/src/rawSHA256_common.h
+++ b/src/rawSHA256_common.h
@@ -30,6 +30,7 @@
 
 int sha256_common_valid(char *ciphertext, struct fmt_main *self);
 void * sha256_common_binary(char *ciphertext);
+void * sha256_common_binary_BE(char *ciphertext);
 char * sha256_common_prepare(char *split_fields[10], struct fmt_main *self);
 char * sha256_common_split(char *ciphertext, int index, struct fmt_main *self);
 

--- a/src/rawSHA256_common_plug.c
+++ b/src/rawSHA256_common_plug.c
@@ -70,6 +70,25 @@ void * sha256_common_binary(char *ciphertext)
 	return out;
 }
 
+void *sha256_common_binary_BE(char *ciphertext)
+{
+	static unsigned char * out;
+	char *p;
+	int i;
+
+	if (!out) out = mem_calloc_tiny(DIGEST_SIZE, MEM_ALIGN_WORD);
+
+	p = ciphertext + HEX_TAG_LEN;
+	for (i = 0; i < DIGEST_SIZE; i++) {
+		out[i] =
+				(atoi16[ARCH_INDEX(*p)] << 4) |
+				 atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+	alter_endianity (out, DIGEST_SIZE);
+	return out;
+}
+
 /* ------- Prepare ------- */
 /* Convert Cisco hashes to hex ones, so .pot entries are compatible */
 char * sha256_common_prepare(char *split_fields[10], struct fmt_main *self)

--- a/src/rawSHA512_common.h
+++ b/src/rawSHA512_common.h
@@ -43,8 +43,10 @@ int sha512_common_valid_xsha512(char *ciphertext, struct fmt_main *self);
 int sha512_common_valid_nsldap(char *ciphertext, struct fmt_main *self);
 
 void * sha512_common_binary(char *ciphertext);
+void * sha512_common_binary_BE(char *ciphertext);
 void * sha512_common_binary_rev(char *ciphertext);
 void * sha512_common_binary_xsha512(char *ciphertext);
+void * sha512_common_binary_xsha512_BE(char *ciphertext);
 void * sha512_common_binary_xsha512_rev(char *ciphertext);
 void * sha512_common_binary_nsldap(char *ciphertext);
 

--- a/src/rawSHA512_common_plug.c
+++ b/src/rawSHA512_common_plug.c
@@ -194,6 +194,25 @@ void * sha512_common_binary(char *ciphertext)
 	return out;
 }
 
+void *sha512_common_binary_BE(char *ciphertext)
+{
+	static unsigned char * out;
+	char *p;
+	int i;
+
+	if (!out) out = mem_calloc_tiny(DIGEST_SIZE, BINARY_ALIGN);
+
+	p = ciphertext + TAG_LENGTH;
+	for (i = 0; i < DIGEST_SIZE; i++) {
+		out[i] =
+				(atoi16[ARCH_INDEX(*p)] << 4) |
+				 atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+	alter_endianity_to_BE64(out, DIGEST_SIZE/8);
+	return out;
+}
+
 void *sha512_common_binary_rev(char *ciphertext)
 {
 	static union {
@@ -243,6 +262,28 @@ void * sha512_common_binary_xsha512(char *ciphertext)
 #ifdef SIMD_COEF_64
 	alter_endianity_to_BE64(out, DIGEST_SIZE/8);
 #endif
+	return out;
+}
+
+void *sha512_common_binary_xsha512_BE(char *ciphertext)
+{
+	static union {
+		unsigned char out[DIGEST_SIZE];
+		uint64_t x;
+	} x;
+	unsigned char *out = x.out;
+	char *p;
+	int i;
+
+	ciphertext += XSHA512_TAG_LENGTH;
+	p = ciphertext + 8;
+	for (i = 0; i < DIGEST_SIZE; i++) {
+		out[i] =
+				(atoi16[ARCH_INDEX(*p)] << 4) |
+				 atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+	alter_endianity_to_BE64(out, DIGEST_SIZE/8);
 	return out;
 }
 


### PR DESCRIPTION
### Summary
Affects only raw-SHA256 and x/raw-SHA512 OpenCL formats.
