### PR TITLE
Removed limit of (2^18-4) keys/board per crypt_all()

### DIFF
--- a/src/ztex/device_bitstream.h
+++ b/src/ztex/device_bitstream.h
@@ -23,8 +23,7 @@ struct device_bitstream {
 	// (keys * mask_num_cand)/crypt_all_interval per jtr_device.
 	unsigned int candidates_per_crypt;
 	// keys/crypt_all_interval for all devices - link layer performance issue.
-	// Also consider 16-bit IDs for template_list/word_list:
-	// no more than (64K - 1) keys per crypt_all per jtr_device
+	// As keys are of variable size, this is a rough upper limit.
 	unsigned int abs_max_keys_per_crypt;
 	// Max. number of entries in onboard comparator
 	int cmp_entries_max;

--- a/src/ztex_bcrypt.c
+++ b/src/ztex_bcrypt.c
@@ -56,7 +56,7 @@ static struct device_bitstream bitstream = {
 	// computing performance estimation (in candidates per interval)
 	// (keys * mask_num_cand)/crypt_all_interval per jtr_device.
 	1,	// set by init()
-	262140,	// Absolute max. keys/crypt_all_interval for all devices.
+	1 * 1024*1024,	// Absolute max. keys/crypt_all_interval for all devices.
 	3,		// Max. number of entries in onboard comparator.
 	124,	// Min. number of keys for effective device utilization
 	1, { 141 },	// Programmable clocks

--- a/src/ztex_descrypt.c
+++ b/src/ztex_descrypt.c
@@ -54,7 +54,7 @@ struct device_bitstream bitstream = {
 	// (keys * mask_num_cand)/crypt_all_interval per jtr_device.
 	35 * 1024*1024,
 	// Absolute max. keys/crypt_all_interval for all devices.
-	262140,
+	2 * 1024*1024,
 	// Max. number of entries in onboard comparator.
 	2047,
 	0,	// Min. number of keys (doesn't matter for fast "formats")


### PR DESCRIPTION
### Summary

Such a limit appeared because of 16-bit word(key) ID in word_list/template_list packet and internally in FPGA where IDs are stored/processed.
Now it just sends several packets where necessary.
