### PR TITLE
sort input files

### DIFF
--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -99,7 +99,7 @@ OPT_INLINE = -Os -funroll-loops -finline-functions
 
 # Works with Solaris make, and GNU make
 PLUGFORMATS_SRCS: sh =echo *_plug.c
-PLUGFORMATS_SRCS += $(wildcard *_plug.c)
+PLUGFORMATS_SRCS += $(sort $(wildcard *_plug.c))
 PLUGFORMATS_OBJS = $(PLUGFORMATS_SRCS:.c=.o)
 
 JOHN_OBJS = \


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.
