### PR TITLE
Eliminate warnings about unused functions from secp256k1 code

### DIFF
--- a/src/secp256k1/ecmult.h
+++ b/src/secp256k1/ecmult.h
@@ -23,7 +23,7 @@ static void secp256k1_ecmult_context_build(secp256k1_ecmult_context *ctx, const 
 static void secp256k1_ecmult_context_clone(secp256k1_ecmult_context *dst,
                                            const secp256k1_ecmult_context *src, const secp256k1_callback *cb);
 static void secp256k1_ecmult_context_clear(secp256k1_ecmult_context *ctx);
-static int secp256k1_ecmult_context_is_built(const secp256k1_ecmult_context *ctx);
+// static int secp256k1_ecmult_context_is_built(const secp256k1_ecmult_context *ctx);
 
 /** Double multiply: R = na*A + ng*G */
 static void secp256k1_ecmult(const secp256k1_ecmult_context *ctx, secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_scalar *na, const secp256k1_scalar *ng);

--- a/src/secp256k1/ecmult_gen.h
+++ b/src/secp256k1/ecmult_gen.h
@@ -33,7 +33,7 @@ static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context* ctx
 static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context *dst,
                                                const secp256k1_ecmult_gen_context* src, const secp256k1_callback* cb);
 static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context* ctx);
-static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context* ctx);
+// static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context* ctx);
 
 /** Multiply with the generator: R = a*G */
 static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context* ctx, secp256k1_gej *r, const secp256k1_scalar *a);

--- a/src/secp256k1/ecmult_gen_impl.h
+++ b/src/secp256k1/ecmult_gen_impl.h
@@ -91,9 +91,11 @@ static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context *ctx
     secp256k1_ecmult_gen_blind(ctx, NULL);
 }
 
+#if 0
 static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context* ctx) {
     return ctx->prec != NULL;
 }
+#endif
 
 static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context *dst,
                                                const secp256k1_ecmult_gen_context *src, const secp256k1_callback* cb) {

--- a/src/secp256k1/ecmult_impl.h
+++ b/src/secp256k1/ecmult_impl.h
@@ -213,9 +213,11 @@ static void secp256k1_ecmult_context_clone(secp256k1_ecmult_context *dst,
 #endif
 }
 
+#if 0
 static int secp256k1_ecmult_context_is_built(const secp256k1_ecmult_context *ctx) {
     return ctx->pre_g != NULL;
 }
+#endif
 
 static void secp256k1_ecmult_context_clear(secp256k1_ecmult_context *ctx) {
     free(ctx->pre_g);

--- a/src/secp256k1/field.h
+++ b/src/secp256k1/field.h
@@ -103,19 +103,19 @@ static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a);
 static int secp256k1_fe_sqrt(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Checks whether a field element is a quadratic residue. */
-static int secp256k1_fe_is_quad_var(const secp256k1_fe *a);
+// static int secp256k1_fe_is_quad_var(const secp256k1_fe *a);
 
 /** Sets a field element to be the (modular) inverse of another. Requires the input's magnitude to be
  *  at most 8. The output magnitude is 1 (but not guaranteed to be normalized). */
 static void secp256k1_fe_inv(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Potentially faster version of secp256k1_fe_inv, without constant-time guarantee. */
-static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256k1_fe *a);
+// static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Calculate the (modular) inverses of a batch of field elements. Requires the inputs' magnitudes to be
  *  at most 8. The output magnitudes are 1 (but not guaranteed to be normalized). The inputs and
  *  outputs must not overlap in memory. */
-static void secp256k1_fe_inv_all_var(secp256k1_fe *r, const secp256k1_fe *a, size_t len);
+// static void secp256k1_fe_inv_all_var(secp256k1_fe *r, const secp256k1_fe *a, size_t len);
 
 /** Convert a field element to the storage type. */
 static void secp256k1_fe_to_storage(secp256k1_fe_storage *r, const secp256k1_fe *a);

--- a/src/secp256k1/field_impl.h
+++ b/src/secp256k1/field_impl.h
@@ -223,6 +223,7 @@ static void secp256k1_fe_inv(secp256k1_fe *r, const secp256k1_fe *a) {
     secp256k1_fe_mul(r, a, &t1);
 }
 
+#if 0
 static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256k1_fe *a) {
 #if defined(USE_FIELD_INV_BUILTIN)
     secp256k1_fe_inv(r, a);
@@ -259,7 +260,9 @@ static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256k1_fe *a) {
 #error "Please select field inverse implementation"
 #endif
 }
+#endif
 
+#if 0
 static void secp256k1_fe_inv_all_var(secp256k1_fe *r, const secp256k1_fe *a, size_t len) {
     secp256k1_fe u;
     size_t i;
@@ -286,7 +289,9 @@ static void secp256k1_fe_inv_all_var(secp256k1_fe *r, const secp256k1_fe *a, siz
 
     r[0] = u;
 }
+#endif
 
+#if 0
 static int secp256k1_fe_is_quad_var(const secp256k1_fe *a) {
 #ifndef USE_NUM_NONE
     unsigned char b[32];
@@ -311,5 +316,6 @@ static int secp256k1_fe_is_quad_var(const secp256k1_fe *a) {
     return secp256k1_fe_sqrt(&r, a);
 #endif
 }
+#endif
 
 #endif

--- a/src/secp256k1/group.h
+++ b/src/secp256k1/group.h
@@ -65,7 +65,7 @@ static void secp256k1_ge_neg(secp256k1_ge *r, const secp256k1_ge *a);
 static void secp256k1_ge_set_gej(secp256k1_ge *r, secp256k1_gej *a);
 
 /** Set a batch of group elements equal to the inputs given in jacobian coordinates */
-static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a, size_t len, const secp256k1_callback *cb);
+// static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a, size_t len, const secp256k1_callback *cb);
 
 /** Set a batch of group elements equal to the inputs given in jacobian
  *  coordinates (with known z-ratios). zr must contain the known z-ratios such
@@ -95,7 +95,7 @@ static void secp256k1_gej_neg(secp256k1_gej *r, const secp256k1_gej *a);
 static int secp256k1_gej_is_infinity(const secp256k1_gej *a);
 
 /** Check whether a group element's y coordinate is a quadratic residue. */
-static int secp256k1_gej_has_quad_y_var(const secp256k1_gej *a);
+// static int secp256k1_gej_has_quad_y_var(const secp256k1_gej *a);
 
 /** Set r equal to the double of a. If rzr is not-NULL, r->z = a->z * *rzr (where infinity means an implicit z = 0).
  * a may not be zero. Constant time. */
@@ -105,7 +105,7 @@ static void secp256k1_gej_double_nonzero(secp256k1_gej *r, const secp256k1_gej *
 static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr);
 
 /** Set r equal to the sum of a and b. If rzr is non-NULL, r->z = a->z * *rzr (a cannot be infinity in that case). */
-static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr);
+// static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr);
 
 /** Set r equal to the sum of a and b (with b given in affine coordinates, and not infinity). */
 static void secp256k1_gej_add_ge(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b);

--- a/src/secp256k1/group_impl.h
+++ b/src/secp256k1/group_impl.h
@@ -110,6 +110,7 @@ static void secp256k1_ge_set_gej(secp256k1_ge *r, secp256k1_gej *a) {
     r->y = a->y;
 }
 
+#if 0
 static void secp256k1_ge_set_gej_var(secp256k1_ge *r, secp256k1_gej *a) {
     secp256k1_fe z2, z3;
     r->infinity = a->infinity;
@@ -125,7 +126,9 @@ static void secp256k1_ge_set_gej_var(secp256k1_ge *r, secp256k1_gej *a) {
     r->x = a->x;
     r->y = a->y;
 }
+#endif
 
+#if 0
 static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a, size_t len, const secp256k1_callback *cb) {
     secp256k1_fe *az;
     secp256k1_fe *azi;
@@ -151,6 +154,7 @@ static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a
     }
     free(azi);
 }
+#endif
 
 static void secp256k1_ge_set_table_gej_var(secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zr, size_t len) {
     size_t i = len - 1;
@@ -264,6 +268,7 @@ static int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
     return a->infinity;
 }
 
+#if 0
 static int secp256k1_gej_is_valid_var(const secp256k1_gej *a) {
     secp256k1_fe y2, x3, z2, z6;
     if (a->infinity) {
@@ -283,6 +288,7 @@ static int secp256k1_gej_is_valid_var(const secp256k1_gej *a) {
     secp256k1_fe_normalize_weak(&x3);
     return secp256k1_fe_equal_var(&y2, &x3);
 }
+#endif
 
 static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
     secp256k1_fe y2, x3, c;
@@ -358,6 +364,7 @@ static SECP256K1_INLINE void secp256k1_gej_double_nonzero(secp256k1_gej *r, cons
     secp256k1_gej_double_var(r, a, rzr);
 }
 
+#if 0
 static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr) {
     /* Operations: 12 mul, 4 sqr, 2 normalize, 12 mul_int/add/negate */
     secp256k1_fe z22, z12, u1, u2, s1, s2, h, i, i2, h2, h3, t;
@@ -410,6 +417,7 @@ static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, cons
     secp256k1_fe_mul(&h3, &h3, &s1); secp256k1_fe_negate(&h3, &h3, 1);
     secp256k1_fe_add(&r->y, &h3);
 }
+#endif
 
 static void secp256k1_gej_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, secp256k1_fe *rzr) {
     /* 8 mul, 3 sqr, 4 normalize, 12 mul_int/add/negate */
@@ -683,6 +691,7 @@ static void secp256k1_ge_mul_lambda(secp256k1_ge *r, const secp256k1_ge *a) {
 }
 #endif
 
+#if 0
 static int secp256k1_gej_has_quad_y_var(const secp256k1_gej *a) {
     secp256k1_fe yz;
 
@@ -696,5 +705,6 @@ static int secp256k1_gej_has_quad_y_var(const secp256k1_gej *a) {
     secp256k1_fe_mul(&yz, &a->y, &a->z);
     return secp256k1_fe_is_quad_var(&yz);
 }
+#endif
 
 #endif


### PR DESCRIPTION
This should fix https://github.com/magnumripper/JohnTheRipper/issues/2693.