### PR TITLE
maint: add a static code analysis tool

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -33,6 +33,7 @@ SED = @SED@
 NULL = /dev/null
 SORT = @SORT@
 STRIP = @STRIP@
+CPPCHECK=cppcheck
 
 SHELL = /bin/sh
 VPATH = @srcdir@
@@ -918,6 +919,13 @@ distclean: clean
 strip: default
 	@echo Stripping executables.
 	$(STRIP) $(PROJ)
+
+### cppcheck static coverage analysis
+#
+.PHONY: cppcheck
+
+cppcheck:
+	$(CPPCHECK) --enable=all --force -q .
 
 install: strip shell-completion
 #ifneq ($(prefix), ../run)


### PR DESCRIPTION
Since it is harmless, and can be useful for some people, I'm proposing the patch. 
* It does static code analysis and output warnings like these:

```
[misc.c:98]: (style) The scope of the variable 'block' can be reduced.
[misc.c:121]: (style) The scope of the variable 'pos' can be reduced.
[misc.c:122]: (style) The scope of the variable 'c' can be reduced.
[misc.c:384]: (style) The scope of the variable 't' can be reduced.
[misc.c:56]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[misc.c:76]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.

[7z_fmt_plug.c:591]: (style) The scope of the variable 'len' can be reduced.
[7z_fmt_plug.c:509]: (error) Signed integer overflow for expression '4294967295-3'.
[7z_fmt_plug.c:516]: (error) Signed integer overflow for expression '4294967295-3'.
[7z_fmt_plug.c:150] -> [7z_fmt_plug.c:152]: (style) Variable 'omp_t' is reassigned a value before the old one has been used.
```