### PR TITLE
Reduce false positives in MultiBit format

### DIFF
--- a/run/multibit2john.py
+++ b/run/multibit2john.py
@@ -30,21 +30,23 @@ def process_file(filename):
 
     version = 1  # MultiBit Classic
     pdata = b"".join(data.split())
-    if len(pdata) < 44:
-        sys.stderr.write("%s: Short length for MultiBit wallet files!\n" % bname)
+    if len(pdata) < 64:
+        sys.stderr.write("%s: Short length for a MultiBit wallet file!\n" % bname)
         return
 
     try:
-        pdata = base64.b64decode(pdata[:44])
-        if len(pdata) < 32:
-            # sys.stderr.write("%s: Short length for MultiBit wallet files!\n" % bname)
+        pdata = base64.b64decode(pdata[:64])
+        if not pdata.startswith("Salted__"):
+            version = 2
+        if len(pdata) < 48:
+            # sys.stderr.write("%s: Short length for a MultiBit wallet file!\n" % bname)
             # return
             version = 2  # MultiBit HD possibly?
     except:
         version = 2  # MultiBit HD possibly?
 
     if version == 1:
-        encrypted_data = pdata[16:32]
+        encrypted_data = pdata[16:48]  # two AES blocks
         salt = pdata[8:16]
         encrypted_data = binascii.hexlify(encrypted_data).decode("ascii")
         salt = binascii.hexlify(salt).decode("ascii")

--- a/src/multibit_fmt_plug.c
+++ b/src/multibit_fmt_plug.c
@@ -54,8 +54,8 @@ john_register_one(&fmt_multibit);
 
 static struct fmt_tests multibit_tests[] = {
 	// Wallets created by MultiBit Classic 0.5.18
-	{"$multibit$1*0908a1bd44147709*c82b6d0409c1e46a4660ea6d4fa9ae12", "openwall"},
-	{"$multibit$1*2043ebb14b6d9670*24284a38a62b6a63fb0912ebc05aa9d2", "openwall123"},
+	{"$multibit$1*0908a1bd44147709*c82b6d0409c1e46a4660ea6d4fa9ae12e4e234c98a71a51ced105c7e66a57ca3", "openwall"},
+	{"$multibit$1*2043ebb14b6d9670*24284a38a62b6a63fb0912ebc05aa9d26d6fd828134d20b9778d8d841f65f584", "openwall123"},
 	// MultiBit HD wallet 0.5.0
 	{"$multibit$2*081e3a1252c26731120d0d63783ae46f*8354d5b454e78fb15f81c9e6289ba9b8*081e3a1252c26731120d0d63783ae46f", "openwall"},
 	{NULL}
@@ -67,7 +67,7 @@ static int *cracked, cracked_count;
 static struct custom_salt {
 	uint32_t type;
 	unsigned char salt[16];
-	unsigned char block[64];
+	unsigned char block[32];
 	unsigned char iv[16];
 	unsigned char block2[16];
 
@@ -117,9 +117,9 @@ static int valid(char *ciphertext, struct fmt_main *self)
 			goto err;
 		if (hexlenl(p, &extra) != 8 * 2 || extra)
 			goto err;
-		if ((p = strtokm(NULL, "*")) == NULL) // encrypted block
+		if ((p = strtokm(NULL, "*")) == NULL) // encrypted blocks
 			goto err;
-		if (hexlenl(p, &extra) != 16 * 2 || extra)
+		if (hexlenl(p, &extra) != 32 * 2 || extra)
 			goto err;
 	} else if (value == 2) {
 		if ((p = strtokm(NULL, "*")) == NULL) // iv
@@ -160,7 +160,7 @@ static void *get_salt(char *ciphertext)
 		for (i = 0; i < 8; i++)
 			cs.salt[i] = (atoi16[ARCH_INDEX(p[2 * i])] << 4) | atoi16[ARCH_INDEX(p[2 * i + 1])];
 		p = strtokm(NULL, "*");
-		for (i = 0; i < 16; i++)
+		for (i = 0; i < 32; i++)
 			cs.block[i] = (atoi16[ARCH_INDEX(p[2 * i])] << 4) | atoi16[ARCH_INDEX(p[2 * i + 1])];
 	} else if (cs.type == 2) {
 		for (i = 0; i < 16; i++)
@@ -194,7 +194,7 @@ static char *get_key(int index)
 
 static int is_bitcoinj_protobuf_data(unsigned char *block)
 {
-	// Does it look like a bitcoinj protobuf file?
+	// Does it look like a bitcoinj protobuf (newest Bitcoin for Android backup)?
 	if ((strncmp((const char*)block + 2, "org.", 4) == 0) && block[0] == '\x0a')
 		return 1; // success
 
@@ -209,7 +209,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	const int count = *pcount;
 	int index = 0;
 
-	memset(cracked, 0, sizeof(cracked[0])*cracked_count);
+	memset(cracked, 0, sizeof(cracked[0]) * cracked_count);
 
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -218,7 +218,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	{
 		unsigned char iv[16];
 		unsigned char key[32];
-		unsigned char outbuf[16 + 1];
+		unsigned char outbuf[32 + 1];
 		AES_KEY aes_decrypt_key;
 		int i;
 
@@ -245,25 +245,26 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			MD5_Final(iv, &ctx);
 			outbuf[16] = 0; // NULL terminate
 			AES_set_decrypt_key(key, 128 * 2, &aes_decrypt_key);
-			AES_cbc_encrypt(cur_salt->block, outbuf, 16, &aes_decrypt_key, iv, AES_DECRYPT);
+			AES_cbc_encrypt(cur_salt->block, outbuf, 32, &aes_decrypt_key, iv, AES_DECRYPT);
 			c = outbuf[0];
 			if (c == 'L' || c == 'K' || c == '5' || c == 'Q' || c == '\x0a' || c == '#') {
 				// Does it look like a base58 private key (MultiBit, MultiDoge, or oldest-format Android key backup)? (btcrecover)
 				if (c == 'L' || c == 'K' || c == '5' || c == 'Q') {
-					// check if remaining 12 bytes are in base58 set [1-9A-HJ-NP-Za-km-z]
-					for (i = 1; i < 16; i++) {
+					// check if bytes are in base58 set [1-9A-HJ-NP-Za-km-z]
+					for (i = 1; i < 32; i++) {
 						c = outbuf[i];
 						if ((c > 'z') || (c < '1') || ((c > '9') && (c < 'A')) || ((c > 'Z') && (c < 'a'))) {
 							cracked[index] = 0;
 							break;
 						}
 					}
-					if (i == 16)
+					if (i == 32)
 						cracked[index] = 1;
 				} else {
-					// Does it look like a bitcoinj protobuf (newest Bitcoin for Android backup) or a KnC for Android key backup? (btcrecover)
+					// Does it look like a bitcoinj protobuf (newest Bitcoin for Android backup)? (btcrecover)
 					if (strncmp((const char*)outbuf, "# KEEP YOUR PRIV", 8) == 0) // 8 should be enough
 						cracked[index] = 1;
+					// Does it look like a KnC for Android key backup?
 					else if (is_bitcoinj_protobuf_data(outbuf)) {
 						cracked[index] = 1;
 					}
@@ -332,7 +333,7 @@ struct fmt_main fmt_multibit = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
 		{ NULL },
 		{ FORMAT_TAG },
 		multibit_tests


### PR DESCRIPTION
Ported from https://github.com/gurnec/btcrecover/commit/8a6e74e66 commit.

The hashes need re-extraction using `multibit2john.py` after this commit.

This should fix issue https://github.com/magnumripper/JohnTheRipper/issues/2578.