### PR TITLE
bugfixes in ztex-bcrypt

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -321,7 +321,7 @@ AbortTemperature = 95
 # Define typical setting of hashes it's going to process. It allows
 # to adjust for best performance.
 # (unable to do it automately - can't set keys_per_crypt after reset())
-TargetSetting = 7
+TargetSetting = 6
 # Startup frequency for bcrypt-ztex is 140. Design tools guaranteed
 # 141.5 in worst-case temperature and voltage.
 Frequency = 141

--- a/src/ztex/device_format.c
+++ b/src/ztex/device_format.c
@@ -146,6 +146,10 @@ void device_format_reset()
 	if (!mask_is_inactive())
 		range_info_buffer = mem_alloc(MASK_FMT_INT_PLHDR
 				* jtr_fmt_params->max_keys_per_crypt);
+
+
+	task_list_delete(task_list);
+	task_list = NULL;
 }
 
 
@@ -176,8 +180,7 @@ int device_format_crypt_all(int *pcount, struct db_salt *salt)
 	// * assign tasks to jtr_devices
 	// * global jtr_device_list used
 	//
-	if (task_list)
-		task_list_delete(task_list);
+	task_list_delete(task_list);
 	task_list = task_list_create(*pcount, keys_buffer,
 			mask_is_inactive() ? NULL : range_info_buffer);
 

--- a/src/ztex/pkt_comm/cmp_config.c
+++ b/src/ztex/pkt_comm/cmp_config.c
@@ -102,7 +102,10 @@ void cmp_config_new(struct db_salt *salt, void *salt_ptr, int salt_len)
 
 	int cost_num;
 	for (cost_num = 0; cost_num < FMT_TUNABLE_COSTS; cost_num ++) {
-		cmp_config.tunable_costs[cost_num] = salt->cost[cost_num];
+		if (jtr_fmt_params->tunable_cost_name[cost_num])
+			cmp_config.tunable_costs[cost_num] = salt->cost[cost_num];
+		else
+			cmp_config.tunable_costs[cost_num] = 0;
 	}
 
 	// db_salt->salt depends on host system (e.g. different on 32 and 64-bit).
@@ -143,7 +146,7 @@ struct pkt *pkt_cmp_config_new(struct cmp_config *cmp_config)
 	int size = 3 + cmp_config->salt_len
 			+ cmp_config->num_hashes * binary_size
 			+ 4 * FMT_TUNABLE_COSTS;
-  char *data = malloc(size);
+	char *data = malloc(size);
 	if (!data) {
 		pkt_error("pkt_cmp_config_new(): unable to allocate %d bytes\n",
 				size);

--- a/src/ztex/task.c
+++ b/src/ztex/task.c
@@ -376,6 +376,8 @@ struct task_result *task_result_by_index(struct task_list *task_list, int index)
 
 void task_list_delete(struct task_list *task_list)
 {
+	if (!task_list)
+		return;
 	struct task *task = task_list->task;
 	if (!task)
 		return;


### PR DESCRIPTION
### Summary

- Fixed  incorrect handling of automated (w/o hitting a key) status reporting at the start of --restore, there's the case where get_key() is called before crypt_all().
- In salt->cost[cost_num]  initialized are only array elements that match non-null tunable_cost_name's. The rest (up to FMT_TUNABLE_COSTS) are uninitialized memory.