### PR TITLE
Add support for EME2-AES in PGP Disk format

### DIFF
--- a/run/pgpdisk2john.py
+++ b/run/pgpdisk2john.py
@@ -8,8 +8,8 @@
 #
 # Written in August of 2017 based on PGPDesktop10.0.1_Source.zip.
 #
-# Only tested with Symantec Encryption Desktop 10.4.1 MP1 running on Windows 7
-# SP1 and macOS Sierra.
+# Tested with Symantec Encryption Desktop (SED) 10.4.1 MP1 running on Windows 7
+# SP1 and macOS Sierra. Also tested with PGP 8.0 running on Windows XP SP3.
 
 import os
 import sys
@@ -253,8 +253,8 @@ def process_file(filename):
         fields = struct.unpack(OnDiskMainHeader_fmt, idata)
         headerMagic, headerType, headerSize, headerCRC, nextHeaderOffset, reserved, majorVersion, minorVersion, _, _, _, _, algorithm, salt, something, customTimeout, numBlocksReEncrypted, defaultRoot  = fields[0:18]
         if headerMagic == b"PGPd" and headerType == b"MAIN":
-            if algorithm != 5 and algorithm != 4 and algorithm != 3:
-                sys.stderr.write("Only AES-256, Twofish, CAST5 algorithms are supported currently. Found (%d) instead!\n" % algorithm)
+            if algorithm != 7 and algorithm != 6 and algorithm != 5 and algorithm != 4 and algorithm != 3:
+                sys.stderr.write("Only AES-256, Twofish, CAST5, EME-AES, EME2-AES algorithms are supported currently. Found (%d) instead!\n" % algorithm)
                 return
             if majorVersion != 7 and majorVersion != 6:
                 sys.stderr.write("Untested majorVersion (%d) found, not generating a hash!\n" % majorVersion)

--- a/src/pgpdisk_fmt_plug.c
+++ b/src/pgpdisk_fmt_plug.c
@@ -61,6 +61,10 @@ static struct fmt_tests tests[] = {
 	{"$pgpdisk$0*5*12608*72eacfad309a37bf169a4c7375a583d2*5725d6c36ded48b4309edb2e7fcdc69c", "äbc"},
 	{"$pgpdisk$0*5*14813*72eacfad309a37bf169a4c7375a583d2*d3e61d400fecc177a100f576a5138570", "bar"},
 	{"$pgpdisk$0*5*14792*72eacfad309a37bf169a4c7375a583d2*304ae364c311bbde2d6965ca3246a823", "foo"},
+	{"$pgpdisk$0*7*17739*fb5de863aa2766aff5562db5a7b34ffd*9ca8d6b97c7ebea876f7db7fe35d9f15", "openwall"}, // EME2-AES
+	// Windows XP SP3 + PGP 8.0
+	{"$pgpdisk$0*3*16000*3248d14732ecfb671dda27fd614813bc*4829a0152666928f0000000000000000", "openwall"},
+	{"$pgpdisk$0*4*16000*b47a66d9d4cf45613c3c73a2952d7b88*4e1cd2de6e986d999e1676b2616f5337", "openwall"},
 	{NULL}
 };
 
@@ -116,7 +120,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	if (!isdec(p))
 		goto bail;
 	res = atoi(p);
-	if (res != 5 && res != 4 && res != 3) // AES-256, Twofish, CAST5
+	if (res != 7 && res != 6 && res != 5 && res != 4 && res != 3) // EME-AES, EME2-AES, AES-256, Twofish, CAST5
 		goto bail;
 	if ((p = strtokm(NULL, "*")) == NULL) // iterations
 		goto bail;
@@ -250,7 +254,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		for (i = 0; i < MAX_KEYS_PER_CRYPT; i++) {
 			unsigned char key[40];
 
-			if (cur_salt->algorithm == 5) {
+			if (cur_salt->algorithm == 5 || cur_salt->algorithm == 6 || cur_salt->algorithm == 7) {
 				AES_KEY aes_key;
 
 				pgpdisk_kdf(saved_key[i+index], cur_salt->salt, key, 32);


### PR DESCRIPTION
Usage of EME2-AES with PGP Virtual Disks is broken in SED 10.4.1 MP1 in Windows 7 64-bit. The generated disk images are corrupt (e.g. CheckBytes are all zero).  Such images "mount" but don't work afterwards, and can't be unmounted.

The same EME2-AES feature works fine when used on macOS.