### PR TITLE
Make wpapcap2john more robust in input handling

### DIFF
--- a/src/wpapcap2john.h
+++ b/src/wpapcap2john.h
@@ -177,9 +177,12 @@ typedef struct WPA4way_s {
 	char bssid[18];
 	char sta[18];
 	uint8 *packet1;
+	int packet1_len;
 	uint8 *packet2;
+	int packet2_len;
 	uint8 *orig_2;
 	uint8 *packet3;
+	int packet3_len;
 	uint8 *packet4;
 	int fully_cracked;
 	int hopefully_cracked; // we have a 1 & 2


### PR DESCRIPTION
This should help with issue https://github.com/magnumripper/JohnTheRipper/issues/2636.

This fixes various ASan crashes found with the help of libFuzzer.

The most important change in this PR is,

``` diff
@@ -513,11 +521,15 @@ static void HandleBeacon(uint16 subtype)
 
        while (((uint8*)tag) < pFinal) {
                char *x = (char*)tag;
+               if (x + 2 > (char*)pFinal || x + 2 + tag->taglen > (char*)pFinal)
+                       break;
                if (tag->tagtype == 0 && tag->taglen < sizeof(essid))
                        memcpy(essid, tag->tag, tag->taglen);
                x += tag->taglen + 2;
                tag = (ether_beacon_tag_t *)x;
        }
```