### PR TITLE
Few enhancements for openssl2john.py

### DIFF
--- a/run/openssl2john.py
+++ b/run/openssl2john.py
@@ -2,16 +2,29 @@
 
 import sys
 import base64
-#import optparse
-import argparse
+import optparse
+from binascii import hexlify
+
+# openssl aes-256-cbc -in secret.txt -out secret.txt.enc
+# openssl aes-256-cbc -a -in secret.txt -out secret.txt.enc
+# openssl enc -aes-256-cbc -in secret.txt -out secret.txt.enc
+
+PY3 = sys.version_info[0] == 3
+
 
 def process(filename, plaintext=None, cipher=0, md=0):
 
     with open(filename, "rb") as f:
         data = f.read()
-        data = base64.decodestring(data)
 
-        if not data.startswith("Salted__"):
+        if not data.startswith(b"Salted__"):
+            try:
+                data = base64.decodestring(data)
+            except:
+                sys.stderr.write("%s doesn't seem to be encrypted using OpenSSL's enc command!\n" % filename)
+                return
+
+        if not data.startswith(b"Salted__"):
             sys.stderr.write("%s doesn't seem to be encrypted using OpenSSL's enc command!\n" % filename)
             return
 
@@ -21,6 +34,9 @@ def process(filename, plaintext=None, cipher=0, md=0):
 
         rlen = len(data) - 16
         salt = data[8:16]
+        salt = hexlify(salt)
+        if PY3:
+            salt = salt.decode("ascii")
 
         if rlen <= 16:
             last_chunk = data[-16:]
@@ -28,8 +44,11 @@ def process(filename, plaintext=None, cipher=0, md=0):
                 s = "1$%s" % plaintext
             else:
                 s = "0"
-            sys.stdout.write("%s:$openssl$%s$%s$8$%s$%s$1$%s" % (filename, cipher, md, salt.encode("hex"),
-                last_chunk.encode("hex"), s))
+            last_chunk = hexlify(last_chunk)
+            if PY3:
+                last_chunk = last_chunk.decode("ascii")
+            sys.stdout.write("%s:$openssl$%s$%s$8$%s$%s$1$%s\n" %
+                             (filename, cipher, md, salt, last_chunk, s))
         else:
             last_chunk = data[-32:]
             # try to decode maximum of 16
@@ -38,8 +57,15 @@ def process(filename, plaintext=None, cipher=0, md=0):
                 s = "1$%s" % plaintext
             else:
                 s = "0"
-            sys.stdout.write("%s:$openssl$%s$%s$8$%s$%s$0$%s$%s$%s\n" % (filename, cipher, md, salt.encode("hex"),
-                last_chunk.encode("hex"), len(rdata), rdata.encode("hex"), s))
+            last_chunk = hexlify(last_chunk)
+            if PY3:
+                last_chunk = last_chunk.decode("ascii")
+            rdata = hexlify(rdata)
+            if PY3:
+                rdata = rdata.decode("ascii")
+            sys.stdout.write("%s:$openssl$%s$%s$8$%s$%s$0$%s$%s$%s\n" %
+                             (filename, cipher, md, salt, last_chunk,
+                              len(rdata), rdata, s))
 
 
 if __name__ == '__main__':
@@ -50,16 +76,11 @@ if __name__ == '__main__':
         sys.stderr.write("md: 0 => md5, 1 => sha1\n")
         sys.exit(-1)
 
-    #parser = optparse.OptionParser()
-    parser = argparse.ArgumentParser()
-    #parser.add_option('-p', action="store", dest="plaintext")
-    parser.add_argument('-p', action="store", dest="plaintext")
-    #parser.add_option('-c', action="store", dest="cipher", default=0)
-    parser.add_argument('-c', action="store", dest="cipher", default=0)
-    #parser.add_option('-m', action="store", dest="md", default=0)
-    parser.add_argument('-m', action="store", dest="md", default=0)
-    #options, remainder = parser.parse_args()
-    args = parser.parse_args()
+    parser = optparse.OptionParser()
+    parser.add_option('-p', action="store", dest="plaintext")
+    parser.add_option('-c', action="store", dest="cipher", default=0)
+    parser.add_option('-m', action="store", dest="md", default=0)
+    options, remainder = parser.parse_args()
 
-    for j in range(0, len(parser.REMAINDER)):
-        data = process(parser.REMAINDER[j], args.plaintext, args.cipher, args.md)
+    for j in range(0, len(remainder)):
+        data = process(remainder[j], options.plaintext, options.cipher, options.md)


### PR DESCRIPTION
This reverts the changes made by commit d297620f376, as we need compatibility with Python 2.4 for now.

Files encrypted with "openssl enc" which do not use base64 encoding are also supported now.