### PR TITLE
wpapcap2john: Re-introduce support for Ethernet encapsulation. See #2751

### DIFF
--- a/src/wpapcap2john.h
+++ b/src/wpapcap2john.h
@@ -249,3 +249,19 @@ struct ivs2_WPA_hdsk
     int keyver;                                  /* key version (TKIP / AES)     */
     int state;                                   /* handshake completion         */
 };
+
+#if WPADEBUG
+static void dump_hex(char *msg, void *x, unsigned int size)
+{
+	unsigned int i;
+
+	fprintf(stderr, "%s : ", msg);
+
+	for (i = 0; i < size; i++) {
+		fprintf(stderr, "%.2x", ((unsigned char*)x)[i]);
+		if ((i % 4) == 3)
+			fprintf(stderr, " ");
+	}
+	fprintf(stderr, "\n");
+}
+#endif


### PR DESCRIPTION
@kholia here's my stab at #2751. My code too is somewhat hairy, but it's less intrusive and keeps full functionality of `wpa[ess]` ie. dupe checking and so on.

What I do is "fabricate" a fake 802.11 header using the original Ethernet data. It seems to work just fine.