### PR TITLE
Improvements in ztex library

### DIFF
--- a/src/ztex/device_format.h
+++ b/src/ztex/device_format.h
@@ -29,6 +29,14 @@ void device_format_set_key(char *key, int index);
 // Performs computation of keys_buffer using given salt
 int device_format_crypt_all(int *pcount, struct db_salt *salt);
 
+int device_format_get_hash_0(int index);
+int device_format_get_hash_1(int index);
+int device_format_get_hash_2(int index);
+int device_format_get_hash_3(int index);
+int device_format_get_hash_4(int index);
+int device_format_get_hash_5(int index);
+int device_format_get_hash_6(int index);
+
 int device_format_cmp_all(void *binary, int count);
 
 int device_format_cmp_one(void *binary, int index);

--- a/src/ztex/jtr_device.c
+++ b/src/ztex/jtr_device.c
@@ -323,7 +323,7 @@ void jtr_device_list_process_inpkt(struct task_list *task_list)
 							pkt_equal->word_id, task->num_keys);
 				}
 				if (pkt_equal->gen_id >= mask_num_cand()) {
-					fprintf(stderr, "CMP_EQUAL: gen_id=%lu, mask_num_cand=%d\n",
+					fprintf(stderr, "CMP_EQUAL: gen_id=%u, mask_num_cand=%d\n",
 							pkt_equal->gen_id, mask_num_cand());
 				}
 				if (pkt_equal->hash_num >= cmp_config.num_hashes) {
@@ -349,7 +349,7 @@ void jtr_device_list_process_inpkt(struct task_list *task_list)
 				struct pkt_done *pkt_done = pkt_done_new(inpkt);
 				if (pkt_done->num_processed
 						!= task->num_keys * mask_num_cand()) {
-					fprintf(stderr, "PROCESSING_DONE: keys=%d, %lu/%u\n",
+					fprintf(stderr, "PROCESSING_DONE: keys=%d, %u/%u\n",
 							task->num_keys, pkt_done->num_processed,
 							task->num_keys * mask_num_cand());
 				}

--- a/src/ztex/pkt_comm/inpkt.h
+++ b/src/ztex/pkt_comm/inpkt.h
@@ -12,21 +12,34 @@
 #define PKT_TYPE_CMP_EQUAL			0xd1
 #define PKT_TYPE_PROCESSING_DONE 	0xd2
 #define PKT_TYPE_RESULT1			0xd3
+#define PKT_TYPE_CMP_RESULT			0xd4
 
 
 struct pkt_equal {
-	unsigned short word_id;
-	unsigned long gen_id;
-	unsigned short hash_num;
+	uint32_t id;
+	uint16_t word_id;
+	uint32_t gen_id;
+	uint16_t hash_num;
 };
 
 struct pkt_done {
-	unsigned long num_processed;
+	uint32_t id;
+	uint32_t num_processed;
 };
 
 struct pkt_result1 {
-	unsigned short word_id;
-	unsigned long gen_id;
+	uint32_t id;
+	uint16_t word_id;
+	uint32_t gen_id;
+	unsigned char *result;
+};
+
+struct pkt_cmp_result {
+	uint32_t id;
+	uint16_t word_id;
+	uint32_t gen_id;
+	uint16_t hash_num;
+	int result_len;
 	unsigned char *result;
 };
 
@@ -37,3 +50,12 @@ struct pkt_equal *pkt_equal_new(struct pkt *pkt);
 // creates 'struct pkt_done', fills-in data from 'pkt'
 // 'pkt' is deleted
 struct pkt_done *pkt_done_new(struct pkt *pkt);
+
+// creates 'struct pkt_cmp_result', fills-in data from 'pkt'
+// allocates memory for result
+struct pkt_cmp_result *pkt_cmp_result_new(struct pkt *pkt);
+
+void pkt_cmp_result_delete(struct pkt_cmp_result *pkt_cmp_result);
+
+// Returns human-readable packet type
+char *inpkt_type_name(int pkt_type);

--- a/src/ztex/pkt_comm/word_gen.c
+++ b/src/ztex/pkt_comm/word_gen.c
@@ -16,48 +16,43 @@
 
 struct word_gen word_gen_words_pass_by = {
 	0, { }		// 0 ranges
-	//1, { 0 }	// insert 1 word at position 0
-	//0			// generate 2**32 per word
 };
 
 
-struct pkt *pkt_word_gen_new(struct word_gen *word_gen, int num_generate)
+struct pkt *pkt_word_gen_new(struct word_gen *word_gen)
 {
+	int max_len = sizeof(struct word_gen) + 5;
+	char *data = malloc(max_len);
 
-	char *data = malloc(sizeof(struct word_gen));
 	if (!data) {
 		pkt_error("pkt_word_gen_new(): unable to allocate %d bytes\n",
-				sizeof(struct word_gen));
+				max_len);
 		return NULL;
 	}
-
 	int offset = 0;
 
 	int i;
-
 	data[offset++] = word_gen->num_ranges;
 	for (i = 0; i < word_gen->num_ranges; i++) {
 		struct word_gen_char_range *range = &word_gen->ranges[i];
 		data[offset++] = range->num_chars;
-		data[offset++] = range->start_idx;
+		data[offset++] = 0;
 		memcpy(data + offset, range->chars, range->num_chars);
 		offset += range->num_chars;
 	}
-	
+
+	*((uint32_t*)(data + offset)) = 0;
+	offset += 4;
+
 	// word_gen_v2 doesn't have this stuff
 	//data[offset++] = word_gen->num_words;
 	//for (i = 0; i < word_gen->num_words; i++) {
 	//	data[offset++] = word_gen->word_insert_pos[i];
 	//}
-	
-	data[offset++] = num_generate;//word_gen->num_generate;
-	data[offset++] = num_generate >> 8;//word_gen->num_generate >> 8;
-	data[offset++] = num_generate >> 16;//word_gen->num_generate >> 16;
-	data[offset++] = num_generate >> 24;//word_gen->num_generate >> 24;
 
 	data[offset++] = 0xBB;
-	
+
 	struct pkt *pkt = pkt_new(PKT_TYPE_WORD_GEN, data, offset);
-	//printf("pkt_word_gen_new: data_len %d\n", offset);
+
 	return pkt;
 }

--- a/src/ztex/pkt_comm/word_gen.h
+++ b/src/ztex/pkt_comm/word_gen.h
@@ -7,6 +7,8 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  *
+ * Note: start_idx, num_generate actually not used.
+ *
  */
 
 #define PKT_TYPE_WORD_GEN	2
@@ -32,5 +34,5 @@ struct word_gen {
 
 struct word_gen word_gen_words_pass_by;
 
-struct pkt *pkt_word_gen_new(struct word_gen *word_gen, int num_generate);
+struct pkt *pkt_word_gen_new(struct word_gen *word_gen);
 

--- a/src/ztex_descrypt.c
+++ b/src/ztex_descrypt.c
@@ -330,29 +330,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 }
 
 
-inline static int get_hash(int index)
-{
-	int out;
-	struct task_result *result = task_result_by_index(task_list, index);
-	if (!result || !result->binary) {
-		fprintf(stderr,"get_hash(%d): no task_result or binary\n", index);
-		error();
-	}
-	out = *(uint64_t *)result->binary;
-	//fprintf(stderr,"get_hash(%d): %08x\n",index,out);
-	return out;
-}
-
-
-static int get_hash_0(int index) { return get_hash(index) & PH_MASK_0; }
-static int get_hash_1(int index) { return get_hash(index) & PH_MASK_1; }
-static int get_hash_2(int index) { return get_hash(index) & PH_MASK_2; }
-static int get_hash_3(int index) { return get_hash(index) & PH_MASK_3; }
-static int get_hash_4(int index) { return get_hash(index) & PH_MASK_4; }
-static int get_hash_5(int index) { return get_hash(index) & PH_MASK_5; }
-static int get_hash_6(int index) { return get_hash(index) & PH_MASK_6; }
-
-
 static int cmp_one(void *binary, int index)
 {
 	struct task_result *result = task_result_by_index(task_list, index);
@@ -425,13 +402,13 @@ struct fmt_main fmt_ztex_descrypt = {
 		fmt_default_clear_keys,
 		crypt_all, //device_format_crypt_all,
 		{
-			get_hash_0,
-			get_hash_1,
-			get_hash_2,
-			get_hash_3,
-			get_hash_4,
-			get_hash_5,
-			get_hash_6
+			device_format_get_hash_0,
+			device_format_get_hash_1,
+			device_format_get_hash_2,
+			device_format_get_hash_3,
+			device_format_get_hash_4,
+			device_format_get_hash_5,
+			device_format_get_hash_6
 		},
 		device_format_cmp_all,
 		cmp_one, //device_format_cmp_one,


### PR DESCRIPTION
### Summary

Improvements in ztex library
- fixed memory leak
- correct handling of FMT_REMOVE flag
- moved some code from format to library
- some cleanup

### Other Information

- fixed compiler warning
- set line terminator to LF and removed trailing spaces in modified C files