### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ john-local.conf
 
 run/SIPdump
 run/base64conv
+run/bitlocker2john
 run/calc_stat
 run/cprepair
 run/custom.chr


### PR DESCRIPTION
This PR adds the newly added `run/bitlocker2john` binary to the gitignore so it will not show up as a changed file after compiling