### PR TITLE
Various bitlocker2john.c cleanups

### DIFF
--- a/src/bitlocker2john.c
+++ b/src/bitlocker2john.c
@@ -1,16 +1,15 @@
-/* bitlocker2john utility written in February of 2017 by Elenago <elena dot ago at gmail dot com>.
- * bitlocker2john processes input memory images encrypted with BitLocker. by means of a password,
- * into a format suitable for use with JtR. This software
- * is Copyright (c) 2017, Elenago <elena dot ago at gmail dot com> and it
- * is hereby released under GPLv2 license.
- * This is a research project, therefore please cite or contact me if you want to use it
+/*
+ * bitlocker2john processes input disk images encrypted with BitLocker, by
+ * means of a password, into a format suitable for use with JtR.
+ *
+ * This software is Copyright (c) 2017, Elenago <elena dot ago at gmail dot com> and
+ * it is hereby released under GPLv2 license.
  *
  * bitlocker2john is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * More informations here: http://openwall.info/wiki/john/OpenCL-BitLocker
- *
  */
 
 #if AC_BUILT
@@ -29,60 +28,29 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #if  (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER
-#include <unistd.h>             // getopt defined here for unix
+#include <unistd.h> // getopt defined here for unix
 #endif
 #include "params.h"
 #include "memory.h"
 #include "memdbg.h"
 
-#include "sha2.h"
-#include "base64.h"
-
-#define BITLOCKER_HASH_SIZE 8   //32
-#define BITLOCKER_ROUND_SHA_NUM 64
-#define BITLOCKER_SINGLE_BLOCK_SHA_SIZE 64
-#define BITLOCKER_SINGLE_BLOCK_W_SIZE 64
-#define BITLOCKER_PADDING_SIZE 40
-#define BITLOCKER_ITERATION_NUMBER 0x100000
-#define BITLOCKER_WORD_SIZE 4
-#define BITLOCKER_INPUT_SIZE 512
-#define BITLOCKER_FIXED_PART_INPUT_CHAIN_HASH 88
-#define BITLOCKER_BLOCK_UNIT 32
-#define BITLOCKER_HASH_SIZE_STRING 32
-#define BITLOCKER_MAX_INPUT_PASSWORD_LEN 16
-#define BITLOCKER_MIN_INPUT_PASSWORD_LEN 8
-
-#define AUTHENTICATOR_LENGTH 16
-#define AES_CTX_LENGTH 256
-#define FALSE 0
-#define TRUE 1
 #define BITLOCKER_SALT_SIZE 16
 #define BITLOCKER_NONCE_SIZE 12
-#define BITLOCKER_IV_SIZE 16
 #define BITLOCKER_VMK_SIZE 44
 #define BITLOCKER_MAC_SIZE 16
-#ifndef UINT32_C
-#define UINT32_C(c) c ## UL
-#endif
 
 static unsigned char salt[BITLOCKER_SALT_SIZE],
-       nonce[BITLOCKER_NONCE_SIZE], 
-       mac[BITLOCKER_MAC_SIZE],
-       encryptedVMK[BITLOCKER_VMK_SIZE];
-
-static void fillBuffer(FILE *fp, unsigned char *buffer, int size);
-
-static char *outFile = NULL;
+		nonce[BITLOCKER_NONCE_SIZE],
+		mac[BITLOCKER_MAC_SIZE],
+		encryptedVMK[BITLOCKER_VMK_SIZE];
 
 static void fillBuffer(FILE *fp, unsigned char *buffer, int size)
 {
 	int k;
 
-	for (k = 0; k < size; k++) {
+	for (k = 0; k < size; k++)
 		buffer[k] = (unsigned char)fgetc(fp);
-	}
 }
-
 
 static void print_hex(unsigned char *str, int len)
 {
@@ -92,22 +60,9 @@ static void print_hex(unsigned char *str, int len)
 		printf("%02x", str[i]);
 }
 
-static void warn_exit(const char *fmt, ...)
-{
-	va_list ap;
-
-	va_start(ap, fmt);
-	if (fmt != NULL)
-		vfprintf(stderr, fmt, ap);
-	va_end(ap);
-	fprintf(stderr, "\n");
-
-	exit(EXIT_FAILURE);
-}
-
 static void process_encrypted_image(char *encryptedImagePath)
 {
-	FILE *encryptedImage, *ofp;
+	FILE *encryptedImage;
 
 	int match = 0;
 	char signature[8] = "-FVE-FS-";
@@ -136,43 +91,40 @@ static void process_encrypted_image(char *encryptedImagePath)
 		}
 		if (i == 8) {
 			match = 1;
-			printf("Signature found at 0x%08lx\n",
-			       (ftell(encryptedImage) - i - 1));
+			fprintf(stderr, "Signature found at 0x%08lx\n",
+					(ftell(encryptedImage) - i - 1));
 			fseek(encryptedImage, 1, SEEK_CUR);
 			version = fgetc(encryptedImage);
-			printf("Version: %d ", version);
+			fprintf(stderr, "Version: %d ", version);
 			if (version == 1)
-				printf("(Windows Vista)\n");
+				fprintf(stderr, "(Windows Vista)\n");
 			else if (version == 2)
-				printf("(Windows 7 or later)\n");
+				fprintf(stderr, "(Windows 7 or later)\n");
 			else {
-				printf
-				("\nInvalid version, looking for a signature with valid version..\n");
+				fprintf
+					(stderr, "\nInvalid version, looking for a signature with valid version...\n");
 			}
 		}
 		i = 0;
-		while ( i < 4 && (unsigned char)c == vmk_entry[i]) {
+		while (i < 4 && (unsigned char)c == vmk_entry[i]) {
 			c = fgetc(encryptedImage);
 			i++;
 		}
 		if (i == 4) {
-			printf("VMK entry found at 0x%08lx\n",
-			       (ftell(encryptedImage) - i - 3));
+			fprintf(stderr, "VMK entry found at 0x%08lx\n",
+					(ftell(encryptedImage) - i - 3));
 			fseek(encryptedImage, 27, SEEK_CUR);
 			if (
-				((unsigned char)fgetc(encryptedImage) == key_protection_type[0]) &&
-			    ((unsigned char)fgetc(encryptedImage) == key_protection_type[1])
-			)
-			{
-				printf("Key protector with user password found\n");
-				//SALT
+					((unsigned char)fgetc(encryptedImage) == key_protection_type[0]) &&
+					((unsigned char)fgetc(encryptedImage) == key_protection_type[1])
+			   ) {
+				fprintf(stderr, "Key protector with user password found\n");
 				fseek(encryptedImage, 12, SEEK_CUR);
 				fillBuffer(encryptedImage, salt, BITLOCKER_SALT_SIZE);
-
 				fseek(encryptedImage, 83, SEEK_CUR);
 				if (((unsigned char)fgetc(encryptedImage) != value_type[0]) ||
-				        ((unsigned char)fgetc(encryptedImage) != value_type[1])) {
-					warn_exit("Error: VMK not encrypted with AES-CCM\n");
+						((unsigned char)fgetc(encryptedImage) != value_type[1])) {
+					fprintf(stderr, "Error: VMK not encrypted with AES-CCM\n");
 				}
 				fseek(encryptedImage, 3, SEEK_CUR);
 				fillBuffer(encryptedImage, nonce, BITLOCKER_NONCE_SIZE);
@@ -186,75 +138,37 @@ static void process_encrypted_image(char *encryptedImagePath)
 	}
 	fclose(encryptedImage);
 	if (match == 0) {
-		warn_exit("Error while extracting data: No signature found!\n");
+		fprintf(stderr, "Error while extracting data: No signature found!\n");
 	} else {
-		printf("\n\nBitLocker-OpenCL format hash: $bitlocker$");
-		print_hex(nonce, BITLOCKER_NONCE_SIZE);
-		printf("$");
+		unsigned char padding[16] = {0};
+		printf("%s:$bitlocker$0$%d$", encryptedImagePath, BITLOCKER_SALT_SIZE);
 		print_hex(salt, BITLOCKER_SALT_SIZE);
-		printf("$");
-		print_hex(encryptedVMK, 1);
-		print_hex(encryptedVMK + 1, 1);
-		print_hex(encryptedVMK + 8, 1);
-		print_hex(encryptedVMK + 9, 1);
-		printf("\n\n");
-
-		if (outFile) {
-			ofp = fopen(outFile, "w");
-			if (!ofp) {
-				fprintf(stderr, "! %s : %s\n", outFile, strerror(errno));
-				return;
-			}
-			//This is super ugly...!
-			fprintf(ofp,
-			        "$bitlocker$%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x$%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x$%02x%02x%02x%02x\n",
-			        nonce[0], nonce[1], nonce[2], nonce[3], nonce[4], nonce[5],
-			        nonce[6], nonce[7], nonce[8], nonce[9], nonce[10], nonce[11],
-			        salt[0], salt[1], salt[2],
-			        salt[3], salt[4], salt[5],
-			        salt[6], salt[7], salt[8],
-			        salt[9], salt[10], salt[11],
-			        salt[12], salt[13], salt[14],
-			        salt[15], encryptedVMK[0], encryptedVMK[1],
-			        encryptedVMK[8], encryptedVMK[9]);
-
-			fclose(ofp);
-		}
+		printf("$%d$%d$", 0x100000, BITLOCKER_NONCE_SIZE); // fixed iterations , fixed nonce size
+		print_hex(nonce, BITLOCKER_NONCE_SIZE);
+		printf("$%d$", BITLOCKER_VMK_SIZE + 16);
+		print_hex(padding, 16); // hack, this should actually be entire AES-CCM encrypted block (which includes encryptedVMK)
+		print_hex(encryptedVMK, BITLOCKER_VMK_SIZE);
+		printf("\n");
 	}
 }
 
 static int usage(char *name)
 {
 	fprintf(stderr,
-	        "Usage: %s [-o <output_file>] <BitLocker Encrypted Memory Image>\n",
-	        name);
+			"Usage: %s <BitLocker Encrypted Disk Image(s)>\n",
+			name);
 
 	return EXIT_FAILURE;
 }
 
 int bitlocker2john(int argc, char **argv)
 {
-	int c;
-
 	errno = 0;
 
-	/* Parse command line */
-	while ((c = getopt(argc, argv, "o:")) != -1) {
-		switch (c) {
-		case 'o':
-			outFile = (char *)mem_alloc(strlen(optarg) + 1);
-			strcpy(outFile, optarg);
-			break;
-		case '?':
-		default:
-			return usage(argv[0]);
-		}
-	}
-	argc -= optind;
-	if (argc == 0)
+	if (argc < 2)
 		return usage(argv[0]);
-	argv += optind;
-
+	argv++;
+	argc--;
 	while (argc--)
 		process_encrypted_image(*argv++);
 


### PR DESCRIPTION
This PR enables `bitlocker2john.c` to generate hashes compatible with the BitLocker CPU format. The BitLocker GPU format will need to be modified to use this new hash format.

@e-ago Please review this. Do you have enough information now to modify the GPU format suitably?