### PR TITLE
Enable usage of libFuzzer with JtR

### DIFF
--- a/doc/libFuzzer-HOWTO.txt
+++ b/doc/libFuzzer-HOWTO.txt
@@ -1,0 +1,55 @@
+Build libFuzzer
+---------------
+
+* Build "libFuzzer.a" using instructions from http://llvm.org/docs/LibFuzzer.html.
+
+* Install Clang binaries in $HOME/clang using instructions from the same link.
+
+* Copy "libFuzzer.a" to $HOME/clang/lib/libLLVMFuzzer.a location, if required.
+
+Build JtR
+---------
+
+$ CC=$HOME/clang/bin/clang ./configure --enable-libfuzzer
+
+$ make -j8
+
+Start fuzzing
+-------------
+
+Here are the instructions for fuzzing keepass2john, which is a program to
+extract hashes from KeePass databases.
+
+* Download sample KeePass databases from http://openwall.info/wiki/john/sample-non-hashes.
+
+* Extract the KeePass databases into "seed" folder. Make a new directory called "my".
+
+* Start fuzzing by running "../run/keepass2john my seed" command.
+
+* Be creative, and good luck! :)
+
+Analyzing crashes
+-----------------
+
+* Run "ASAN_OPTIONS=symbolize=1 ../run/keepass2john <crash-file>" to get a
+  symbolized stacktrace for debugging purposes.
+
+See code coverage
+-----------------
+
+$ ../run/keepass2john my seed -runs=0 -dump_coverage=1 &> /dev/null
+
+$ sancov -symbolize ../run/keepass2john keepass2john.*.sancov > keepass2john.symcov
+
+$ python3 coverage-report-server.py --symcov keepass2john.symcov --srcpath .
+
+Open http://localhost:8001/ in the browser.
+
+References
+----------
+
+* http://llvm.org/docs/LibFuzzer.html
+
+* https://github.com/google/fuzzer-test-suite/blob/master/tutorial/libFuzzerTutorial.md
+
+* http://llvm.org/svn/llvm-project/llvm/trunk/tools/sancov/

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -91,8 +91,6 @@ JOHN_OBJS = \
 	rar2john.o \
 	zip2john.o pkzip.o \
 	racf2john.o \
-	dmg2john.o \
-	keepass2john.o \
 	bitlocker2john.o \
 	hccap2john.o \
 	$(PLUGFORMATS_OBJS) \
@@ -159,6 +157,13 @@ ifdef WITH_FUZZ
 CFLAGS += -DHAVE_FUZZ
 CFLAGS_MAIN += -DHAVE_FUZZ
 JOHN_OBJS += $(FUZZ_OBJS)
+endif
+
+WITH_LIBFUZZER=@HAVE_LIBFUZZER@
+ifdef WITH_LIBFUZZER
+CFLAGS += -DHAVE_LIBFUZZER  -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div
+CFLAGS_MAIN += -DHAVE_LIBFUZZER -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div
+LDFLAGS += -fsanitize=fuzzer,address
 endif
 
 #########################################################
@@ -289,7 +294,7 @@ DES_std.o:	DES_std.c arch.h common.h memory.h DES_std.h memdbg.h os.h os-autocon
 
 detect.o:	detect.c
 
-dmg2john.o:	dmg2john.c autoconfig.h aes.h aes/aes_func.h arch.h filevault.h misc.h jumbo.h memory.h memdbg.h os.h os-autoconf.h
+dmg2john.o:	dmg2john.c autoconfig.h arch.h filevault.h misc.h jumbo.h memory.h memdbg.h os.h os-autoconf.h
 
 dummy.o:	dummy.c common.h arch.h memory.h formats.h params.h misc.h jumbo.h autoconfig.h options.h list.h loader.h getopt.h memdbg.h os.h os-autoconf.h
 
@@ -351,7 +356,7 @@ KeccakHash.o:	KeccakHash.c KeccakHash.h KeccakSponge.h KeccakF-1600-interface.h 
 
 KeccakSponge.o:	KeccakSponge.c KeccakSponge.h KeccakF-1600-interface.h memdbg.h os.h os-autoconf.h autoconfig.h jumbo.h arch.h memory.h
 
-keepass2john.o:	keepass2john.c autoconfig.h arch.h missing_getopt.h jumbo.h params.h memory.h memdbg.h os.h os-autoconf.h
+keepass2john.o:	keepass2john.c autoconfig.h arch.h missing_getopt.h jumbo.h params.h memory.h memdbg.h os.h os-autoconf.h base64.h
 
 bitlocker2john.o:	bitlocker2john.c autoconfig.h arch.h missing_getopt.h jumbo.h params.h memory.h memdbg.h os.h os-autoconf.h
 
@@ -583,10 +588,6 @@ kernels: @KERNEL_OBJS@
 	$(RM) ../run/putty2john
 	$(LN) john ../run/putty2john
 
-../run/keepass2john: ../run/john
-	$(RM) ../run/keepass2john
-	$(LN) john ../run/keepass2john
-
 ../run/bitlocker2john: ../run/john
 	$(RM) ../run/bitlocker2john
 	$(LN) john ../run/bitlocker2john
@@ -606,10 +607,6 @@ kernels: @KERNEL_OBJS@
 ../run/racf2john: ../run/john
 	$(RM) ../run/racf2john
 	$(LN) john ../run/racf2john
-
-../run/dmg2john: ../run/john
-	$(RM) ../run/dmg2john
-	$(LN) john ../run/dmg2john
 
 ../run/hccap2john: ../run/john
 	$(RM) ../run/hccap2john
@@ -647,10 +644,6 @@ kernels: @KERNEL_OBJS@
 	$(CC) symlink.c -o ../run/putty2john.exe
 	$(STRIP) ../run/putty2john.exe
 
-../run/keepass2john.exe: symlink.c
-	$(CC) symlink.c -o ../run/keepass2john.exe
-	$(STRIP) ../run/keepass2john.exe
-
 ../run/bitlocker2john.exe: symlink.c
 	$(CC) symlink.c -o ../run/bitlocker2john.exe
 	$(STRIP) ../run/bitlocker2john.exe
@@ -670,10 +663,6 @@ kernels: @KERNEL_OBJS@
 ../run/racf2john.exe: symlink.c
 	$(CC) symlink.c -o ../run/racf2john.exe
 	$(STRIP) ../run/racf2john.exe
-
-../run/dmg2john.exe: symlink.c
-	$(CC) symlink.c -o ../run/dmg2john.exe
-	$(STRIP) ../run/dmg2john.exe
 
 ../run/hccap2john.exe: symlink.c
 	$(CC) symlink.c -o ../run/hccap2john.exe
@@ -714,6 +703,12 @@ kernels: @KERNEL_OBJS@
 
 ../run/uaf2john@EXE_EXT@: uaf2john.o uaf_encode.o memdbg.o
 	$(LD) $(LDFLAGS) @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ uaf2john.o uaf_encode.o @MEMDBG_CFLAGS@ memdbg.o @OPENMP_CFLAGS@ -o ../run/uaf2john
+
+../run/keepass2john@EXE_EXT@: keepass2john.o memdbg.o
+	$(LD) $(LDFLAGS) @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ keepass2john.o jumbo.o @MEMDBG_CFLAGS@ memdbg.o base64.o @OPENMP_CFLAGS@ -lcrypto -o ../run/keepass2john
+
+../run/dmg2john@EXE_EXT@: dmg2john.o memdbg.o
+	$(LD) $(LDFLAGS) @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ dmg2john.o jumbo.o @MEMDBG_CFLAGS@ memdbg.o @OPENMP_CFLAGS@ -o ../run/dmg2john
 
 # Note that this is NOT depending on PCAP lib. It is self-contained.
 ../run/wpapcap2john@EXE_EXT@: wpapcap2john.o jumbo.o memdbg.o

--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -130,8 +130,6 @@ JOHN_OBJS = \
 	rar2john.o \
 	zip2john.o pkzip.o \
 	racf2john.o \
-	dmg2john.o \
-	keepass2john.o \
 	bitlocker2john.o \
 	hccap2john.o \
 	$(PLUGFORMATS_OBJS) \
@@ -189,8 +187,8 @@ PROJ = find_version ../run/john ../run/unshadow ../run/unafs ../run/unique ../ru
 	../run/rar2john ../run/zip2john \
 	../run/genmkvpwd ../run/mkvcalcproba ../run/calc_stat \
 	../run/tgtsnarf ../run/racf2john ../run/hccap2john \
-	../run/raw2dyna ../run/keepass2john ../run/bitlocker2john \
-	../run/dmg2john ../run/putty2john john.local.conf ../run/uaf2john \
+	../run/raw2dyna ../run/bitlocker2john \
+	../run/putty2john john.local.conf ../run/uaf2john \
 	../run/wpapcap2john \
 	../run/gpg2john ../run/cprepair ../run/base64conv
 PROJ_DOS = find_version ../run/john.bin ../run/john.com \
@@ -198,8 +196,8 @@ PROJ_DOS = find_version ../run/john.bin ../run/john.com \
 	../run/undrop.com \
 	../run/rar2john.com ../run/zip2john \
 	../run/racf2john.com ../run/hccap2john.com \
-	../run/keepass2john.com ../run/bitlocker2john.com \
-	../run/dmg2john.com ../run/putty2john.com john.local.conf \
+	../run/bitlocker2john.com \
+	../run/putty2john.com john.local.conf \
 	../run/gpg2john.com
 PROJ_WIN32 = find_version ../run/john.exe \
 	../run/unshadow.exe ../run/unafs.exe ../run/unique.exe \
@@ -207,8 +205,8 @@ PROJ_WIN32 = find_version ../run/john.exe \
 	../run/rar2john.exe ../run/zip2john.exe \
 	../run/genmkvpwd.exe ../run/mkvcalcproba.exe ../run/calc_stat.exe \
 	../run/racf2john.exe ../run/hccap2john.exe \
-	../run/raw2dyna.exe ../run/keepass2john.exe ../run/bitlocker2john.exe \
-	../run/dmg2john.exe ../run/putty2john.exe \
+	../run/raw2dyna.exe ../run/bitlocker2john.exe \
+	../run/putty2john.exe \
 	john.local.conf ../run/gpg2john.exe ../run/base64conv.exe
 PROJ_WIN32_MINGW = find_version ../run/john-mingw.exe \
 	../run/unshadow.exe ../run/unafs.exe ../run/unique.exe \
@@ -216,7 +214,7 @@ PROJ_WIN32_MINGW = find_version ../run/john-mingw.exe \
 	../run/rar2john.exe ../run/zip2john.exe \
 	../run/genmkvpwd.exe ../run/mkvcalcproba.exe ../run/calc_stat.exe \
 	../run/racf2john.exe ../run/hccap2john.exe \
-	../run/raw2dyna.exe ../run/keepass2john.exe ../run/bitlocker2john.exe \
+	../run/raw2dyna.exe ../run/bitlocker2john.exe \
 	../run/putty2john.exe john.local.conf \
 	../run/gpg2john.exe ../run/base64conv.exe
 PROJ_PCAP = ../run/SIPdump ../run/vncpcap2john
@@ -1705,10 +1703,6 @@ $(SUBDIRS):
 	$(RM) ../run/putty2john
 	ln -s john ../run/putty2john
 
-../run/keepass2john: ../run/john
-	$(RM) ../run/keepass2john
-	ln -s john ../run/keepass2john
-
 ../run/bitlocker2john: ../run/john
 	$(RM) ../run/bitlocker2john
 	ln -s john ../run/bitlocker2john
@@ -1728,10 +1722,6 @@ $(SUBDIRS):
 ../run/racf2john: ../run/john
 	$(RM) ../run/racf2john
 	ln -s john ../run/racf2john
-
-../run/dmg2john: ../run/john
-	$(RM) ../run/dmg2john
-	ln -s john ../run/dmg2john
 
 ../run/hccap2john: ../run/john
 	$(RM) ../run/hccap2john
@@ -1765,9 +1755,6 @@ $(SUBDIRS):
 ../run/putty2john.com: john.com
 	copy john.com ..\run\putty2john.com
 
-../run/keepass2john.com: john.com
-	copy john.com ..\run\keepass2john.com
-
 ../run/bitlocker2john.com: john.com
 	copy john.com ..\run\bitlocker2john.com
 
@@ -1776,9 +1763,6 @@ $(SUBDIRS):
 
 ../run/racf2john.com: john.com
 	copy john.com ..\run\racf2john.com
-
-../run/dmg2john.com: john.com
-	copy john.com ..\run\dmg2john.com
 
 ../run/zip2john.com: john.com
 	copy john.com ..\run\zip2john.com
@@ -1835,10 +1819,6 @@ john.com: john.asm
 	$(CC) symlink.c -o ../run/putty2john.exe
 	$(STRIP) ../run/putty2john.exe
 
-../run/keepass2john.exe: symlink.c
-	$(CC) symlink.c -o ../run/keepass2john.exe
-	$(STRIP) ../run/keepass2john.exe
-
 ../run/bitlocker2john.exe: symlink.c
 	$(CC) symlink.c -o ../run/bitlocker2john.exe
 	$(STRIP) ../run/bitlocker2john.exe
@@ -1850,10 +1830,6 @@ john.com: john.asm
 ../run/racf2john.exe: symlink.c
 	$(CC) symlink.c -o ../run/racf2john.exe
 	$(STRIP) ../run/racf2john.exe
-
-../run/dmg2john.exe: symlink.c
-	$(CC) symlink.c -o ../run/dmg2john.exe
-	$(STRIP) ../run/dmg2john.exe
 
 ../run/zip2john.exe: symlink.c
 	$(CC) symlink.c -o ../run/zip2john.exe

--- a/src/calc_stat.c
+++ b/src/calc_stat.c
@@ -22,7 +22,18 @@ unsigned int *proba1;
 unsigned int *proba2;
 unsigned int *first;
 
+#ifdef HAVE_LIBFUZZER
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	return 0;
+}
+#endif
+
+#ifdef HAVE_LIBFUZZER
+int main_dummy(int argc, char **argv)
+#else
 int main(int argc, char **argv)
+#endif
 {
 	FILE *fichier;
 	char *ligne;

--- a/src/configure
+++ b/src/configure
@@ -630,6 +630,7 @@ PLUGFORMATS_DEPS
 KERNEL_OBJS
 PLUGFORMATS_OBJS
 M4_INCLUDES
+HAVE_LIBFUZZER
 HAVE_FUZZ
 EXE_EXT
 YASM_OPTIONS
@@ -770,6 +771,7 @@ enable_nt_full_unicode
 enable_int128
 enable_experimental_code
 enable_fuzz
+enable_libfuzzer
 enable_openmp
 enable_opencl
 enable_ztex
@@ -1410,6 +1412,7 @@ Optional Features:
   --enable-experimental-code
                           Use experimental code
   --enable-fuzz           Fuzzing prepare(), valid(), init(), etc
+  --enable-libfuzzer      Fuzzing using libFuzzer
   --disable-openmp        do not use OpenMP
   --disable-opencl        do not use OpenCL
   --enable-ztex           Support ZTEX USB-FPGA module 1.15y
@@ -3630,6 +3633,13 @@ if test "${enable_fuzz+set}" = set; then :
   enableval=$enable_fuzz; fuzz=$enableval
 else
   fuzz=no
+fi
+
+# Check whether --enable-libfuzzer was given.
+if test "${enable_libfuzzer+set}" = set; then :
+  enableval=$enable_libfuzzer; libfuzzer=$enableval
+else
+  libfuzzer=no
 fi
 
 
@@ -13839,6 +13849,15 @@ if test "x$fuzz" != xno ; then
 else
    { $as_echo "$as_me:${as_lineno-$LINENO}: Fuzz check disabled" >&5
 $as_echo "$as_me: Fuzz check disabled" >&6;}
+fi
+
+# In makefile, we need to know if building with libFuzzer.
+if test "x$libfuzzer" != xno ; then
+   HAVE_LIBFUZZER=-DHAVE_LIBFUZZER
+
+else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: Fuzzing (using libFuzzer) check disabled" >&5
+$as_echo "$as_me: Fuzzing (using libFuzzer) check disabled" >&6;}
 fi
 
 # code to create M4_INCLUDES (all ./m4/*.m4 )

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -86,6 +86,7 @@ AC_ARG_ENABLE([nt-full-unicode], [AS_HELP_STRING([--enable-nt-full-unicode],[sup
 AC_ARG_ENABLE([int128], [AC_HELP_STRING([--disable-int128], [Do not use int128])], [enable_int128=$enableval], [enable_int128=auto])
 AC_ARG_ENABLE([experimental-code], [AC_HELP_STRING([--enable-experimental-code], [Use experimental code])], [experimental=$enableval], [experimental=no])
 AC_ARG_ENABLE([fuzz], [AC_HELP_STRING([--enable-fuzz], [Fuzzing prepare(), valid(), init(), etc])], [fuzz=$enableval], [fuzz=no])
+AC_ARG_ENABLE([libfuzzer], [AC_HELP_STRING([--enable-libfuzzer], [Fuzzing using libFuzzer])], [libfuzzer=$enableval], [libfuzzer=no])
 
 ####### Actual tests start here #######
 
@@ -884,6 +885,13 @@ if test "x$fuzz" != xno ; then
    AC_SUBST(HAVE_FUZZ,[-DHAVE_FUZZ])
 else
    AC_MSG_NOTICE([Fuzz check disabled])
+fi
+
+# In makefile, we need to know if building with libFuzzer.
+if test "x$libfuzzer" != xno ; then
+   AC_SUBST(HAVE_LIBFUZZER,[-DHAVE_LIBFUZZER])
+else
+   AC_MSG_NOTICE([Fuzzing (using libFuzzer) check disabled])
 fi
 
 # code to create M4_INCLUDES (all ./m4/*.m4 )

--- a/src/genmkvpwd.c
+++ b/src/genmkvpwd.c
@@ -186,7 +186,18 @@ static void stupidsort(unsigned char * result, unsigned int * source, unsigned i
 }
 #endif
 
+#ifdef HAVE_LIBFUZZER
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	return 0;
+}
+#endif
+
+#ifdef HAVE_LIBFUZZER
+int main_dummy(int argc, char * * argv)
+#else
 int main(int argc, char * * argv)
+#endif
 {
 	struct s_pwd pwd;
 	struct s_pwd pwd2;

--- a/src/mkvcalcproba.c
+++ b/src/mkvcalcproba.c
@@ -30,7 +30,18 @@ unsigned char *proba1;
 unsigned char *proba2;
 unsigned char *first;
 
+#ifdef HAVE_LIBFUZZER
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	return 0;
+}
+#endif
+
+#ifdef HAVE_LIBFUZZER
+int main_dummy(int argc, char **argv)
+#else
 int main(int argc, char **argv)
+#endif
 {
 	FILE *fichier;
 	char *ligne;

--- a/src/raw2dyna.c
+++ b/src/raw2dyna.c
@@ -68,7 +68,18 @@ void Setup() {
 	atoi16['f'] = atoi16['F'] = 15;
 }
 
+#ifdef HAVE_LIBFUZZER
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	return 0;
+}
+#endif
+
+#ifdef HAVE_LIBFUZZER
+int main_dummy(int argc, char **argv) {
+#else
 int main(int argc, char **argv) {
+#endif
 	char Buf[1024], *cps, *cph, usr_id[512];;
 
 	Setup();

--- a/src/tgtsnarf.c
+++ b/src/tgtsnarf.c
@@ -248,8 +248,19 @@ upcase(char *string)
   return (string);
 }
 
+#ifdef HAVE_LIBFUZZER
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	return 0;
+}
+#endif
+
+#ifdef HAVE_LIBFUZZER
+int main_dummy(int argc, char **argv)
+#else
 int
 main(int argc, char *argv[])
+#endif
 {
   signed char c;
   char *p, *host, *realm, user[128];

--- a/src/uaf2john.c
+++ b/src/uaf2john.c
@@ -440,7 +440,18 @@ bailout:
 
 }
 
+#ifdef HAVE_LIBFUZZER
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	return 0;
+}
+#endif
+
+#ifdef HAVE_LIBFUZZER
+int main_dummy(int argc, char **argv)
+#else
 int main(int argc, char **argv)
+#endif
 {
 	int i;
 


### PR DESCRIPTION
This patch introduces multiple changes.

+ libFuzzer is enabled when --enable-libfuzzer configure option is used

+ keepass2john.c is now a standalone program

+ dmg2john.c is now a standalone program

+ Fuzzing is implemented for keepass2john, dmg2john, vncpcap2john, uaf2john, eapmd5tojohn, and wpapcap2john
    
+ Stub fuzzing functions for other targets are implemented