### PR TITLE
OpenCL support for PGP Disk format

### DIFF
--- a/src/opencl/pgpdisk_kernel.cl
+++ b/src/opencl/pgpdisk_kernel.cl
@@ -1,0 +1,96 @@
+/*
+ * This software is Copyright (c) 2017 Dhiru Kholia <dhiru at openwall.com> and
+ * it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#include "opencl_device_info.h"
+#include "opencl_misc.h"
+#include "opencl_sha1_ctx.h"
+
+#ifndef PLAINTEXT_LENGTH
+#error PLAINTEXT_LENGTH must be defined
+#endif
+
+#ifndef SHA1_DIGEST_LENGTH
+#define SHA1_DIGEST_LENGTH 20
+#endif
+
+#ifndef _memcpy
+#define _memcpy	memcpy_macro
+#endif
+
+typedef struct {
+	uint length;
+	uchar v[PLAINTEXT_LENGTH];
+} pgpdisk_password;
+
+typedef struct {
+	uchar v[32];
+} pgpdisk_hash;
+
+typedef struct {
+	uint saltlen;
+	uint iterations;
+	uint key_len;
+	uchar salt[16];
+} pgpdisk_salt;
+
+#ifndef __MESA__
+inline
+#endif
+void pgpdisk_kdf(__global const uchar *ipassword, uint password_length,
+		__constant const uchar *isalt, uint saltlen, uint iterations,
+		__global uchar *okey, uint key_len)
+{
+	uint32_t bytesNeeded = key_len;
+	uint32_t offset = 0;
+	unsigned char hash[SHA1_DIGEST_LENGTH];
+	int plen;
+	SHA_CTX ctx;
+	unsigned char key[40];
+	unsigned char password[PLAINTEXT_LENGTH];
+	unsigned char salt[16];
+
+	_memcpy(salt, isalt, saltlen);
+	_memcpy(password, ipassword, password_length);
+	plen = password_length;
+	while (bytesNeeded > 0) {
+		uint32_t bytesThisTime = SHA1_DIGEST_LENGTH < bytesNeeded ? SHA1_DIGEST_LENGTH: bytesNeeded;
+		uint8_t j;
+		uint16_t i;
+
+		SHA1_Init(&ctx);
+		if (offset > 0) {
+			SHA1_Update(&ctx, key, SHA1_DIGEST_LENGTH);
+		}
+		SHA1_Update(&ctx, password, plen);
+		SHA1_Final(hash, &ctx);
+
+		SHA1_Init(&ctx);
+		SHA1_Update(&ctx, salt, saltlen);
+
+		for (i = 0, j = 0; i < iterations; i++, j++) {
+			SHA1_Update(&ctx, hash, bytesThisTime);
+			SHA1_Update(&ctx, &j, 1);
+		}
+		SHA1_Final(key + offset, &ctx);
+
+		bytesNeeded -= bytesThisTime;
+		offset += bytesThisTime;
+	}
+
+	_memcpy(okey, key, key_len);
+}
+
+__kernel void pgpdisk(__global const pgpdisk_password *inbuffer,
+                  __global pgpdisk_hash *outbuffer,
+                  __constant pgpdisk_salt *salt)
+{
+	uint idx = get_global_id(0);
+
+	pgpdisk_kdf(inbuffer[idx].v, inbuffer[idx].length, salt->salt,
+			salt->saltlen, salt->iterations, outbuffer[idx].v, salt->key_len);
+}

--- a/src/opencl_pgpdisk_fmt_plug.c
+++ b/src/opencl_pgpdisk_fmt_plug.c
@@ -1,0 +1,364 @@
+/*
+ * Format for brute-forcing PGP Virtual Disk images.
+ *
+ * This software is Copyright (c) 2017 Dhiru Kholia <dhiru at openwall.net> and
+ * it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#ifdef HAVE_OPENCL
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_opencl_pgpdisk;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_opencl_pgpdisk);
+#else
+
+#include <stdint.h>
+#include <string.h>
+#include <openssl/cast.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "arch.h"
+#include "params.h"
+#include "common.h"
+#include "formats.h"
+#include "misc.h"
+#include "aes.h"
+#include "twofish.h"
+#include "sha.h"
+#include "common-opencl.h"
+#include "options.h"
+#include "pgpdisk_common.h"
+
+#define FORMAT_LABEL            "pgpdisk-opencl"
+#define ALGORITHM_NAME          "SHA1 OpenCL"
+#define BINARY_SIZE             16
+#define BINARY_ALIGN            sizeof(uint32_t)
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define SALT_ALIGN              sizeof(uint32_t)
+#define PLAINTEXT_LENGTH        125
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1001
+
+typedef struct {
+	uint32_t length;
+	uint8_t v[PLAINTEXT_LENGTH];
+} pgpdisk_password;
+
+typedef struct {
+	uint8_t v[32];
+} pgpdisk_hash;
+
+typedef struct {
+	uint32_t saltlen;
+	uint32_t iterations;
+	uint32_t key_len;
+	uint8_t salt[16];
+} pgpdisk_salt;
+
+static uint32_t (*crypt_out)[BINARY_SIZE * 2 / sizeof(uint32_t)];
+static struct custom_salt *cur_salt;
+
+static cl_int cl_error;
+static pgpdisk_password *inbuffer;
+static pgpdisk_hash *outbuffer;
+static pgpdisk_salt currentsalt;
+static cl_mem mem_in, mem_out, mem_setting;
+static struct fmt_main *self;
+
+size_t insize, outsize, settingsize;
+
+// This file contains auto-tuning routine(s). Has to be included after formats definitions.
+#include "opencl-autotune.h"
+#include "memdbg.h"
+
+static const char *warn[] = {
+	"xfer: ",  ", crypt: ",  ", xfer: "
+};
+
+static size_t get_task_max_work_group_size()
+{
+	return autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel);
+}
+
+static void create_clobj(size_t gws, struct fmt_main *self)
+{
+	insize = sizeof(pgpdisk_password) * gws;
+	outsize = sizeof(pgpdisk_hash) * gws;
+	settingsize = sizeof(pgpdisk_salt);
+	crypt_out = mem_calloc(gws, sizeof(*crypt_out));
+
+	inbuffer = mem_calloc(1, insize);
+	outbuffer = mem_alloc(outsize);
+
+	// Allocate memory
+	mem_in =
+	    clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, insize, NULL,
+	    &cl_error);
+	HANDLE_CLERROR(cl_error, "Error allocating mem in");
+	mem_setting =
+	    clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, settingsize,
+	    NULL, &cl_error);
+	HANDLE_CLERROR(cl_error, "Error allocating mem setting");
+	mem_out =
+	    clCreateBuffer(context[gpu_id], CL_MEM_WRITE_ONLY, outsize, NULL,
+	    &cl_error);
+	HANDLE_CLERROR(cl_error, "Error allocating mem out");
+
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 0, sizeof(mem_in),
+		&mem_in), "Error while setting mem_in kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 1, sizeof(mem_out),
+		&mem_out), "Error while setting mem_out kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 2, sizeof(mem_setting),
+		&mem_setting), "Error while setting mem_salt kernel argument");
+}
+
+static void release_clobj(void)
+{
+	if (inbuffer) {
+		HANDLE_CLERROR(clReleaseMemObject(mem_in), "Release mem in");
+		HANDLE_CLERROR(clReleaseMemObject(mem_setting), "Release mem setting");
+		HANDLE_CLERROR(clReleaseMemObject(mem_out), "Release mem out");
+
+		MEM_FREE(inbuffer);
+		MEM_FREE(outbuffer);
+	}
+}
+
+static void init(struct fmt_main *_self)
+{
+	self = _self;
+	opencl_prepare_dev(gpu_id);
+	Twofish_initialise();
+}
+
+static void reset(struct db_main *db)
+{
+	if (!autotuned) {
+		char build_opts[64];
+
+		snprintf(build_opts, sizeof(build_opts),
+		         "-DPLAINTEXT_LENGTH=%d",
+		         PLAINTEXT_LENGTH);
+		opencl_init("$JOHN/kernels/pgpdisk_kernel.cl",
+		            gpu_id, build_opts);
+
+		crypt_kernel = clCreateKernel(program[gpu_id], "pgpdisk", &cl_error);
+		HANDLE_CLERROR(cl_error, "Error creating kernel");
+
+		// Initialize openCL tuning (library) for this format.
+		opencl_init_auto_setup(SEED, 0, NULL, warn, 1, self,
+		                       create_clobj, release_clobj,
+		                       sizeof(pgpdisk_password), 0, db);
+
+		// Auto tune execution from shared/included code.
+		autotune_run(self, 1, 0, 300);
+	}
+}
+
+static void done(void)
+{
+	if (autotuned) {
+		release_clobj();
+
+		HANDLE_CLERROR(clReleaseKernel(crypt_kernel), "Release kernel");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program");
+
+		autotuned--;
+	}
+}
+
+static void *get_binary(char *ciphertext)
+{
+	static union {
+		unsigned char c[BINARY_SIZE];
+		uint32_t dummy;
+	} buf;
+	unsigned char *out = buf.c;
+	char *p;
+	int i;
+	p = strrchr(ciphertext, '*') + 1;
+	for (i = 0; i < BINARY_SIZE; i++) {
+		out[i] = (atoi16[ARCH_INDEX(*p)] << 4) | atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+
+	return out;
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (struct custom_salt *)salt;
+
+	currentsalt.iterations = cur_salt->iterations;
+	if (cur_salt->algorithm == 3) {
+		currentsalt.key_len = 16;
+		currentsalt.saltlen= 8;
+	} else {
+		currentsalt.key_len = 32;
+		currentsalt.saltlen = 16;
+	}
+	memcpy((char*)currentsalt.salt, cur_salt->salt, currentsalt.saltlen);
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_setting,
+		CL_FALSE, 0, settingsize, &currentsalt, 0, NULL, NULL),
+	    "Copy setting to gpu");
+}
+
+#undef set_key
+static void set_key(char *key, int index)
+{
+	uint32_t length = strlen(key);
+
+	if (length > PLAINTEXT_LENGTH)
+		length = PLAINTEXT_LENGTH;
+	inbuffer[index].length = length;
+	memcpy(inbuffer[index].v, key, length);
+}
+
+static char *get_key(int index)
+{
+	static char ret[PLAINTEXT_LENGTH + 1];
+	uint32_t length = inbuffer[index].length;
+	memcpy(ret, inbuffer[index].v, length);
+	ret[length] = '\0';
+	return ret;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index = 0;
+	size_t *lws = local_work_size ? &local_work_size : NULL;
+
+	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+
+	// Copy data to gpu
+	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+		"Copy data to gpu");
+
+	// Run kernel
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
+		NULL, &global_work_size, lws, 0, NULL,
+		multi_profilingEvent[1]),
+		"Run kernel");
+
+	// Read the result back
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
+		outsize, outbuffer, 0, NULL, multi_profilingEvent[2]),
+		"Copy result back");
+
+	if (ocl_autotune_running)
+		return count;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index++) {
+		unsigned char key[40];
+		memcpy(key, outbuffer[index].v, 32);
+
+		if (cur_salt->algorithm == 5 || cur_salt->algorithm == 6 || cur_salt->algorithm == 7) {
+			AES_KEY aes_key;
+
+			AES_set_encrypt_key(key, 256, &aes_key);
+			AES_ecb_encrypt(key, (unsigned char*)crypt_out[index], &aes_key, AES_ENCRYPT);
+		} else if (cur_salt->algorithm == 4) {
+			Twofish_key tkey;
+
+			Twofish_prepare_key(key, 32, &tkey);
+			Twofish_encrypt(&tkey, key, (unsigned char*)crypt_out[index]);
+		} else if (cur_salt->algorithm == 3) {
+			CAST_KEY ck;
+
+			CAST_set_key(&ck, 16, key);
+			memset((unsigned char*)crypt_out[index], 0, BINARY_SIZE);
+			CAST_ecb_encrypt(key, (unsigned char*)crypt_out[index], &ck, CAST_ENCRYPT);
+		}
+	}
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index = 0;
+	for (; index < count; index++)
+		if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main fmt_opencl_pgpdisk = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		{ NULL },
+		{ FORMAT_TAG },
+		pgpdisk_tests,
+	},
+	{
+		init,
+		done,
+		reset,
+		fmt_default_prepare,
+		pgpdisk_common_valid,
+		fmt_default_split,
+		get_binary,
+		pgpdisk_common_get_salt,
+		{
+			0
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */
+
+#endif /* HAVE_OPENCL */

--- a/src/pgpdisk_common.h
+++ b/src/pgpdisk_common.h
@@ -1,0 +1,29 @@
+/*
+ * Common code for the PGP Disk format.
+ */
+
+#include <string.h>
+#include <openssl/cast.h>
+
+#include "formats.h"
+#include "sha.h"
+#include "aes.h"
+#include "twofish.h"
+
+#define FORMAT_NAME             ""
+#define FORMAT_TAG              "$pgpdisk$"
+#define FORMAT_TAG_LENGTH       (sizeof(FORMAT_TAG) - 1)
+
+struct custom_salt {
+	int version;
+	int algorithm;
+	int iterations;
+	int salt_size;
+	unsigned char salt[16];
+};
+
+extern struct fmt_tests pgpdisk_tests[];
+
+// exported 'common' functions
+int pgpdisk_common_valid(char *ciphertext, struct fmt_main *self);
+void *pgpdisk_common_get_salt(char *ciphertext);

--- a/src/pgpdisk_common_plug.c
+++ b/src/pgpdisk_common_plug.c
@@ -1,0 +1,102 @@
+/*
+ * Common code for the PGP Disk format.
+ */
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "pgpdisk_common.h"
+#include "sha.h"
+#include "memdbg.h"
+
+struct fmt_tests pgpdisk_tests[] = {
+	// Windows 7 + Symantec Encryption Desktop 10.4.1 MP1
+	{"$pgpdisk$0*5*16000*3a1bfe10b9d17cf7b446cd94564fc594*1a1ce4453d81117830934495a2516ebc", "openwall"},
+	{"$pgpdisk$0*5*16000*1786114971183410acfdc211cbf46230*7d94867264bc005a4a3c1dd211a13a91", "openwall"},
+	{"$pgpdisk$0*4*16000*5197b63e47ea0254e719bce690d80fc2*7cbce8cfe5b1d15bb5d25126d76e7626", "openwall"}, // Twofish
+	{"$pgpdisk$0*3*16000*3a3c3127fdfa2ea44318cac87c62d263*0a9f26421c5d78e50000000000000000", "openwall"}, // CAST5
+	// macOS Sierra + Symantec Encryption Desktop 10.4.1 MP1
+	{"$pgpdisk$0*5*16822*67a26aeb7d1f237214cce56527480d65*9eee4e08e8bd17afdddd45b19760823d", "12345678"},
+	{"$pgpdisk$0*5*12608*72eacfad309a37bf169a4c7375a583d2*5725d6c36ded48b4309edb2e7fcdc69c", "äbc"},
+	{"$pgpdisk$0*5*14813*72eacfad309a37bf169a4c7375a583d2*d3e61d400fecc177a100f576a5138570", "bar"},
+	{"$pgpdisk$0*5*14792*72eacfad309a37bf169a4c7375a583d2*304ae364c311bbde2d6965ca3246a823", "foo"},
+	{"$pgpdisk$0*7*17739*fb5de863aa2766aff5562db5a7b34ffd*9ca8d6b97c7ebea876f7db7fe35d9f15", "openwall"}, // EME2-AES
+	{"$pgpdisk$0*5*19193*5d535ca4089270b24e8cd32e2dc8f6c8*8094cde867c142452c1ed82c59655d0a", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, // 125 a's
+	// Windows XP SP3 + PGP 8.0
+	{"$pgpdisk$0*3*16000*3248d14732ecfb671dda27fd614813bc*4829a0152666928f0000000000000000", "openwall"},
+	{"$pgpdisk$0*4*16000*b47a66d9d4cf45613c3c73a2952d7b88*4e1cd2de6e986d999e1676b2616f5337", "openwall"},
+	{NULL}
+};
+
+int pgpdisk_common_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *p = ciphertext, *ctcopy, *keeptr;
+	int extra;
+	int res;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
+		return 0;
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LENGTH;
+	if ((p = strtokm(ctcopy, "*")) == NULL) // version
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if ((p = strtokm(NULL, "*")) == NULL) // algorithm
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	res = atoi(p);
+	if (res != 7 && res != 6 && res != 5 && res != 4 && res != 3) // EME-AES, EME2-AES, AES-256, Twofish, CAST5
+		goto bail;
+	if ((p = strtokm(NULL, "*")) == NULL) // iterations
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if ((p = strtokm(NULL, "*")) == NULL) // salt
+		goto bail;
+	if (hexlenl(p, &extra) > 16 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+	if ((p = strtokm(NULL, "*")) == NULL) // CheckBytes
+		goto bail;
+	if (hexlenl(p, &extra) > 16 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+
+	MEM_FREE(keeptr);
+	return 1;
+
+bail:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *pgpdisk_common_get_salt(char *ciphertext)
+{
+	static struct custom_salt cs;
+	int i;
+	char *p = ciphertext, *ctcopy, *keeptr;
+
+	memset(&cs, 0, sizeof(cs));
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LENGTH;
+	p = strtokm(ctcopy, "*");
+	cs.version = atoi(p);
+	p = strtokm(NULL, "*");
+	cs.algorithm = atoi(p);
+	p = strtokm(NULL, "*");
+	cs.iterations = atoi(p);
+	p = strtokm(NULL, "*");
+	cs.salt_size = 16;
+	for (i = 0; i < cs.salt_size; i++)
+		cs.salt[i] = (atoi16[ARCH_INDEX(p[2*i])] << 4) | atoi16[ARCH_INDEX(p[2*i+1])];
+
+	MEM_FREE(keeptr);
+
+	return (void *)&cs;
+}


### PR DESCRIPTION
Writing a pure GPU kernel would involve a lot of work, like implementing Twofish and CAST5 on the GPU.

This fixes #2699.