### PR TITLE
Rename 'gpu_devices' to be adequate to any accelerator

### DIFF
--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -704,7 +704,7 @@ void opencl_preinit(void)
 			struct list_entry *current;
 
 			/* New syntax, sequential --device */
-			if ((current = options.gpu_devices->head)) {
+			if ((current = options.acc_devices->head)) {
 				do {
 					device_list[n++] = current->data;
 				} while ((current = current->next));
@@ -714,7 +714,7 @@ void opencl_preinit(void)
 				gpu_id = -1;
 		}
 
-		if (!options.gpu_devices->head && gpu_id < 0) {
+		if (!options.acc_devices->head && gpu_id < 0) {
 			char *devcfg;
 
 			if ((devcfg = cfg_get_param(SECTION_OPTIONS,

--- a/src/john.c
+++ b/src/john.c
@@ -403,7 +403,7 @@ static void john_log_format(void)
 
 	/* make sure the format is properly initialized */
 #if HAVE_OPENCL
-	if (!(options.gpu_devices->count && options.fork &&
+	if (!(options.acc_devices->count && options.fork &&
 	      strstr(database.format->params.label, "-opencl")))
 #endif
 	fmt_init(database.format);
@@ -641,7 +641,7 @@ static void john_fork(void)
 			options.node_max = options.node_min;
 #if HAVE_OPENCL
 			// Poor man's multi-device support
-			if (options.gpu_devices->count &&
+			if (options.acc_devices->count &&
 			    strstr(database.format->params.label, "-opencl")) {
 				// Pick device to use for this child
 				opencl_preinit();
@@ -677,7 +677,7 @@ static void john_fork(void)
 
 #if HAVE_OPENCL
 	// Poor man's multi-device support
-	if (options.gpu_devices->count &&
+	if (options.acc_devices->count &&
 	    strstr(database.format->params.label, "-opencl")) {
 		// Pick device to use for mother process
 		opencl_preinit();
@@ -1198,7 +1198,7 @@ static void john_load(void)
 			log_event("Loaded a total of %s", john_loaded_counts());
 			/* make sure the format is properly initialized */
 #if HAVE_OPENCL
-			if (!(options.gpu_devices->count && options.fork &&
+			if (!(options.acc_devices->count && options.fork &&
 			      strstr(database.format->params.label, "-opencl")))
 #endif
 			fmt_init(database.format);

--- a/src/loader.c
+++ b/src/loader.c
@@ -833,7 +833,7 @@ find_format:
 			*ciphertext = prepared;
 			ldr_set_encoding(alt);
 #ifdef HAVE_OPENCL
-			if (options.gpu_devices->count && options.fork &&
+			if (options.acc_devices->count && options.fork &&
 			    strstr(alt->params.label, "-opencl"))
 				*format = alt;
 			else

--- a/src/options.c
+++ b/src/options.c
@@ -252,7 +252,7 @@ static struct opt_entry opt_list[] = {
 #endif
 #if defined(HAVE_OPENCL) || defined(HAVE_ZTEX)
 	{"devices", FLG_ZERO, 0, 0, OPT_REQ_PARAM,
-		OPT_FMT_ADD_LIST_MULTI, &options.gpu_devices},
+		OPT_FMT_ADD_LIST_MULTI, &options.acc_devices},
 #endif
 	{"skip-self-tests", FLG_NOTESTS, FLG_NOTESTS},
 	{"costs", FLG_ZERO, 0, 0, OPT_REQ_PARAM,
@@ -340,9 +340,15 @@ JOHN_USAGE_FORK \
 #define JOHN_USAGE_FORMAT \
 "--format=NAME              force hash of type NAME. The supported formats can\n" \
 "                           be seen with --list=formats and --list=subformats\n\n"
+
 #if defined(HAVE_OPENCL)
 #define JOHN_USAGE_GPU \
 "--devices=N[,..]           set OpenCL device(s) (see --list=opencl-devices)\n"
+#define JOHN_USAGE_ZTEX \
+"                           or set ZTEX device(s) by its(their) serial number(s)\n"
+#elif defined(HAVE_ZTEX)
+#define JOHN_USAGE_ZTEX \
+"--devices=N[,..]           set ZTEX device(s) by its(their) serial number(s)\n"
 #endif
 
 static void print_usage(char *name)
@@ -353,6 +359,9 @@ static void print_usage(char *name)
 	printf(JOHN_USAGE, name);
 #if defined(HAVE_OPENCL)
 	printf("%s", JOHN_USAGE_GPU);
+#endif
+#if defined(HAVE_ZTEX)
+	printf("%s", JOHN_USAGE_ZTEX);
 #endif
 	printf("%s", JOHN_USAGE_FORMAT);
 	exit(0);
@@ -460,7 +469,7 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 	list_init(&options.loader.groups);
 	list_init(&options.loader.shells);
 #if defined(HAVE_OPENCL) || defined(HAVE_ZTEX)
-	list_init(&options.gpu_devices);
+	list_init(&options.acc_devices);
 #endif
 
 	options.length = -1;
@@ -550,8 +559,8 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 
 #if HAVE_OPENCL
 	if (options.format && strcasestr(options.format, "opencl") &&
-	    (options.flags & FLG_FORK) && options.gpu_devices->count == 0) {
-		list_add(options.gpu_devices, "all");
+	    (options.flags & FLG_FORK) && options.acc_devices->count == 0) {
+		list_add(options.acc_devices, "all");
 	}
 #endif
 

--- a/src/options.h
+++ b/src/options.h
@@ -367,7 +367,8 @@ struct options_main {
 	unsigned int v_width;
 #endif
 #if defined(HAVE_OPENCL) || defined(HAVE_ZTEX)
-	struct list_main *gpu_devices;
+/* Allow to set and select OpenCL device(s) or ztex boards */
+	struct list_main *acc_devices;
 #endif
 /* -list=WHAT Get a config list (eg. a list of incremental modes available) */
 	char *listconf;

--- a/src/ztex_bcrypt.c
+++ b/src/ztex_bcrypt.c
@@ -146,7 +146,7 @@ static void init(struct fmt_main *fmt_main)
 	//fprintf(stderr, "bitstream.candidates_per_crypt=%d\n",
 	//		bitstream.candidates_per_crypt);
 
-	device_format_init(fmt_main, &bitstream, options.gpu_devices);
+	device_format_init(fmt_main, &bitstream, options.acc_devices);
 }
 
 // Existing CPU implementation use following data structures:

--- a/src/ztex_descrypt.c
+++ b/src/ztex_descrypt.c
@@ -111,7 +111,7 @@ static unsigned char DES_atoi64_bitswapped[128] = {
 static void init(struct fmt_main *fmt_main)
 {
 	DES_std_init(); // Used DES_std.c to perform des_crypt() on CPU
-	device_format_init(fmt_main, &bitstream, options.gpu_devices);
+	device_format_init(fmt_main, &bitstream, options.acc_devices);
 }
 
 


### PR DESCRIPTION
The '--device' option can handle OpenCL CPUs, OpenCL accelerators, OpenCL GPUs, and ZTEX boards.

* CI is happy (even for a ztex build).