### PR TITLE
Ztex improve

### DIFF
--- a/src/ztex/pkt_comm/cmp_config.c
+++ b/src/ztex/pkt_comm/cmp_config.c
@@ -73,7 +73,7 @@ void cmp_config_new(struct db_salt *salt, void *salt_ptr, int salt_len)
 	if (num_hashes > jtr_bitstream->cmp_entries_max) {
 		num_hashes = jtr_bitstream->cmp_entries_max;
 		if (!warning_num_hashes) {
-			fprintf(stderr, "Warning: salt with %d hashes, device supports"
+			fprintf(stderr, "Warning: salt with %d hashes, device supports "
 				"max. %d hashes/salt, extra hashes ignored\n",
 				salt->count, jtr_bitstream->cmp_entries_max);
 			warning_num_hashes = 1;
@@ -128,6 +128,8 @@ void cmp_config_new(struct db_salt *salt, void *salt_ptr, int salt_len)
 			continue;
 		cmp_config.pw[offset++] = pw;
 		cmp_config.num_hashes ++;
+		if (cmp_config.num_hashes == jtr_bitstream->cmp_entries_max)
+			break;
 	}
 
 	if (cmp_config.num_hashes == 1)

--- a/src/ztex/ztex_scan.c
+++ b/src/ztex/ztex_scan.c
@@ -58,8 +58,9 @@ int ztex_scan(struct ztex_dev_list *new_dev_list, struct ztex_dev_list *dev_list
 			count++;
 			continue;
 		}
-		// dummy firmware, do upload
-		else if (!strncmp("USB-FPGA Module 1.15y (default)", dev->product_string, 31)) {
+		// 3rd party firmware or dummy firmware, do upload/override
+		else if (ZTEX_FW_3RD_PARTY_OVERWRITE
+			|| !strncmp("USB-FPGA Module 1.15y (default)", dev->product_string, 31)) {
 			// upload firmware
 			result = ztex_firmware_upload(dev, ZTEX_FW_IHX_PATH);
 			if (result >= 0) {

--- a/src/ztex/ztex_scan.h
+++ b/src/ztex/ztex_scan.h
@@ -15,6 +15,9 @@ extern int ztex_scan_interval;
 
 extern struct timeval ztex_scan_prev_time;
 
+// If set to 1, overwrite any 3rd party firmware
+#define ZTEX_FW_3RD_PARTY_OVERWRITE 1
+
 // firmware image file (*.ihx)
 #define ZTEX_FW_IHX_PATH	"ztex/inouttraffic.ihx"
 


### PR DESCRIPTION
### Summary

- fixed bug in memory allocation in a case where number of hashes per salt exceeds the maximum number supported by bitstream;
- changed the behavior when it detects 3rd party firmware on the board - now it just overwrites it.