### PR TITLE
./john --list=ext-modes should only list standalone external modes

### DIFF
--- a/src/listconf.c
+++ b/src/listconf.c
@@ -455,7 +455,6 @@ void listconf_parse_late(void)
 	if (!strcasecmp(options.listconf, "ext-modes"))
 	{
 		cfg_print_subsections("List.External", "generate", NULL, 0);
-		cfg_print_subsections("List.External", "new", NULL, 0);
 		exit(EXIT_SUCCESS);
 	}
 	if (!strcasecmp(options.listconf, "ext-hybrids"))


### PR DESCRIPTION
I want to be able to use
```
for mode in `./john --list=ext-modes`; do ./john --external=$mode ...; done
```
without this change, I get 
```
No generate() for external mode: hybrid_example
```
etc.

Not sure whether these hybrid modes should be listed under ext-filters.
I think so, because they can filter input words just like regular filters.
And even if they don't, they can be used in addition to another mode which generates the candidates.

Please comment, and I'll adjust my pull request.

BTW: What's the intended difference between ext-filters and ext-filters-only?

Does a generator with a filter make sense?
I think an external mode which has both is somehow broken. 