### PR TITLE
All FreeBSD GELI versions (v0 to v7) are supported now

### DIFF
--- a/run/geli2john.py
+++ b/run/geli2john.py
@@ -20,10 +20,14 @@ from binascii import hexlify
 
 G_ELI_MAGIC = b"GEOM::ELI"
 CRYPTO_AES_XTS = 22
+CRYPTO_AES_CBC = 11
 
-# struct g_eli_metadata
+# struct g_eli_metadata (v1 to v7)
 g_eli_metadata_fmt = '< 16s I I H H H Q I B i 64s 384s 16s'
 g_eli_metadata_size = struct.calcsize(g_eli_metadata_fmt)
+
+g_eli_metadata_v0_fmt = '< 16s I I H H Q I B i 64s 384s 16s'  # H -> md_aalgo is not there
+g_eli_metadata_v0_size = struct.calcsize(g_eli_metadata_v0_fmt)
 
 
 def process_file(filename):
@@ -45,15 +49,25 @@ def process_file(filename):
         sys.stderr.write(sfilename + " : could not find magic value!\n")
         return
 
+    # See eli_metadata_decode_v1v2v3v4v5v6v7 and eli_metadata_decode_v0 in
+    # upstream g_eli.h file. It is hard to see GELI v1 and v2 in practice.
+    # FreeBSD 6.0 and 6.1 use v0, whereas FreeBSD 6.2 uses v3.
+
+    # GELI v1 to v7
     header = struct.unpack(g_eli_metadata_fmt, data[:g_eli_metadata_size])
     (md_magic, md_version, md_flags, md_ealgo, md_keylen, md_aalgo, md_provsize,
      md_sectorsize, md_keys, md_iterations, md_salt, md_mkeys, md_hash) = header
 
-    if md_version != 7:  # we should be able to support v1 to v7 easily, check this
+    if md_version == 0:  # special handling for GELI v0
+        header = struct.unpack(g_eli_metadata_v0_fmt, data[:g_eli_metadata_v0_size])
+        (md_magic, md_version, md_flags, md_ealgo, md_keylen, md_provsize,
+         md_sectorsize, md_keys, md_iterations, md_salt, md_mkeys, md_hash) = header
+
+    if md_version > 7:
         sys.stderr.write(sfilename + " : md_version '%s' not supported yet!\n" % md_version)
         return
 
-    if md_ealgo != CRYPTO_AES_XTS:
+    if md_ealgo != CRYPTO_AES_XTS and md_ealgo != CRYPTO_AES_CBC:
         sys.stderr.write(sfilename + " : md_ealgo '%s' not supported yet!\n" % md_ealgo)
         return
 

--- a/src/geli_common_plug.c
+++ b/src/geli_common_plug.c
@@ -40,14 +40,14 @@ int geli_common_valid(char *ciphertext, struct fmt_main *self)
 	if (!isdec(p))
 		goto err;
 	value = atoi(p);
-	if (value != 7)
+	if (value > 7)
 		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL)   // md_ealgo (encryption algorithm)
 		goto err;
 	if (!isdec(p))
 		goto err;
 	value = atoi(p);
-	if (value != 22)                        // CRYPTO_AES_XTS
+	if (value != 22 && value != 11)         // CRYPTO_AES_XTS, CRYPTO_AES_CBC
 		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL)   // md_keylen
 		goto err;


### PR DESCRIPTION
There is not much to review here. I have uploaded GELI encrypted sample disk images to http://openwall.info/wiki/john/sample-non-hashes page.