### PR TITLE
Fix and improve valid in krb5asrep format

### DIFF
--- a/src/krb5_asrep_fmt_plug.c
+++ b/src/krb5_asrep_fmt_plug.c
@@ -157,7 +157,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	/* assume edata2 following */
 	if (((p = strtokm(NULL, "$")) == NULL))
 		goto err;
-	if (!ishex(p) && (hexlen(p, &extra) < 64 || extra))
+	if (!ishex(p) || (hexlen(p, &extra) < (64 + 16) || extra))
 		goto err;
 
 	if ((strtokm(NULL, "$") != NULL))


### PR DESCRIPTION
This fixes issue #2774.