### PR TITLE
Add pocl as a valid OpenCL implementation

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -11401,7 +11401,7 @@ else
   CPPFLAGS="$CL_CFLAGS $CPPFLAGS"
   ax_save_LIBS=$LIBS
   LIBS=""
-  ax_check_libs="-lOpenCL -lCL -lclparser"
+  ax_check_libs="-lOpenCL -lCL -lclparser -lpocl"
   for ax_lib in $ax_check_libs; do
     if test X$ax_compiler_ms = Xyes; then :
   ax_try_lib=`echo $ax_lib | $SED -e 's/^-l//' -e 's/$/.lib/'`

--- a/src/m4/ax_opencl.m4
+++ b/src/m4/ax_opencl.m4
@@ -82,7 +82,7 @@ if test "$disable_opencl" = 'yes'; then
   CPPFLAGS="$CL_CFLAGS $CPPFLAGS"
   ax_save_LIBS=$LIBS
   LIBS=""
-  ax_check_libs="-lOpenCL -lCL -lclparser"
+  ax_check_libs="-lOpenCL -lCL -lclparser -lpocl"
   for ax_lib in $ax_check_libs; do
     AS_IF([test X$ax_compiler_ms = Xyes],
           [ax_try_lib=`echo $ax_lib | $SED -e 's/^-l//' -e 's/$/.lib/'`],


### PR DESCRIPTION
Portable Computing Language (pocl) aims to become a MIT-licensed
open source implementation of the OpenCL standard which can be
easily adapted for new targets and devices, both for homogeneous
CPU and heterogeneous GPUs/accelerators.

It can't run all formats, but it can be used to improve our OpenCL
testing using Docker images.