### PR TITLE
Warn about the slow startup at many salts in descrypt-opencl

### DIFF
--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -683,12 +683,25 @@ static void reset(struct db_main *db)
 			salt_list[num_salts++] = (*(WORD *)salt -> salt);
 		} while ((salt = salt -> next));
 
+		if (num_salts > 1)
+			fprintf(stderr, "Note: building per-salt kernels. "
+				"This takes e.g. 2 hours for 4096 salts.\n");
 #if _OPENMP && PARALLEL_BUILD
 #pragma omp parallel for
 #endif
-		for (i = 0; i < num_salts; i++)
+		for (i = 0; i < num_salts; i++) {
 			init_kernel(salt_list[i], gpu_id, 1, 0, forced_global_keys ? 0 :local_work_size);
 
+#if _OPENMP && PARALLEL_BUILD
+			if (omp_get_thread_num() == 0)
+#endif
+			{
+				opencl_process_event();
+
+				if (options.verbosity < VERB_LEGACY)
+					advance_cursor();
+			}
+		}
 		set_kernel_args_kpc();
 	}
 	else {


### PR DESCRIPTION
See #2652
****
* Notes:
  * Parallel per-salt kernel build is disabled by default on HEAD.
  * The 4096 limit is not working properly. That said, anyone can crash JtR HEAD using a proper hash file.

```
#0  0x000000000079dc64 in create_tables (htype=<value optimized out>, loaded_hashes_ptr=<value optimized out>, 
    num_ld_hashes=<value optimized out>, offset_table_ptr=0x7fffffffa090, offset_table_sz_ptr=0x7fffffffa098, 
    hash_table_sz_ptr=0x7fffffffa09c, verb=0) at bt.c:474
#1  create_perfect_hash_table (htype=<value optimized out>, loaded_hashes_ptr=<value optimized out>, num_ld_hashes=<value optimized out>, 
    offset_table_ptr=0x7fffffffa090, offset_table_sz_ptr=0x7fffffffa098, hash_table_sz_ptr=0x7fffffffa09c, verb=0) at bt.c:696
#2  0x0000000000611192 in fill_buffer (salt=<value optimized out>, max_uncracked_hashes=<value optimized out>, max_hash_table_size=0xd1eb04)
    at opencl_DES_bs_plug.c:224
#3  0x0000000000611752 in build_tables (db=<value optimized out>) at opencl_DES_bs_plug.c:423
#4  0x000000000060ca3d in reset (db=0xd64600) at opencl_DES_bs_h_plug.c:667
#5  0x000000000074aee5 in john_run () at john.c:1710
#6  0x000000000074b785 in main (argc=8, argv=0x7fffffffe398) at john.c:1996
```