### PR TITLE
Make sure our definition of CPU name matches what was actually defined with the cpuid tests. See #2764.

### DIFF
--- a/src/CircleCI-MinGW.sh
+++ b/src/CircleCI-MinGW.sh
@@ -52,16 +52,22 @@ export PATH="$HOME/bin:$PATH"
 # echo -1 > /proc/sys/fs/binfmt_misc/status
 # umount /proc/sys/fs/binfmt_misc
 
+echo ""
+echo '******************************************************************************'
+echo "now building for Windows, with CPU fallback"
+echo '******************************************************************************'
+echo ""
+
 # Build with AVX
 mingw32 ./configure --disable-native-tests CPPFLAGS='-mavx -DCPU_FALLBACK -DCPU_FALLBACK_BINARY="\"john-sse2.exe\""' --host=i686-w64-mingw32
 mingw32 make -sj4
-mv ../run/john ../run/john-avx.exe
+mv -v ../run/john ../run/john-avx.exe
 make clean; make distclean
 
 # Build with AVX2 (32-bit, see https://github.com/magnumripper/JohnTheRipper/issues/2543 for details)
 mingw32 ./configure --disable-native-tests CPPFLAGS='-mavx2 -DCPU_FALLBACK -DCPU_FALLBACK_BINARY="\"john-avx.exe\""' --host=i686-w64-mingw32
 mingw32 make -sj4
-mv ../run/john ../run/john-avx2.exe
+mv -v ../run/john ../run/john-avx2.exe
 make clean; make distclean
 
 # Build with SSE2 only
@@ -71,8 +77,10 @@ mingw32 ./configure --disable-native-tests CPPFLAGS='-mno-ssse3' --host=i686-w64
 if [ "x$?" != "x0" ] ; then exit 1 ; fi
 mingw64 make -sj4
 if [ "x$?" != "x0" ] ; then exit 1 ; fi
-mv ../run/john ../run/john-sse2.exe
-mv ../run/john-avx2.exe ../run/john.exe
+mv -v ../run/john ../run/john-sse2.exe
+
+# AVX2 is default, but with CPU fallback
+mv -v ../run/john-avx2.exe ../run/john.exe
 
 cd ../run
 # the mingw build does not name many exe files correctly, fix that.
@@ -105,8 +113,16 @@ zip -r /base/builds/JtR-MinGW-${v}.zip run/ doc/ README.md README README-jumbo
 # 7z a /base/builds/JtR-MinGW-${v}.7z run/ doc/ README.md README README-jumbo
 
 # restore the sse2 build for testing purposes
-mv run/john-sse2.exe run/john.exe
+mv -v run/john-sse2.exe run/john.exe
 
+echo ""
+echo ""
+echo ""
+echo ""
+echo '******************************************************************************'
+echo "now testing the 32-bit SSE2 Windows build
+echo '******************************************************************************'
+echo ""
 # crazy testing!
 cd /base/JohnTheRipper/run
 export WINEDEBUG=-all  # suppress wine warnings
@@ -122,12 +138,12 @@ echo ""
 echo ""
 echo ""
 echo '******************************************************************************'
-echo "now testing a NON-SIMD build"
+echo "now building/testing a NON-SIMD 64-bit Linux build"
 echo '******************************************************************************'
 echo ""
 cd /base/JohnTheRipper/src
 make -s distclean
-CFLAGS_EXTRA="-fstack-protector-all" CPPFLAGS="-mno-sse2" ./configure
+CFLAGS_EXTRA="-fstack-protector-all" CPPFLAGS="-mno-sse2 -mno-mmx" ./configure
 if [ "x$?" != "x0" ] ; then exit 1 ; fi
 make -sj4
 if [ "x$?" != "x0" ] ; then exit 1 ; fi
@@ -143,7 +159,7 @@ echo ""
 echo ""
 echo ""
 echo '******************************************************************************'
-echo "now testing a 32 bit NON-SIMD build"
+echo "now building/testing a 32 bit NON-SIMD Linux build"
 echo '******************************************************************************'
 echo ""
 make -s distclean
@@ -160,7 +176,7 @@ echo ""
 echo ""
 echo ""
 echo '******************************************************************************'
-echo "now testing a 32 bit SSE2 build"
+echo "now building/testing a 32 bit SSE2 Linux build"
 echo '******************************************************************************'
 echo ""
 make -f Makefile.legacy -s clean

--- a/src/john.c
+++ b/src/john.c
@@ -144,6 +144,7 @@ static int john_omp_threads_new;
 
 #if CPU_DETECT
 extern int CPU_detect(void);
+extern char CPU_req_name[];
 #endif
 
 extern struct fmt_main fmt_DES, fmt_BSDI, fmt_MD5, fmt_BF;
@@ -1395,7 +1396,7 @@ static void CPU_detect_or_fallback(char **argv, int make_check)
 		}
 #endif
 		fprintf(stderr, "Sorry, %s is required for this build\n",
-		    CPU_NAME);
+		    CPU_req_name);
 		if (make_check)
 			exit(0);
 		error();

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -74,6 +74,10 @@
 #include "listconf.h" /* must be included after version.h */
 #include "memdbg.h"
 
+#if CPU_DETECT
+extern char CPU_req_name[];
+#endif
+
 /*
  * FIXME: Should all the listconf_list_*() functions get an additional stream
  * parameter, so that they can write to stderr instead of stdout in case fo an
@@ -130,6 +134,9 @@ static void listconf_list_build_info(void)
 	puts("System-wide exec: " JOHN_SYSTEMWIDE_EXEC);
 	puts("System-wide home: " JOHN_SYSTEMWIDE_HOME);
 	puts("Private home: " JOHN_PRIVATE_HOME);
+#endif
+#if CPU_REQ
+	printf("CPU tests: %s\n", CPU_req_name);
 #endif
 #if CPU_FALLBACK
 	puts("CPU fallback binary: " CPU_FALLBACK_BINARY);

--- a/src/x86-64.S
+++ b/src/x86-64.S
@@ -1656,8 +1656,13 @@ DES_bs_crypt_plain_loop:
 .text
 
 #ifdef UNDERSCORES
+#define CPU_req_name _CPU_req_name
 #define CPU_detect _CPU_detect
 #endif
+.globl CPU_req_name
+CPU_req_name:
+	.asciz CPU_NAME
+
 .globl CPU_detect
 CPU_detect:
 	pushq %rbx

--- a/src/x86.S
+++ b/src/x86.S
@@ -28,8 +28,9 @@
 #define DES_xor_key2			_DES_xor_key2
 #define MD5_body			_MD5_body
 #define BF_body				_BF_body
-#define BF_body_generic     _BF_body_generic
+#define BF_body_generic     		_BF_body_generic
 #define BF_current			_BF_current
+#define CPU_req_name			_CPU_req_name
 #define CPU_detect			_CPU_detect
 #endif
 
@@ -1314,6 +1315,12 @@ BF_body:
 #define cpuid \
 	.byte 0x0F; \
 	.byte 0xA2
+#endif
+
+#ifdef CPU_NAME
+.globl CPU_req_name
+CPU_req_name:
+	.asciz CPU_NAME
 #endif
 
 .globl CPU_detect


### PR DESCRIPTION
This ensures that messages like "Sorry, AVX2 is required for this build" matches what CPU features are actually tested with cpuid. See #2764.