### PR TITLE
Force python2

### DIFF
--- a/run/luks2john.py
+++ b/run/luks2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This software is Copyright (c) 2016, Sanju Kholia <sanju.kholia at gmail.com>
 # and it is hereby released to the general public under the following terms:


### PR DESCRIPTION
### Summary

Forced usage of python 2 for luks2john.py.
in python3 the variable magic will be a bytes object which will not evaluate to True for magic == "LUKS\xba\xbe"