### PR TITLE
Spelling and grammar fixes, plus cleanup of remining CUDA references

### DIFF
--- a/doc/BUGS
+++ b/doc/BUGS
@@ -15,22 +15,6 @@ Not working on big-endian CPU architectures (disabled by autoconf):
 Intel's OCL SDK 1.5 CPU driver has problems with some formats. Use a
 newer version of the SDK.
 
-All CUDA formats substantially benefit from compile-time tuning.
-README-CUDA includes some info on this.  In short, on GTX 400 series and
-newer NVIDIA cards, you'll likely want to change "-arch sm_10" to "-arch
-sm_20" or greater (as appropriate for your GPU) on the NVCC_FLAGS line
-in Makefile.  You'll also want to tune BLOCKS and THREADS for the
-specific format you're interested in.  These are typically specified in
-cuda_*.h files.  README-CUDA includes a handful of pre-tuned settings.
-It is not unusual to obtain e.g. a 3x speedup (compared to the generic
-defaults) with this sort of tuning.
-
-Even though wpapsk-cuda primarily use the GPU, it also does a (small,
-but not negligible) portion of the computation on CPU and thus it
-substantially benefits from OpenMP-enabled builds.  We intend to reduce
-its use of CPU in a future version. The OpenCL version does all
-computation on GPU.
-
 With GPU-enabled formats (and sometimes with OpenMP on CPU as well), the
 number of candidate passwords being tested concurrently can be very
 large (thousands).  When the format is of a "slow" type (such as an

--- a/doc/CRAM-MD5.txt
+++ b/doc/CRAM-MD5.txt
@@ -10,7 +10,7 @@ The input format for JtR is:
 
 $cram_md5$<challenge>$<response>
 
-eg.
+e.g.
 
 $cram_md5$PG5vLXJlcGx5QGhhc2hjYXQubmV0Pg==$dXNlciA0NGVhZmQyMmZlNzY2NzBmNmIyODc5MDgxYTdmNWY3MQ==
 

--- a/doc/DYNAMIC_EXPRESSIONS
+++ b/doc/DYNAMIC_EXPRESSIONS
@@ -59,7 +59,7 @@ Variables:
     in order, i.e. if you have a $c2, then you should have a $c1 already.
     so md5($s.$c1.$p.$c1),c1=x   gives us  md5($s."x".$p."x")
 
-Casing (note only a few things can be cased)
+Casing (note: only a few things can be cased)
   lc($u) is for lower case of the user name (proper unicode lower casing)
   uc($u) is for upper case of the user name (again, proper unicode up casing)
   lc($p and uc($p) are for lower/upper casing the password.
@@ -81,7 +81,7 @@ Grouping.  All expressions must be a single 'outer' expression, but within
 
 The hashing functions come in multiple 'flavors', doing slightly different
   things. examples: md5(exp) MD5(exp) md5_raw(exp) md5_64(exp) md5_64c(exp)
-  There is the lower case hash (like md5(...)) It returns it's results
+  There is the lower case hash (like md5(...)) It returns its results
   as a lower case base16 number. So md5("password") would return
   5f4dcc3b5aa765d61d8327deb882cf99,  Upper case of the hash, returns the
   upper cased base16 hash. So MD5("password") would return
@@ -107,6 +107,6 @@ The hashing functions (each have a lc, uc, _raw, _64 and _64c version)
          haval_256_3, haval_256_4, haval_256_5,
 
 These functions can be intermixed in pretty much any way. So a hash of
-  sha512(md5(panama($p).$s.ripmd128($s.$p)))  is perfectly 'valid'
+  sha512(md5(panama($p).$s.ripmd128($s.$p)))  is perfectly 'valid'.
 
 

--- a/doc/ENCODINGS
+++ b/doc/ENCODINGS
@@ -30,15 +30,15 @@ wordlist is encoded in ISO-8859-1, you need to use the "--encoding=iso-8859-1"
 option (unless you have set that as default in john.conf). But you also need to
 know what encoding the hashes were made from - for example, LM hashes are
 always made from a legacy MS-DOS codepage like CP437 or CP850. This can be
-specified by using the option eg. "--target-encoding=CP437". John will convert
+specified by using the option e.g. "--target-encoding=CP437". John will convert
 to/from Unicode as needed.
 
-Finally, there's the special case where both input (wordlist) and output (eg.
-hashes from a website) are UTF-8 but you want to use rules including eg. upper
+Finally, there's the special case where both input (wordlist) and output (e.g.
+hashes from a website) are UTF-8 but you want to use rules including e.g. upper
 or lower-casing non-ASCII characters. In this case you can use an intermediate
 encoding (--internal-codepage option) and pick some codepage that can
 shelter as much of the needed input as possible. For US/Western Europe, any
-"Latin-1" codepage will do fine, eg. CP850, ISO-8859-1 or CP1252 (if you do
+"Latin-1" codepage will do fine, e.g. CP850, ISO-8859-1 or CP1252 (if you do
 this with a Unicode format like NT, it will silently be treated in another
 way internally for performance reasons but the outcome will be the same).
 

--- a/doc/EXTERNAL
+++ b/doc/EXTERNAL
@@ -93,7 +93,7 @@ hybrid_total should be set, AND hybrid_resume is the number of iterations
 which were done in the prior run. restore() should use this to change whatever
 is required within the script's global state, so that the next call to next()
 will produce the correct next word.  If the script can not easily know how
-many candidate a word produces, or adjust it's global state to start from
+many candidate a word produces, or adjust its global state to start from
 some random location, then within new() the script should NOT set 'hybrid_total'
 and within restore() the script should also not set 'hybrid_total'. In this
 case,  the cracker will call new() with the word, and then call next()
@@ -188,7 +188,7 @@ variables added to aid in session resuming.
 Hybrid Functions:
 
 * new() This function is called at the start of each NEW word to be worked on.
-The script should do whatever is needed to setup it's state. This may be
+The script should do whatever is needed to setup its state. This may be
 counting letters in the base word, saving off the base word, or many other
 things. The only time that new() is NOT called, is upon a restore() call
 when the script knows how to easily restore.  In that case restore() should

--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -26,7 +26,7 @@ for you to compile and you can start using John right away.
 
 The Jumbo versions requires OpenSSL 0.9.7 or later. To get all functionality
 you need 1.0.1. For building, not only the run-time libs are needed but also
-"devel" stuff like header files. This is often a separate package, so eg.
+"devel" stuff like header files. This is often a separate package, so, e.g.,
 for Ubuntu you need "libssl-dev" as well as "libssl".
 
 A few helper tools need C++. Some helper tools are written in Python. A couple
@@ -37,7 +37,7 @@ extra libraries in order to get included:
 	krb5-18/23	libkrb5
 	wowsrp		libgmp (will build without it, but is slower then)
 
-Again, you also need eg. libnss-dev, libkrb5-dev and libgmp-dev in order to
+Again, you also need e.g. libnss-dev, libkrb5-dev and libgmp-dev in order to
 build.
 
 
@@ -62,7 +62,7 @@ Note that whenever you pass CFLAGS like this, the default "-g -O2" will go
 away, so add that too (like was done above).
 
 You might want to add "-s" to make, for suppressing normal output and just
-print warnings and errors. For a multi-core host you can also add eg. "-j4"
+print warnings and errors. For a multi-core host you can also add e.g. "-j4"
 for using 4 cores in parallel when building. This can be written together,
 as in:
 	./configure && make -sj4

--- a/doc/MASK
+++ b/doc/MASK
@@ -12,7 +12,7 @@ A mask may consist of:
 - ?u upper-case ASCII letters
 - ?d digits
 - ?s specials (all printable ASCII characters not in ?l, ?u or ?d)
-- ?a full 'printable' ASCII. Note that for formats that doesn't recognize case
+- ?a full 'printable' ASCII. Note that for formats that don't recognize case
      (eg. LM), this only includes lower-case characters which is a tremendous
      reduction of keyspace for the win.
 - ?B all 8-bit (0x80-0xff)
@@ -24,9 +24,9 @@ A mask may consist of:
 - ?D non-ASCII "digits"
 - ?S non-ASCII "specials"
 - ?A all valid characters in the current code page (including ASCII). Note
-     that for formats that doesn't recognize case (eg. LM), this only includes
+     that for formats that don't recognize case (eg. LM), this only includes
      lower-case characters which is a tremendous reduction of keyspace.
-- Placeholders that are custom defined, so we can eg. define ?1 to mean [?u?l]
+- Placeholders that are custom defined, so we can e.g. define ?1 to mean [?u?l]
   ?1 .. ?9 user-defined place-holder 1 .. 9
 - Placeholders for Hybrid Mask mode:
   ?w is a placeholder for the original word produced by the parent mode in
@@ -38,7 +38,7 @@ Mask Mode alone produces words from the mask, for example ?u?l?l will generate
 all possible three-letter words, with first character uppercased and the
 remaining in lowercase.
 
-Hybrid (a.k.a Stacked) Mask means we use eg. a wordlist with or without rules
+Hybrid (a.k.a Stacked) Mask means we use e.g. a wordlist with or without rules
 (or any other cracking mode), and then apply the mask to each word.  So with a
 mask of ?w?d?d and an input word (from the parent cracking mode) of "pass",
 it will produce "pass00", "pass01" and so on until "pass99".  Hybrid Mask can
@@ -56,7 +56,7 @@ external filters with "GPU side mask" will cause a somewhat undefined behavior
 though: The filter will be applied before the GPU-side mask has finished the
 word!
 
-You can define custom placeholders for ?1 .. ?9 using command line eg. -1=?l?u
+You can define custom placeholders for ?1 .. ?9 using command line e.g. -1=?l?u
 or in john.conf section [Mask].
 
 There is a default mask in john.conf too (defaulting to same as hashcat).

--- a/doc/MODES
+++ b/doc/MODES
@@ -153,7 +153,7 @@ the same result as a rule adding two digits to the base word.
 	Multiple stacking of modes.
 
 The mask and regex modes can be stacked upon some other mode (any mode except
-single, but including eg. stdin and loopback modes).  Regex can be a parent
+single, but including e.g. stdin and loopback modes).  Regex can be a parent
 mode to mask mode even when regex itself runs stacked on some other mode.  In
 that case, mask is always last in chain  (by design, since it can accelerate
 fast GPU formats).  Basically, the first mode is any mode except single, and

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -34,7 +34,7 @@ command line.  See --rules for more details.
 
 --single-seed=WORD[,WORD][,...]
 
-Add static word(s) for all salts in single mode.  Adding eg. "Rockyou"
+Add static word(s) for all salts in single mode.  Adding e.g. "Rockyou"
 will have the same effect as having that word in all gecos fields in the
 whole input file (except the latter would eat memory).
 
@@ -367,8 +367,8 @@ you can use group aliases "dynamic", "cpu", "gpu", "opencl" and "cuda"
 as a format name, or use one wildcard, as in "--format=mysql-*",
 "--format=raw*ng" or "--format=*office".  There's also a special way
 to match any substring within the "algorithm name" (the string shown
-within brackets, eg. "[DES 128/128 AVX-16]" using @tag syntax as in
-eg. "--format=@DES" or "--format=@AVX".  Regardless of method, the
+within brackets, e.g. "[DES 128/128 AVX-16]" using @tag syntax as in
+e.g. "--format=@DES" or "--format=@AVX".  Regardless of method, the
 matching ignores case.
 
 "--format=crypt" may or may not be supported in a given build of John.
@@ -472,7 +472,7 @@ These options limit the length of candidates that will be tried.  In wordlist
 mode (after applying rules, if any), a word that is not within the requested
 limits will be rejected (as opposed to truncated).  Most other modes also
 honour these settings.  For example, you can fully exhaust a short keyspace
-with incremental mode with eg. --max-len=4 and then start a longer session
+with incremental mode with e.g. --max-len=4 and then start a longer session
 for the rest with --min-length=5, or use one core for lengths up to 8 and
 other cores for exact lengths of 9, 10 and so on.
 Note: With UTF-8 encoding and no internal codepage, non-ASCII characters will
@@ -506,7 +506,7 @@ further cracking, so you can use it to find alternative plaintexts.
 
 This esoteric option can be used to filter out many bogus hashes.  It only
 works well with not too small binary sizes.  Rejected hashes are printed (as
-text) to stderr.  It may fail to work with some formats that eg. reverses
+text) to stderr.  It may fail to work with some formats that e.g. reverse
 steps.  A good example of that is it does not work with raw-md5 format, but
 works fine with dynamic_0 (which is also raw MD5 but less optimized).  An
 example of hash that would be rejected is 6d61676e756d474747476d61676e756d

--- a/doc/README-OPENCL
+++ b/doc/README-OPENCL
@@ -38,7 +38,7 @@ COMPILING:
 
 The new autoconf (./configure) should find your OpenCL installation and
 enable it. If it doesn't, you may need to pass some parameters about where
-it's located, eg.
+it's located, e.g.,
     ./configure LDFLAGS=-L/opt/AMDAPP/lib CFLAGS=-I/opt/AMDAPP/include
     make -s
 
@@ -73,7 +73,7 @@ USAGE:
 You can use john with your favourite options and the corresponding
 OpenCL format you need. If no --format is given, john will always
 pick the CPU format. To use OpenCL you must explicitly select the
-format eg. --format=wpapsk-opencl
+format, e.g., --format=wpapsk-opencl
 
 
 ====================
@@ -107,7 +107,7 @@ RAKP-opencl               IPMI 2.0 RAKP (RMCP+)
 sha1crypt-opencl          NetBSD's sha1crypt
 WPAPSK-opencl             WPA/WPA2 PSK
 
-If/when a format runs vectorized, it will show algorithm name as eg.
+If/when a format runs vectorized, it will show algorithm name as e.g.
 [OpenCL 4x] as opposed to just [OpenCL].
 
 
@@ -178,7 +178,7 @@ The above will fork to four processes and each process will use a different
 GPU or Accelerator device. The "-dev" option (--device) is likely needed
 because it defaults to 'all' which may include unwanted devices. Instead
 of -dev=gpu,acc (use all/any GPUs and accelerators) you could specify them
-explicitly if needed, eg. -dev=0,1,5,6.
+explicitly if needed, e.g. -dev=0,1,5,6.
 
 Or maybe you have two cards in a remote host called alpha and one card in
 a host called bravo. Build with MPI support and use this variant of the above:
@@ -190,7 +190,7 @@ as one process on bravo. In this case, the "-dev=gpu" option will be
 enumerated on each host so if GPUs are devices 1 & 3 on alpha but device 0 on
 bravo, that is not a problem.
 
-If for some reason you want to run eg. two processes on each GPU, just double
+If for some reason you want to run e.g. two processes on each GPU, just double
 the -fork argument or the MPI number of hosts (using -np option to mpirun).
 The device list will round-robin.
 

--- a/run/dumb16.conf
+++ b/run/dumb16.conf
@@ -12,7 +12,7 @@
 #
 # Note that these modes will handle --max-len differently than normal: They
 # will consider number of characters as opposed to number of bytes. This
-# means you can naturally just use eg. --max-len=3 for generating all
+# means you can naturally just use e.g. --max-len=3 for generating all
 # three-character candidates (which may be up to 9 bytes each).
 [List.External:Dumb16]
 int maxlength;            // Maximum password length to try

--- a/run/dumb32.conf
+++ b/run/dumb32.conf
@@ -12,7 +12,7 @@
 #
 # Note that these modes will handle --max-len differently than normal: They
 # will consider number of characters as opposed to number of bytes. This
-# means you can naturally just use eg. --max-len=3 for generating all
+# means you can naturally just use e.g. --max-len=3 for generating all
 # three-character candidates (which may be up to 12 bytes each).
 #
 # Also note that for UTF-16 formats, the resulting plaintext size within the

--- a/run/dynamic_flat_sse_formats.conf
+++ b/run/dynamic_flat_sse_formats.conf
@@ -1,5 +1,5 @@
 # NOTE, same format as dynamic_0  It is slower (50% slower, or more).  But it is not limited to 55 byte passwords.
-# this should work for passwords up to 110 bytes long (max length dynamic will currently allow). It should not be
+# This should work for passwords up to 110 bytes long (max length dynamic will currently allow). It should not be
 # used for shorter passwords (under 55 bytes).  Use dyna_0 for those.
 [List.Generic:dynamic_2000]
 Expression=md5($p) (PW > 55 bytes)

--- a/run/john.conf
+++ b/run/john.conf
@@ -175,7 +175,7 @@ NoLoaderDupeCheck = N
 # Default encoding for input files (ie. login/GECOS fields) and wordlists
 # etc.  If this is not set here and --encoding is not used either, the default
 # is ISO-8859-1 for Unicode conversions and 7-bit ASCII encoding is assumed
-# for rules - eg. uppercasing of letters other than a-z will not work at all!
+# for rules, e.g., uppercasing of letters other than a-z will not work at all!
 DefaultEncoding = UTF-8
 
 # Default --target-encoding for Microsoft hashes (LM, NETLM et al) when input
@@ -187,8 +187,8 @@ DefaultMSCodepage = CP850
 # rules engine, when both input and target encodings are Unicode (eg. UTF-8
 # wordlist and NT hashes). In some cases this hits performance but lets us
 # do things like Unicode case conversions. You can pick any supported
-# legacy codepage that has as much support for the input data as possible -
-# eg. for "Latin-1" language passwords you can use ISO-8859-1, CP850 or
+# legacy codepage that has as much support for the input data as possible,
+# e.g., for "Latin-1" language passwords you can use ISO-8859-1, CP850 or
 # CP1252 and it will hardly make any difference but in some cases, ISO-8859-1
 # is faster. Using "UTF-8" (which is not a legacy codepage!) will disable.
 #
@@ -213,7 +213,7 @@ UnicodeStoreUTF8 = Y
 # Always report/store non-Unicode formats as UTF-8, regardless of input
 # encoding. Note: The actual codepage that was used is not stored anywhere
 # except in the log file.
-# This is needed eg. for --loopback to crack LM->NT including non-ASCII.
+# This is needed e.g. for --loopback to crack LM->NT including non-ASCII.
 CPstoreUTF8 = Y
 
 # Default verbosity is 3, valid figures are 1-5 right now.
@@ -227,7 +227,7 @@ Verbosity = 3
 # If set to Y, do not output, log  or store cracked passwords verbatim.
 # This implies a different default .pot database file "secure.pot" instead
 # of "john.pot" but it can still be overridden using --pot=FILE.
-# This also overrides other options, eg. LogCrackedPasswords.
+# This also overrides other options, e.g. LogCrackedPasswords.
 SecureMode = N
 
 # If set to Y, a session using --fork or MPI will signal to other nodes when

--- a/run/jtr_rulez.pm
+++ b/run/jtr_rulez.pm
@@ -886,7 +886,7 @@ sub handle_backref { my ($gnum, $c, $s, $total, $idx) = (@_);
 	# find any \$gnum and replace with $c
 	$s =~ s/\\$gnum/$c/g;
 
-	# find any \p$gnum[] and replace with the $gnum from it's group
+	# find any \p$gnum[] and replace with the $gnum from its group
 	$i = index($s, "\\p$gnum"."[");
 	while ($i >= 0) {
 		my $chars = get_items($s, $i+3, $i2);
@@ -899,7 +899,7 @@ sub handle_backref { my ($gnum, $c, $s, $total, $idx) = (@_);
 		$i = index($s, "\\p$gnum"."[");
 	}
 
-	# find any \p$gnum\r[] and replace with the $gnum from it's non-dedup'd group
+	# find any \p$gnum\r[] and replace with the $gnum from its non-dedup'd group
 	$i = index($s, "\\p$gnum\\r[");
 	while ($i >= 0) {
 		my $chars = get_items($s, $i+5, $i2, 1);

--- a/run/kerberom/README.md
+++ b/run/kerberom/README.md
@@ -70,7 +70,7 @@ optional arguments:
   -v, --verbose         increase verbosity level
   --delta DELTA         set time delta in Kerberos tickets. Useful when DC is
                         not on the same timezone. Format is
-                        "(+/-)hours:minutes:seconds", eg. --delta="+00:05:00"
+                        "(+/-)hours:minutes:seconds", e.g. --delta="+00:05:00"
                         or --delta="-02:00:00"
   -k USER_SID, --user_sid USER_SID
                         force ldap SPN retrieval through kerberos, sid is

--- a/run/kerberom/kerberom.py
+++ b/run/kerberom/kerberom.py
@@ -451,7 +451,7 @@ def parse_arguments():
 
     parser.add_argument('--delta', required=False,
     help="set time delta in Kerberos tickets. Useful when DC is not on the same timezone.\
-    Format is \"(+/-)hours:minutes:seconds\", eg. --delta=\"+00:05:00\" or --delta=\"-02:00:00\"")
+    Format is \"(+/-)hours:minutes:seconds\", e.g. --delta=\"+00:05:00\" or --delta=\"-02:00:00\"")
 
     group2.add_argument('-k', '--user_sid', required=False, help="force ldap SPN\
     retrieval through kerberos, sid is mandatory. Cannot be used with '-i'")

--- a/run/pass_gen.pl
+++ b/run/pass_gen.pl
@@ -400,7 +400,7 @@ if (@ARGV == 1) {
 
 #############################################################################
 # these variables modify outout in output_hash, for 'some' formats. We might
-# upcase the password. The hash may return multple fields in it's 'hash' that
+# upcase the password. The hash may return multple fields in its 'hash' that
 # is returned, so that means we add fewer 'extra' fields prior to the password.
 # also, we may have to insert the user name as field 1.  This function sets
 # 'proper' defaults, so if a hash function does not set anything, it will
@@ -624,7 +624,7 @@ sub str_force_length_pad {
 	$str = substr($str, 0, $_[1]);
 	return $str;
 }
-# every byte of the string has it's bits put into reverse order.
+# every byte of the string has its bits put into reverse order.
 # vnc does this for some reason. But I put into a function so if
 # needed again, we can do this.
 sub str_reverse_bits_in_bytes {

--- a/run/repeats16.conf
+++ b/run/repeats16.conf
@@ -11,7 +11,7 @@
 #
 # Note that these modes will handle --max-len differently than normal: They
 # will consider number of characters as opposed to number of bytes. This
-# means you can naturally just use eg. --max-len=3 for generating all
+# means you can naturally just use e.g. --max-len=3 for generating all
 # three-character candidates (which may be up to 9 bytes each).
 [List.External:Repeats16]
 int minlength, maxlength, maxc, length, c;

--- a/run/repeats32.conf
+++ b/run/repeats32.conf
@@ -11,7 +11,7 @@
 #
 # Note that these modes will handle --max-len differently than normal: They
 # will consider number of characters as opposed to number of bytes. This
-# means you can naturally just use eg. --max-len=3 for generating all
+# means you can naturally just use e.g. --max-len=3 for generating all
 # three-character candidates (which may be up to 12 bytes each).
 #
 # Also note that for UTF-16 formats, the resulting plaintext size within the

--- a/src/cmpt_cp.pl
+++ b/src/cmpt_cp.pl
@@ -173,7 +173,7 @@ foreach my $i (0x80..0xFF) {
 				if ($nfd =~ m/[aoueiyœæøɪʏɛɔαεηιοωυаэыуояеюиєіı]/i) {
 					$vowels .= sprintf("\\x%02X", $i);
 					$cvowels .= $c;
-					# Note eg. in English, y depends on situation
+					# Note, e.g., in English, y depends on situation
 					# (yellow, happy). We set latin yY variants as both!
 					if ($nfd =~ m/y/i) {
 						$consonants .= sprintf("\\x%02X", $i);

--- a/src/dynamic_compiler.c
+++ b/src/dynamic_compiler.c
@@ -18,8 +18,8 @@
  *    This expression language will be very similar to the expression language in pass_gen.pl
  *
  *  Valid items in EXPR
- *     md5(EXPR)   Perform MD5.   Results in lowcase hex (unless it's the outter EXPR)
- *     sha1(EXPR)  Perform SHA1.  Results in lowcase hex (unless it's the outter EXPR)
+ *     md5(EXPR)   Perform MD5.   Results in lowcase hex (unless it's the outer EXPR)
+ *     sha1(EXPR)  Perform SHA1.  Results in lowcase hex (unless it's the outer EXPR)
  *     md4(EXPR), sha256(EXPR), sha224(EXPR), sha384(EXPR), sha512(EXPR), gost(EXPR),
  *     whirlpool(EXPR) tiger(EXPR), ripemd128(EXPR), ripemd160(EXPR), ripemd256(EXPR),
  *     ripemd320(EXPR) all act like md5() and sha1, but use the hash listed.
@@ -800,7 +800,7 @@ static const char *comp_get_symbol(const char *pInput) {
 					  return comp_push_sym(TmpBuf, fpNull, pInput+3, 0);
 		}
 	}
-	// these are functions, BUT can not be used for 'outter' function (i.e. not the final hash)
+	// these are functions, BUT can not be used for 'outer' function (i.e. not the final hash)
 	// Note this may 'look' small, but it is a large IF block, once the macro's expand
 	LastTokIsFunc = 1;
 	LOOKUP_IF_BLK(md5,MD5,5,5,3,16)
@@ -1849,7 +1849,7 @@ static int parse_expression(DC_struct *p) {
 									if (inp_cnt) max_inp_len -= (len_comp-239+(inp_cnt-1))/inp_cnt;
 									else max_inp_len = (239-len_comp);
 									if (max_inp_len <= 0)
-										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a 64 bit SIMD subexpression that is longer than the 239 byte max. It's length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 239-max_inp_len);
+										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a 64 bit SIMD subexpression that is longer than the 239 byte max. Its length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 239-max_inp_len);
 								}
 							} else if (!strncasecmp(pCode[i], "f5", 2 ) || !strncasecmp(pCode[i], "f4", 2) ||
 									   !strncasecmp(pCode[i], "f1", 2) || !strncasecmp(pCode[i], "f224", 4 ) ||
@@ -1859,7 +1859,7 @@ static int parse_expression(DC_struct *p) {
 									if (inp_cnt) max_inp_len -= (len_comp-247+(inp_cnt-1))/inp_cnt;
 									else max_inp_len = (247-len_comp);
 									if (max_inp_len <= 0)
-										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a 32 bit SIMD subexpression that is longer than the 247 byte max. It's length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 247-max_inp_len);
+										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a 32 bit SIMD subexpression that is longer than the 247 byte max. Its length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 247-max_inp_len);
 								}
 							} else {
 								// non SIMD code can use full 256 byte buffers.
@@ -1867,7 +1867,7 @@ static int parse_expression(DC_struct *p) {
 									if (inp_cnt) max_inp_len -= (len_comp-256+(inp_cnt-1))/inp_cnt;
 									else max_inp_len = (256-len_comp);
 									if (max_inp_len <= 0)
-										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a subexpression that is longer than the 256 byte max. It's length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 256-max_inp_len);
+										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a subexpression that is longer than the 256 byte max. Its length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 256-max_inp_len);
 
 								}
 							}
@@ -1883,7 +1883,7 @@ static int parse_expression(DC_struct *p) {
 									if (inp_cnt2) max_inp_len -= (len_comp2-239+(inp_cnt2-1))/inp_cnt2;
 									else max_inp_len = (239-len_comp2);
 									if (max_inp_len <= 0)
-										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a 64 bit SIMD subexpression that is longer than the 239 byte max. It's length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 239-max_inp_len);
+										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a 64 bit SIMD subexpression that is longer than the 239 byte max. Its length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 239-max_inp_len);
 								}
 							} else if (!strncasecmp(pCode[i], "f5", 2 ) || !strncasecmp(pCode[i], "f4", 2) ||
 									   !strncasecmp(pCode[i], "f1", 2) || !strncasecmp(pCode[i], "f224", 4 ) ||
@@ -1893,7 +1893,7 @@ static int parse_expression(DC_struct *p) {
 									if (inp_cnt2) max_inp_len -= (len_comp2-247+(inp_cnt2-1))/inp_cnt2;
 									else  max_inp_len = (247-len_comp2);
 									if (max_inp_len <= 0)
-										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a 32 bit SIMD subexpression that is longer than the 247 byte max. It's length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 247-max_inp_len);
+										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a 32 bit SIMD subexpression that is longer than the 247 byte max. Its length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 247-max_inp_len);
 								}
 							} else {
 								// non SIMD code can use full 256 byte buffers.
@@ -1901,7 +1901,7 @@ static int parse_expression(DC_struct *p) {
 									if (inp_cnt2) max_inp_len -= (len_comp2-256+(inp_cnt2-1))/inp_cnt2;
 									else max_inp_len = (256-len_comp2);
 									if (max_inp_len <= 0)
-										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a subexpression that is longer than the 256 byte max. It's length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 256-max_inp_len);
+										error_msg("This expression can not be handled by the Dynamic engine.\nThere is a subexpression that is longer than the 256 byte max. Its length is %d bytes long, even with 0 byte PLAINTEXT_LENGTH\n", 256-max_inp_len);
 								}
 							}
 							len_comp2 = 0;

--- a/src/formats.h
+++ b/src/formats.h
@@ -72,7 +72,7 @@ struct db_salt;
 #define FMT_UTF8			0x00000008
 /*
  * Mark password->binary = NULL immediately after a hash is cracked. Must be
- * set for formats that reads salt->list in crypt_all for the purpose of
+ * set for formats that read salt->list in crypt_all for the purpose of
  * identification of uncracked hashes for this salt.
  */
 #define FMT_REMOVE			0x00000010

--- a/src/gpu_sensors.h
+++ b/src/gpu_sensors.h
@@ -1,6 +1,6 @@
 /*
  * Glue for NVIDIA and AMD hardware sensors' libs. This is a subset of
- * typedefs and defines for eg. JtR and is distributed under the "fair use"
+ * typedefs and defines for e.g. JtR and is distributed under the "fair use"
  * doctrine. For complete headers and documentation, see respective vendor's
  * SDK.
  *

--- a/src/mask.c
+++ b/src/mask.c
@@ -213,7 +213,7 @@ static char* plhdr2string(char p, int fmt_case)
 
 	/*
 	 * Force lowercase for case insignificant formats. Dupes will
-	 * be removed, so eg. ?l?u == ?l.
+	 * be removed, so e.g. ?l?u == ?l.
 	 */
 	if (!fmt_case) {
 		if (p == 'u')
@@ -937,7 +937,7 @@ static char* plhdr2string(char p, int fmt_case)
  * brackets are already given, as in [?d], output is still [0123456789]
  *
  * This function must pass any escaped characters on, as-is (still escaped).
- * It may also have to ADD escapes to ranges produced from eg. ?s.
+ * It may also have to ADD escapes to ranges produced from e.g. ?s.
  */
 static char* expand_plhdr(char *string, int fmt_case)
 {
@@ -1986,7 +1986,7 @@ char *stretch_mask(char *mask, mask_parsed_ctx *parsed_mask)
  * Note that de-hex comes after UTF-8 conversion so any 8-bit hex escaped
  * characters will be parsed as the *internal* encoding.
  *
- * Hex characters *can* compose ranges, eg. "\x80-\xff", but can not end up as
+ * Hex characters *can* compose ranges, e.g. "\x80-\xff", but can not end up as
  * placeholders. Eg. "\x3fd" ("?d" after de-hex) must be parsed literally as
  * "?d" and not a digits range.
  *

--- a/src/opencl_aes.h
+++ b/src/opencl_aes.h
@@ -27,7 +27,7 @@
 #define OCL_AES_DECRYPT 1
 #endif
 
-/* These default to __private but can be eg. __global */
+/* These default to __private but can be e.g. __global */
 #ifndef AES_KEY_TYPE
 #define AES_KEY_TYPE const
 #endif

--- a/src/opencl_sha1.h
+++ b/src/opencl_sha1.h
@@ -447,7 +447,7 @@
 
 /*
  * The extra a, b, c, d, e variables are a workaround for a really silly
- * AMD bug (seen in eg. Catalyst 14.9). We should really do without them
+ * AMD bug (seen in e.g. Catalyst 14.9). We should really do without them
  * but somehow we get thrashed output without them.
  * On the other hand, they also seem to work as an optimization for nvidia!
  */

--- a/src/options.c
+++ b/src/options.c
@@ -535,7 +535,7 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 		}
 	}
 
-	/* Bodge for bash completion of eg. "john -stdout -list=..." */
+	/* Bodge for bash completion of e.g. "john -stdout -list=..." */
 	if (options.listconf != NULL && options.fork == 0)
 		options.flags |= (FLG_CRACKING_SUP | FLG_STDIN_SET);
 

--- a/src/pkzip.c
+++ b/src/pkzip.c
@@ -119,7 +119,7 @@ int winzip_common_valid(char *ciphertext, struct fmt_main *self)
 	if ((cp = strtokm(NULL, "*")) == NULL || !ishexlc(cp) || strlen((char*)cp) != WINZIP_BINARY_SIZE<<1)  {
 		sFailStr = "Authentication data invalid (not hex number), or not 20 hex characters"; goto Bail; }
 
-	// Ok, now if we have to pull from .zip file, lets do so, and we can validate with the authentication bytes
+	// Ok, now if we have to pull from .zip file, let's do so, and we can validate with the authentication bytes
 	if (zip_file_validate) {
 		sFailStr = ValidateZipFileData(Fn, Oh, Ob, val, cp);
 		if (*sFailStr) {

--- a/src/rules.c
+++ b/src/rules.c
@@ -103,7 +103,7 @@ static struct {
 	char *classes[0x100];
 } CC_CACHE_ALIGN rules_data;
 
-/* A null string that is safe to read past (for eg. ASan) */
+/* A null string that is safe to read past (e.g. for ASan) */
 static char safe_null_string[RULE_BUFFER_SIZE];
 
 #define rules_pass rules_data.pass

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -102,7 +102,7 @@ void sha1_unreverse3(uint32_t *hash);
 #define SHA1_ALGORITHM_NAME		"32/" ARCH_BITS_STR
 #endif
 
-// we use the 'outter' SIMD_COEF_32 wrapper, as the flag for SHA256/SHA512.  FIX_ME!!
+// we use the 'outer' SIMD_COEF_32 wrapper, as the flag for SHA256/SHA512.  FIX_ME!!
 #if SIMD_COEF_32 > 1
 
 #ifdef SIMD_COEF_32

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -101,10 +101,10 @@ extern const char opt_trailingBytesUTF8[64];
 /*
  * Convert to UTF-16LE from UTF-8.
  * 'maxtargetlen' is max. number of characters (as opposed to bytes) in output,
- * eg. PLAINTEXT_LENGTH.
+ * e.g. PLAINTEXT_LENGTH.
  * 'sourcelen' can be strlen(source).
  * Returns number of UTF16 characters (as opposed to bytes) of resulting
- * output. If return is negative, eg. -32, it means 32 characters of INPUT were
+ * output. If return is negative, e.g. -32, it means 32 characters of INPUT were
  * used and then we had to truncate. Either because we ran out of maxtargetlen,
  * or because input was not valid after that point (eg. illegal UTF-8 sequence).
  * To get the length of output in that case, use strlen16(target).
@@ -119,10 +119,10 @@ extern int utf8_to_utf16_be(UTF16 *target, unsigned int len, const UTF8 *source,
 /*
  * Convert to UTF-16LE from whatever encoding is used (--encoding aware).
  * 'maxdstlen' is max. number of characters (as opposed to bytes) in output,
- * eg. PLAINTEXT_LENGTH.
+ * e.g. PLAINTEXT_LENGTH.
  * 'srclen' can be strlen(src).
  * Returns number of UTF16 characters (as opposed to bytes) of resulting
- * output. If return is negative, eg. -32, it means 32 characters of INPUT were
+ * output. If return is negative, e.g. -32, it means 32 characters of INPUT were
  * used and then we had to truncate. Either because we ran out of maxdstlen, or
  * because input was not valid after that point (eg. illegal UTF-8 sequence).
  * To get the length of output in that case, use strlen16(dst).

--- a/src/unused/locktest.sh
+++ b/src/unused/locktest.sh
@@ -4,7 +4,7 @@
 #
 # NOTE: If you use NFS, there's more to it than running just this test script:
 # An NFS mount should be tested first by running this script on the server (on
-# it's real filesystem, eg. ext4) and then on a client, and lastly by locking
+# its real filesystem, e.g., ext4) and then on a client, and lastly by locking
 # a file on the server (eg. using "flock -x .lockfile sleep 300") and while
 # that lock is in place, run this script on a client in whatever mounted
 # directory is pointing to the *same* "physical" directory on the server.


### PR DESCRIPTION
### Summary

Some spelling and grammar fixes  in docs, comments, and string literals, and removing remaining CUDA references from doc/BUGS.