### PR TITLE
Allow to duplicate a device on --devices list

### DIFF
--- a/src/common-gpu.c
+++ b/src/common-gpu.c
@@ -42,6 +42,7 @@
 
 int gpu_id;
 int gpu_device_list[MAX_GPU_DEVICES];
+int requested_devices[MAX_GPU_DEVICES];
 hw_bus gpu_device_bus[MAX_GPU_DEVICES];
 
 int gpu_temp_limit;

--- a/src/common-gpu.h
+++ b/src/common-gpu.h
@@ -38,6 +38,7 @@ typedef struct {
 #define MAX_GPU_DEVICES         128
 extern int gpu_id;
 extern int gpu_device_list[MAX_GPU_DEVICES];
+extern int requested_devices[MAX_GPU_DEVICES];
 
 extern hw_bus gpu_device_bus[MAX_GPU_DEVICES];
 

--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -189,6 +189,15 @@ int get_number_of_devices_in_use()
 	return --i;
 }
 
+int get_number_of_requested_devices()
+{
+	int i = 0;
+
+	while (requested_devices[i++] != -1);
+
+	return --i;
+}
+
 int get_platform_id(int sequential_id)
 {
 	int pos = 0, i = 0;
@@ -614,8 +623,10 @@ static void add_device_to_list(int sequential_id)
 		}
 		gpu_device_list[get_number_of_devices_in_use() + 1] = -1;
 		gpu_device_list[get_number_of_devices_in_use()] = sequential_id;
-
 	}
+	// The full list of requested devices.
+	requested_devices[get_number_of_requested_devices() + 1] = -1;
+	requested_devices[get_number_of_requested_devices()] = sequential_id;
 }
 
 static void add_device_type(cl_ulong device_type)
@@ -691,6 +702,8 @@ void opencl_preinit(void)
 
 		gpu_device_list[0] = -1;
 		gpu_device_list[1] = -1;
+		requested_devices[0] = -1;
+		requested_devices[1] = -1;
 
 		gpu_temp_limit = cfg_get_int(SECTION_OPTIONS, SUBSECTION_GPU,
 		                             "AbortTemperature");

--- a/src/common-opencl.h
+++ b/src/common-opencl.h
@@ -166,6 +166,9 @@ unsigned int opencl_get_vector_width(int sequential_id, int size);
 /* Returns number of selected devices */
 int get_number_of_devices_in_use(void);
 
+/* Returns number of requested devices */
+int get_number_of_requested_devices(void);
+
 /* Initialize a specific device. If necessary, parse command line and get
  * information about all OpenCL devices. */
 int opencl_prepare_dev(int sequential_id);

--- a/src/john.c
+++ b/src/john.c
@@ -647,7 +647,7 @@ static void john_fork(void)
 				// Pick device to use for this child
 				opencl_preinit();
 				gpu_id =
-				    gpu_device_list[i % get_number_of_devices_in_use()];
+				    requested_devices[i % get_number_of_requested_devices()];
 				platform_id = get_platform_id(gpu_id);
 
 				// Hide any other devices from list


### PR DESCRIPTION
So, anyone can list and use the same device(s) more than once while
forking (e.g., to compensate the performance difference between
devices).

Closes #2778 