### PR TITLE
Update Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,19 @@ matrix:
   include:
   - os: linux
     compiler: gcc
-    env: ASAN="--enable-asan" OPENCL="yes"
-
-  - os: linux
-    compiler: clang
     env: ASAN="" OPENCL="yes"
 
   - os: linux
+    compiler: clang
+    env: ASAN=""
+
+  - os: linux
+    compiler: gcc
+    env: ASAN="--enable-asan"
+
+  - os: linux
     env: ASAN="--enable-asan" TEST="fresh test"
-
-  - os: linux
-    env: ASAN="" TEST="TS --restore"
-
-  - os: linux
-    env: ASAN="" TEST="no OpenMP" OPENCL="yes"
+    group: deprecated-2017Q3
 
   - os: osx
     osx_image: xcode8.3
@@ -33,24 +32,17 @@ matrix:
 
   allow_failures:
   - os: linux
-    env: ASAN="--enable-asan" OPENCL="yes"
-
-  - os: linux
-    env: ASAN="" OPENCL="yes"
+    compiler: gcc
+    env: ASAN="--enable-asan"
 
   - os: linux
     env: ASAN="--enable-asan" TEST="fresh test"
 
-  - os: linux
-    env: ASAN="" TEST="TS --restore"
-
-  - os: linux
-    env: ASAN="" TEST="no OpenMP" OPENCL="yes"
+  - os: osx
+    osx_image: xcode8.3
+    env: ASAN="" OPENCL="yes"
 
   fast_finish: true
-
-before_install:
-  - export OMP_NUM_THREADS=4
 
 script:
   - .travis/check.sh

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # There is a bug in echo -e in Travis
-echo '[Disabled:Formats]' > john-local.conf
+echo '[Local:Disabled:Formats]' > john-local.conf
 echo 'Raw-SHA512-free-opencl = Y' >> john-local.conf
 echo 'XSHA512-free-opencl = Y' >> john-local.conf
 echo 'gpg-opencl = Y' >> john-local.conf


### PR DESCRIPTION
Closes #2736. 

* The goal is to test and produce a result as fast as possible
* The build jobs (ones that can't fail) will run in approx 25 minutes
* It is possible to reduce the time if we separate the slower test into 2 sets (cpu and opencl)
* Apple stuff can take hours to start to build, so I made it 'optional' (the build result do not depend on it).
