### PR TITLE
Initialize Twofish correctly in GPG OpenCL format

### DIFF
--- a/src/opencl_gpg_fmt_plug.c
+++ b/src/opencl_gpg_fmt_plug.c
@@ -182,6 +182,7 @@ static void release_clobj(void)
 static void init(struct fmt_main *_self)
 {
 	self = _self;
+	Twofish_initialise();
 	opencl_prepare_dev(gpu_id);
 }
 


### PR DESCRIPTION
Found, and patch supplied by Steven Noonan.

This fixes https://github.com/magnumripper/JohnTheRipper/issues/2814.