### PR TITLE
BitLocker-OpenCL

### DIFF
--- a/src/bitlocker2john.c
+++ b/src/bitlocker2john.c
@@ -30,7 +30,6 @@
 #if  (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER
 #include <unistd.h> // getopt defined here for unix
 #endif
-#include <getopt.h>
 #include "params.h"
 #include "memory.h"
 #include "memdbg.h"
@@ -43,14 +42,6 @@
 #define INPUT_SIZE 2048
 
 static unsigned char salt[SALT_SIZE], nonce[NONCE_SIZE], mac[MAC_SIZE], vmk[VMK_SIZE];
-
-static struct option long_options[] =
-{
-	{"help", no_argument, 0, 'h'},
-	{"image", required_argument, 0, 'i'},
-	{"outfile", required_argument, 0, 'o'},
-	{0, 0, 0, 0}
-};
 
 void * Calloc(size_t len, size_t size) {
 	void * ptr = NULL;
@@ -240,11 +231,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 static int usage(char *name){
 	printf("\nUsage: %s -i <Encrypted memory unit> -o <output file>\n\n"
 		"Options:\n\n"
-		"  -h, --help"
+		"  -h"
 		"\t\tShow this help\n"
-		"  -i, --image"
+		"  -i"
 		"\t\tPath of memory unit encrypted with BitLocker\n"
-		"  -o, --outfile"
+		"  -o"
 		"\t\tOutput file\n\n", name);
 
 	return EXIT_FAILURE;
@@ -252,12 +243,12 @@ static int usage(char *name){
 
 int main(int argc, char **argv)
 {
-	int opt, option_index = 0;
+	int opt = 0;
 	char * imagePath=NULL, * outFile=NULL;
 	
 	errno = 0;
 	while (1) {
-		opt = getopt_long(argc, argv, "hi:o:", long_options, &option_index);
+		opt = getopt(argc, argv, "hi:o:");
 		if (opt == -1)
 			break;
 		switch (opt)

--- a/src/opencl/bitlocker_kernel.cl
+++ b/src/opencl/bitlocker_kernel.cl
@@ -286,20 +286,6 @@ __constant unsigned int TS3[256] = {
 	0x5454FCA8U, 0xBBBBD66DU, 0x16163A2CU
 };
 
-#if 0 /* This is not used */
-inline unsigned int IADD3(unsigned int a, unsigned int b, unsigned int c)
-{
-#if HAVE_LUT3
-	unsigned int d;
-
-	asm("iadd3 %0, %1, %2, %3;": "=r"(d):"r"(a), "r"(b), "r"(c));
-	return d;
-#else
-	return a + b + c;
-#endif
-}
-#endif
-
 inline unsigned int LOP3LUT_XOR(unsigned int a, unsigned int b, unsigned int c)
 {
 #if HAVE_LUT3
@@ -452,55 +438,17 @@ __kernel void opencl_bitlocker_attack_init(__global int *numPasswordMem,
                                       __global int *output_hash
                                       )
 {
-	int globalIndexPassword = (int)get_global_id(0);
-
-	unsigned int schedule0;
-	unsigned int schedule1;
-	unsigned int schedule2;
-	unsigned int schedule3;
-	unsigned int schedule4;
-	unsigned int schedule5;
-	unsigned int schedule6;
-	unsigned int schedule7;
-	unsigned int schedule8;
-	unsigned int schedule9;
-	unsigned int schedule10;
-	unsigned int schedule11;
-	unsigned int schedule12;
-	unsigned int schedule13;
-	unsigned int schedule14;
-	unsigned int schedule15;
-	unsigned int schedule16;
-	unsigned int schedule17;
-	unsigned int schedule18;
-	unsigned int schedule19;
-	unsigned int schedule20;
-	unsigned int schedule21;
-	unsigned int schedule22;
-	unsigned int schedule23;
-	unsigned int schedule24;
-	unsigned int schedule25;
-	unsigned int schedule26;
-	unsigned int schedule27;
-	unsigned int schedule28;
-	unsigned int schedule29;
-	unsigned int schedule30;
-	unsigned int schedule31;
-
+	unsigned int schedule0, schedule1, schedule2, schedule3, schedule4, schedule5, schedule6, schedule7, schedule8, schedule9;
+	unsigned int schedule10, schedule11, schedule12, schedule13, schedule14, schedule15, schedule16, schedule17, schedule18, schedule19;
+	unsigned int schedule20, schedule21, schedule22, schedule23, schedule24, schedule25, schedule26, schedule27, schedule28, schedule29;
+	unsigned int schedule30, schedule31;
+	unsigned int first_hash0, first_hash1, first_hash2, first_hash3, first_hash4, first_hash5, first_hash6, first_hash7;
 	unsigned int a, b, c, d, e, f, g, h;
-	int index_generic;
-	unsigned int first_hash0;
-	unsigned int first_hash1;
-	unsigned int first_hash2;
-	unsigned int first_hash3;
-	unsigned int first_hash4;
-	unsigned int first_hash5;
-	unsigned int first_hash6;
-	unsigned int first_hash7;
-	int numPassword = numPasswordMem[0];
-
-	unsigned int indexW = (globalIndexPassword * FIXED_PASSWORD_BUFFER);
-	int curr_fetch=0;
+	int index_generic=0, numPassword = 0, curr_fetch=0, indexW=0;
+	int globalIndexPassword = (int)get_global_id(0);
+	
+	numPassword = numPasswordMem[0];
+	indexW = (globalIndexPassword * FIXED_PASSWORD_BUFFER);
 
 	while (globalIndexPassword < numPassword) {
 
@@ -764,74 +712,29 @@ __kernel void opencl_bitlocker_attack_init(__global int *numPasswordMem,
 	}
 }
 
+// ----- Main SHA-256 loop
 __kernel void opencl_bitlocker_attack_loop(__global int *numPasswordMem,
                                       __global unsigned int *w_blocks_d,
                                       __global int *first_hash,
                                       __global int *output_hash,
                                       __global int *numIterPtr)
 {
-	int globalIndexPassword = get_global_id(0);
-
-	unsigned int hash0;
-	unsigned int hash1;
-	unsigned int hash2;
-	unsigned int hash3;
-	unsigned int hash4;
-	unsigned int hash5;
-	unsigned int hash6;
-	unsigned int hash7;
-
-	unsigned int schedule0;
-	unsigned int schedule1;
-	unsigned int schedule2;
-	unsigned int schedule3;
-	unsigned int schedule4;
-	unsigned int schedule5;
-	unsigned int schedule6;
-	unsigned int schedule7;
-	unsigned int schedule8;
-	unsigned int schedule9;
-	unsigned int schedule10;
-	unsigned int schedule11;
-	unsigned int schedule12;
-	unsigned int schedule13;
-	unsigned int schedule14;
-	unsigned int schedule15;
-	unsigned int schedule16;
-	unsigned int schedule17;
-	unsigned int schedule18;
-	unsigned int schedule19;
-	unsigned int schedule20;
-	unsigned int schedule21;
-	unsigned int schedule22;
-	unsigned int schedule23;
-	unsigned int schedule24;
-	unsigned int schedule25;
-	unsigned int schedule26;
-	unsigned int schedule27;
-	unsigned int schedule28;
-	unsigned int schedule29;
-	unsigned int schedule30;
-	unsigned int schedule31;
-
+	unsigned int schedule0, schedule1, schedule2, schedule3, schedule4, schedule5, schedule6, schedule7, schedule8, schedule9;
+	unsigned int schedule10, schedule11, schedule12, schedule13, schedule14, schedule15, schedule16, schedule17, schedule18, schedule19;
+	unsigned int schedule20, schedule21, schedule22, schedule23, schedule24, schedule25, schedule26, schedule27, schedule28, schedule29;
+	unsigned int schedule30, schedule31;
+	unsigned int first_hash0, first_hash1, first_hash2, first_hash3, first_hash4, first_hash5, first_hash6, first_hash7;
+	unsigned int hash0, hash1, hash2, hash3, hash4, hash5, hash6, hash7;
 	unsigned int a, b, c, d, e, f, g, h;
-	unsigned int first_hash0;
-	unsigned int first_hash1;
-	unsigned int first_hash2;
-	unsigned int first_hash3;
-	unsigned int first_hash4;
-	unsigned int first_hash5;
-	unsigned int first_hash6;
-	unsigned int first_hash7;
-	int numPassword = numPasswordMem[0];
-	int numIter = numIterPtr[0];
-	unsigned int indexW = 0;
-	int index = 0;
 
-	//For each password
+	int index, numPassword = 0, curr_fetch=0, indexW=0;
+	int globalIndexPassword = (int)get_global_id(0);
+	int numIter = numIterPtr[0];
+	
+	numPassword = numPasswordMem[0];
+
 	while (globalIndexPassword < numPassword)
 	{
-		//Starting index for W Block
 		indexW = (SINGLE_BLOCK_W_SIZE * numIter * HASH_LOOPS);
 
 		first_hash0 = first_hash[(globalIndexPassword*INT_HASH_SIZE) + 0];
@@ -852,10 +755,8 @@ __kernel void opencl_bitlocker_attack_loop(__global int *numPasswordMem,
 		hash6 = output_hash[(globalIndexPassword*INT_HASH_SIZE) + 6];
 		hash7 = output_hash[(globalIndexPassword*INT_HASH_SIZE) + 7];
 
-		// HASH_LOOPS num of iteration
 		for (index = 0; index < HASH_LOOPS; index++)
 		{
-			// Prima parte
 			a = 0x6A09E667;
 			b = 0xBB67AE85;
 			c = 0x3C6EF372;
@@ -1062,6 +963,7 @@ __kernel void opencl_bitlocker_attack_loop(__global int *numPasswordMem,
 	}
 }
 
+// ----- Finale AES-CCM
 __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
                                       __global int *found,
                                       __global unsigned char *vmkKey,
@@ -1176,7 +1078,6 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
 		                            TS1[(schedule0 >> 16) & 0xFF], TS2[(schedule1 >> 8) & 0xFF]),
 		                TS3[schedule2 & 0xFF], hash7);
 
-		//----- 2
 		hash0 ^= (TS2[(hash7 >> 24)] & 0x000000FF) ^
 		         (TS3[(hash7 >> 16) & 0xFF] & 0xFF000000) ^
 		         (TS0[(hash7 >> 8) & 0xFF] & 0x00FF0000) ^
@@ -1228,7 +1129,6 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
 		                TS3[schedule2 & 0xFF], hash7);
 
 
-		//----- 3
 		hash0 ^= (TS2[(hash7 >> 24)] & 0x000000FF) ^
 		         (TS3[(hash7 >> 16) & 0xFF] & 0xFF000000) ^
 		         (TS0[(hash7 >> 8) & 0xFF] & 0x00FF0000) ^
@@ -1280,8 +1180,6 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
 		                            TS1[(schedule0 >> 16) & 0xFF], TS2[(schedule1 >> 8) & 0xFF]),
 		                TS3[schedule2 & 0xFF], hash7);
 
-
-		//----- 4
 		hash0 ^= (TS2[(hash7 >> 24)] & 0x000000FF) ^
 		         (TS3[(hash7 >> 16) & 0xFF] & 0xFF000000) ^
 		         (TS0[(hash7 >> 8) & 0xFF] & 0x00FF0000) ^
@@ -1332,8 +1230,6 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
 		                            TS1[(schedule0 >> 16) & 0xFF], TS2[(schedule1 >> 8) & 0xFF]),
 		                TS3[schedule2 & 0xFF], hash7);
 
-
-		//----- 5
 		hash0 ^= (TS2[(hash7 >> 24)] & 0x000000FF) ^
 		         (TS3[(hash7 >> 16) & 0xFF] & 0xFF000000) ^
 		         (TS0[(hash7 >> 8) & 0xFF] & 0x00FF0000) ^
@@ -1384,8 +1280,6 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
 		                            TS1[(schedule0 >> 16) & 0xFF], TS2[(schedule1 >> 8) & 0xFF]),
 		                TS3[schedule2 & 0xFF], hash7);
 
-
-		//----- 6
 		hash0 ^= (TS2[(hash7 >> 24)] & 0x000000FF) ^
 		         (TS3[(hash7 >> 16) & 0xFF] & 0xFF000000) ^
 		         (TS0[(hash7 >> 8) & 0xFF] & 0x00FF0000) ^
@@ -1436,7 +1330,6 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
 		                            TS1[(schedule0 >> 16) & 0xFF], TS2[(schedule1 >> 8) & 0xFF]),
 		                TS3[schedule2 & 0xFF], hash7);
 
-		// last 4 words
 		hash0 ^= (TS2[(hash7 >> 24)] & 0x000000FF) ^
 		         (TS3[(hash7 >> 16) & 0xFF] & 0xFF000000) ^
 		         (TS0[(hash7 >> 8) & 0xFF] & 0x00FF0000) ^
@@ -1445,7 +1338,6 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
 		hash2 ^= hash1;
 		hash3 ^= hash2;
 
-		// NR-th round
 		schedule0 = (TS2[(schedule4 >> 24)] & 0xFF000000) ^
 		            (TS3[(schedule5 >> 16) & 0xFF] & 0x00FF0000) ^
 		            (TS0[(schedule6 >> 8) & 0xFF] & 0x0000FF00) ^

--- a/src/opencl/bitlocker_kernel.cl
+++ b/src/opencl/bitlocker_kernel.cl
@@ -963,7 +963,7 @@ __kernel void opencl_bitlocker_attack_loop(__global int *numPasswordMem,
 	}
 }
 
-// ----- Finale AES-CCM
+// ----- Final AES-CCM
 __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
                                       __global int *found,
                                       __global unsigned char *vmkKey,

--- a/src/opencl/bitlocker_kernel.cl
+++ b/src/opencl/bitlocker_kernel.cl
@@ -972,26 +972,9 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
                                       __global unsigned int *IV8, __global unsigned int *IV12,
                                       __global int *output_hash)
 {
+	unsigned int schedule0, schedule1, schedule2, schedule3, schedule4, schedule5, schedule6, schedule7;
+	unsigned int hash0, hash1, hash2, hash3, hash4, hash5, hash6, hash7;
 	int globalIndexPassword = get_global_id(0);
-
-	unsigned int hash0;
-	unsigned int hash1;
-	unsigned int hash2;
-	unsigned int hash3;
-	unsigned int hash4;
-	unsigned int hash5;
-	unsigned int hash6;
-	unsigned int hash7;
-
-	unsigned int schedule0;
-	unsigned int schedule1;
-	unsigned int schedule2;
-	unsigned int schedule3;
-	unsigned int schedule4;
-	unsigned int schedule5;
-	unsigned int schedule6;
-	unsigned int schedule7;
-
 	int numPassword = numPasswordMem[0];
 
 	while (globalIndexPassword < numPassword) {
@@ -1358,23 +1341,33 @@ __kernel void opencl_bitlocker_attack_final(__global int *numPasswordMem,
 		            (TS0[(schedule5 >> 8) & 0xFF] & 0x0000FF00) ^
 		            (TS1[(schedule6) & 0xFF] & 0x000000FF) ^ hash3;
 
-
 		schedule4 =
 		    (unsigned int)(((unsigned int)(schedule0 & 0xff000000)) >> 24) |
 		    (unsigned int)((unsigned int)(schedule0 & 0x00ff0000) >> 8) |
 		    (unsigned int)((unsigned int)(schedule0 & 0x0000ff00) << 8) |
 		    (unsigned int)((unsigned int)(schedule0 & 0x000000ff) << 24);
+
+		schedule5 =
+		    (unsigned int)(((unsigned int)(schedule1 & 0xff000000)) >> 24) |
+		    (unsigned int)((unsigned int)(schedule1 & 0x00ff0000) >> 8) |
+		    (unsigned int)((unsigned int)(schedule1 & 0x0000ff00) << 8) |
+		    (unsigned int)((unsigned int)(schedule1 & 0x000000ff) << 24);
+
 		schedule6 =
 		    (unsigned int)(((unsigned int)(schedule2 & 0xff000000)) >> 24) |
 		    (unsigned int)((unsigned int)(schedule2 & 0x00ff0000) >> 8) |
 		    (unsigned int)((unsigned int)(schedule2 & 0x0000ff00) << 8) |
 		    (unsigned int)((unsigned int)(schedule2 & 0x000000ff) << 24);
 
-		if (((vmkKey[16+0] ^ ((unsigned char)schedule4)) == VMK_SIZE) &&
+		if (
+				((vmkKey[16+0] ^ ((unsigned char)schedule4)) == 0x2c) &&
 		        ((vmkKey[16+1] ^ ((unsigned char)(schedule4 >> 8))) == 0x00) &&
+		        ((vmkKey[16+4] ^ ((unsigned char) schedule5)) == 0x01) &&
+                ((vmkKey[16+5] ^ ((unsigned char) (schedule5 >> 8))) == 0x00) &&
 		        ((vmkKey[16+8] ^ ((unsigned char)schedule6)) <= 0x05) &&
 		        ((vmkKey[16+9] ^ ((unsigned char)(schedule6 >> 8))) == 0x20)
-		   ) {
+		   )
+		{
 			found[0] = globalIndexPassword;
 			break;
 		}

--- a/src/opencl_bitlocker_fmt_plug.c
+++ b/src/opencl_bitlocker_fmt_plug.c
@@ -561,7 +561,7 @@ struct fmt_main fmt_opencl_bitlocker = {
 	SALT_ALIGN,
 	MIN_KEYS_PER_CRYPT,
 	MAX_KEYS_PER_CRYPT,
-	FMT_CASE | FMT_8_BIT,
+	FMT_CASE | FMT_8_BIT | FMT_NOT_EXACT,
 		{
 			"iteration count",
 		},


### PR DESCRIPTION
In this pull request:

- bitlocker2john code reworked (more checks on VMK format)
- bitlocker-opencl:
  - code cleanup 
  - comments in main attack kernel

NB. False positive occurred (see issue opened on my repo: https://github.com/e-ago/bitcracker/issues/1 ); I found an empirically verified and more restrictive check to avoid this type of false positives (-s option, see README https://github.com/e-ago/bitcracker). In the future I will improve this option with a slower but more robust check.
Is it possible to add this optional check in this JtR version? (opening in a different pull request)
