### PR TITLE
racf2john update to dump KDFAES hashes

### DIFF
--- a/src/racf2john.c
+++ b/src/racf2john.c
@@ -14,7 +14,19 @@
  * vectors, algorithm details, RACF sample database  and requesting the
  * RACF cracker in the first place.
  *
- * racfdump format => userid:$racf$*userid*deshash  */
+ * racfdump format => userid:$racf$*userid*deshash
+ *
+ ***********************************************************************************
+ * update   4/10/16  BeS - added support to dump racf-kdfaes style password10      *
+ * hashes, in addition to fixing the extraction of the old algorithm so that       *
+ * only active profiles are dumped.                                                *
+ *                                                                                 *
+ *  TODO - add option to dump password history (could be useful) hashes as well    *
+ *                                                                                 *
+ * racfdump format(racf-kdfaes) => userid:$racf$*userid*racf-kdfaes                *
+ ***********************************************************************************
+ *
+ */
 
 #if AC_BUILT
 #include "autoconfig.h"
@@ -31,9 +43,17 @@
 #if (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER
 #include <unistd.h>
 #endif
+#include <stdint.h>
 #include "memory.h"
 #include "memdbg.h"
 
+#define T_EMPTY 0
+#define T_DES 1
+#define T_KDFAES 2
+#define false 0
+#define true 1
+
+// table to convert EBCDIC to ASCII
 static unsigned char e2a[256] = {
 	0,  1,  2,  3,156,  9,134,127,151,141,142, 11, 12, 13, 14, 15,
 	16, 17, 18, 19,157,133,  8,135, 24, 25,146,143, 28, 29, 30, 31,
@@ -53,32 +73,104 @@ static unsigned char e2a[256] = {
 	48, 49, 50, 51, 52, 53, 54, 55, 56, 57,250,251,252,253,254,255
 };
 
+// pretty hex printing of resulting hash
 static void print_hex(unsigned char *str, int len)
 {
-        int i;
-        for (i = 0; i < len; ++i)
-                printf("%02X", str[i]);
+	int i;
+	for (i = 0; i < len; ++i)
+		printf("%02X", str[i]);
 }
 
-static void print_userid(unsigned char *s)
+// assumes ebcdic input and prints result as ascii
+static void print_ebcdic(unsigned char *s, int len)
 {
 	int i;
 	for (i = 0; s[i] != 0x02; i++)
 		printf("%c", e2a[s[i]]);
 }
 
+// found a valid user record, search for a DES or KDFAES password hash (no passphrases at this point)
+static void process_user_rec(unsigned char * up, uint16_t len, unsigned char * pn, uint8_t pnl) {
+	char passf[2] = {12,100};  // only finds passwords (not phrases) at this time; both DES and KDFAES
+	char fn;
+	uint16_t fl;
+	uint16_t x=0;
+	int found = T_EMPTY;
+	int rpt = false;
+	unsigned char * h1;
+	uint8_t h1_len;
+	unsigned char * h2;
+	uint8_t h2_len;
 
+	while (x<len) {
+		fn = up[x];
+		fl = (uint8_t)up[x+1];
+
+		if ((fl >> 7) == 1) {  // handles repeating fields
+			fl = ((up[x+1] << 24 ) + (up[x+2] << 16) + (up[x+3] << 8) + (up[x+4]));
+			rpt = true;
+		}
+
+		if (!rpt && fn == passf[0]) { // do we have a password field? (both hash types)
+			if (fl == 8) {
+				h1 = &up[x+2];
+				h1_len = 8;
+				found = T_DES;
+			}
+		} else if (!rpt && fn == passf[1]) { // do we have an extended pass field (kdfaes)
+			if (fl == 40) {
+				found = T_KDFAES;
+				h2 = &up[x+2];
+				h2_len = 40;
+			}
+		}
+
+		if (rpt) {
+			x=x+fl+5;
+			rpt = false;
+		} else {
+			x=x+fl+2;
+		}
+
+	}
+	if (found==T_DES) {
+		found = T_EMPTY;
+		print_ebcdic(pn,pnl);
+		printf(":$racf$*");
+		print_ebcdic(pn,pnl);
+		printf("*");
+		print_hex(h1,h1_len);
+		printf("\n");
+
+	} else if (found==T_KDFAES) {
+		found = T_EMPTY;
+		print_ebcdic(pn,pnl);
+		printf(":$racf$*");
+		print_ebcdic(pn,pnl);
+		printf("*");
+		print_hex(h2,h2_len);
+		print_hex(h1,h1_len);
+		printf("\n");
+	}
+}
+
+// process raw racf database file (assumed downloaded binary from z/os)
 static void process_file(const char *filename)
 {
 	FILE *fp = fopen(filename, "r");
 	struct stat sb;
 	unsigned char *buffer;
 	off_t size;
-	unsigned char userid[9];
-	int i, j, count;
-	int offset;
+	int i,count=0;
+	unsigned char *user_prof;
+	uint32_t user_rec_addr = 0;
+	uint16_t user_rec_len = 0;
+	uint16_t header_len = 0;
+	uint16_t profile_len = 0;
+	uint8_t profile_name_len = 0;
+	unsigned char *profile_name = 0;
 
-	if (stat(filename, &sb) == -1) {
+	if(stat(filename, &sb) == -1) {
 		perror("stat");
 		exit(EXIT_FAILURE);
 	}
@@ -88,31 +180,32 @@ static void process_file(const char *filename)
 	count = fread(buffer, size, 1, fp);
 	assert(count == 1);
 
-	for (i = 7; i < size - 62; i++) {
-		if (buffer[i-7] == 0xc2 && buffer[i-6] == 0xc1 &&
-			buffer[i-5] == 0xe2 && buffer[i-4] == 0xc5 &&
-			buffer[i-3] == 0x40 && buffer[i-2] == 0x40 &&
-			buffer[i-1] == 0x40 && buffer[i] == 0x40 &&
-			buffer[i+1] == 0 && buffer[i+2] < 9 &&
-			buffer[i+3] == 0 ) {
-			offset = buffer[i+2];
+	// our initial check below checks 7 char ahead of our i ctr, so start at i=7
+	i = 7;
 
-			if (buffer[i+offset+44] == 8 && buffer[i+offset+53] == 0xd) {
-				/* userid begins at index i + 4 */
-				int index = 0;
-				for (j = i + 4; buffer[j] != 0x02 && index < 9; j++)
-					userid[index++] = buffer[j];
-				userid[index] = 0x02;
-				print_userid(userid);
-				printf(":$racf$*");
-				print_userid(userid);
-				printf("*");
-				/* DES hash at index (i + offset + 44) */
-				print_hex(&buffer[i+offset+45], 8);
-				printf("\n");
+	// this brute force finds profiles, whether active or disabled and dumps their primary hashes
+	while (i < size) {
+		if (buffer[i-7] == 0xc2 && buffer[i-6] == 0xc1 &&		//"BA"
+				buffer[i-5] == 0xe2 && buffer[i-4] == 0xc5 &&	//"SE"
+				buffer[i-3] == 0x40 && buffer[i-2] == 0x40 &&	//"  "
+				buffer[i-1] == 0x40 && buffer[i] == 0x40 &&		//"  "
+				buffer[i+1] == 0 && buffer[i+2] < 9 &&			//null + total namelen < 9
+				buffer[i+3] == 0 ) {							//null
+
+			user_rec_addr = i-16;
+			user_rec_len = (((uint8_t)buffer[i-9]) << 8) + (uint8_t)buffer[i-8];
+			profile_name_len = (uint8_t)buffer[i+2];
+			profile_name = &buffer[i+4];
+			header_len = (i+4+profile_name_len) - user_rec_addr;
+			profile_len = user_rec_len - header_len;
+			user_prof = &buffer[user_rec_addr + header_len];
+			if (user_prof[0] == 0x02) {
+				process_user_rec(user_prof,profile_len,profile_name,profile_name_len);
 			}
 		}
+		i++;
 	}
+	// clean up and exit
 	MEM_FREE(buffer);
 	fclose(fp);
 }


### PR DESCRIPTION
### Summary

racf2john currently dumps DES RACF hashes, this update
allows it to also dump the newer type (2014) KDFAES hashes.

The new password algorithm announcement can be found here:
https://www-01.ibm.com/support/docview.wss?uid=isg1OA43999

### The new output looks like:
```
sh-4.4$ run/racf2john
Usage: racf2john [RACF binary files]

sh-4.4$ run/racf2john ./testdb.bin
BBBBBBB:$racf$*BBBBBBB*932C1BBBB12A8274
C123456:$racf$*C123456*50A4B524A1854E38
A123456:$racf$*A123456*E7D7E66D00018000000800320010001041E09CD903BD84255D547CC162DCC1EC135D5D0AF2961EE5DD01B5FF489D2776
B123456:$racf$*B123456*E7D7E66D0001800000080032001000103D743EDF9DB18E2762E9C3F801672954A787F176DCF675EBE303B463FC81775A
```
The short hashes are DES and are currently supported by John for cracking.
The longer hashes are not yet supported by John, but do represent the KDFAES format.

