### PR TITLE
racf2john: mute a compiler warning

### DIFF
--- a/src/racf2john.c
+++ b/src/racf2john.c
@@ -97,9 +97,9 @@ static void process_user_rec(unsigned char * up, uint16_t len, unsigned char * p
 	uint16_t x=0;
 	int found = T_EMPTY;
 	int rpt = false;
-	unsigned char * h1;
+	unsigned char * h1 = NULL;
 	uint8_t h1_len;
-	unsigned char * h2;
+	unsigned char * h2 = NULL;
 	uint8_t h2_len;
 
 	while (x<len) {


### PR DESCRIPTION
Since my CI builds use 'Werror' enabled, this change is needed.