### PR TITLE
Use OS X support in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,28 +10,42 @@ env:
 
 matrix:
   include:
-  - compiler: gcc
+  - os: linux
+    compiler: gcc
     env: ASAN="--enable-asan" OPENCL="yes"
 
-  - compiler: clang
+  - os: linux
+    compiler: clang
     env: ASAN="" OPENCL="yes"
 
-  - env: ASAN="--enable-asan" TEST="fresh test"
+  - os: linux
+    env: ASAN="--enable-asan" TEST="fresh test"
 
-  - env: ASAN="" TEST="TS --restore"
+  - os: linux
+    env: ASAN="" TEST="TS --restore"
 
-  - env: ASAN="" TEST="no OpenMP" OPENCL="yes"
+  - os: linux
+    env: ASAN="" TEST="no OpenMP" OPENCL="yes"
+
+  - os: osx
+    osx_image: xcode8.3
+    env: ASAN="" OPENCL="yes"
 
   allow_failures:
-  - env: ASAN="--enable-asan" OPENCL="yes"
+  - os: linux
+    env: ASAN="--enable-asan" OPENCL="yes"
 
-  - env: ASAN="" OPENCL="yes"
+  - os: linux
+    env: ASAN="" OPENCL="yes"
 
-  - env: ASAN="--enable-asan" TEST="fresh test"
+  - os: linux
+    env: ASAN="--enable-asan" TEST="fresh test"
 
-  - env: ASAN="" TEST="TS --restore"
+  - os: linux
+    env: ASAN="" TEST="TS --restore"
 
-  - env: ASAN="" TEST="no OpenMP" OPENCL="yes"
+  - os: linux
+    env: ASAN="" TEST="no OpenMP" OPENCL="yes"
 
   fast_finish: true
 

--- a/.travis/check.sh
+++ b/.travis/check.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-if [[ -z "$TEST" ]]; then
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    # brew install --force openssl
+    cd src
+
+    ./configure CPPFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib"
+    make -sj4
+
+    ../.travis/test.sh
+
+elif [[ -z "$TEST" ]]; then
     cd src
 
     # Build and run with the address sanitizer instrumented code


### PR DESCRIPTION
This PR enables building of JtR on OS X. The building and testing on OS X completes in under 8 minutes, it seems.

This fixes issue https://github.com/magnumripper/JohnTheRipper/issues/2454.