### PR TITLE
Add support for cracking Kerberos des-cbc-md5 hashes

### DIFF
--- a/src/krb5_common.h
+++ b/src/krb5_common.h
@@ -7,7 +7,7 @@
 #include "aes.h"
 
 void nfold(unsigned int inbits, const unsigned char *in,
-		unsigned int outbits,unsigned char *out);
+		unsigned int outbits, unsigned char *out);
 
 void AES_cts_encrypt(const unsigned char *in, unsigned char *out, size_t len,
 		const AES_KEY *key, unsigned char *ivec, const int encryptp);
@@ -22,3 +22,6 @@ void krb_decrypt(const unsigned char ciphertext[], size_t ctext_size,
 void krb_encrypt(const unsigned char ciphertext[], size_t ctext_size,
 		unsigned char plaintext[], const unsigned char key[], size_t key_size);
 #endif
+
+int des_string_to_key_shishi(char *string, size_t stringlen,
+		char *salt, size_t saltlen, unsigned char *outkey);

--- a/src/krb5_db_fmt_plug.c
+++ b/src/krb5_db_fmt_plug.c
@@ -19,7 +19,9 @@
  * pbkdf2-hmac-sha1() and simple call to 2 AES limb encrypt for entire process. Very
  * simple, and 10x faster, and no obsure -lkrb5 dependency.
  *
- * Added support for etype 17 in October, 2017 by Dhiru Kholia.
+ * Added support for etype 17 and etype 2/3 in October, 2017 by Dhiru Kholia.
+ *
+ * Note: Both etype 2 and 3 share the same hashing scheme!
  */
 
 #if AC_BUILT
@@ -29,9 +31,11 @@
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_krb5_18;
 extern struct fmt_main fmt_krb5_17;
+extern struct fmt_main fmt_krb5_3;
 #elif FMT_REGISTERS_H
 john_register_one(&fmt_krb5_18);
 john_register_one(&fmt_krb5_17);
+john_register_one(&fmt_krb5_3);
 #else
 
 #include <string.h>
@@ -47,6 +51,7 @@ john_register_one(&fmt_krb5_17);
 #include "simd-intrinsics.h"
 #include "pbkdf2_hmac_sha1.h"
 #include "aes.h"
+#include "krb5_common.h"
 #ifdef _OPENMP
 #include <omp.h>
 #ifdef SIMD_COEF_32
@@ -63,22 +68,30 @@ john_register_one(&fmt_krb5_17);
 
 #define FORMAT_LABEL            "krb5-18"
 #define FORMAT_LABEL_17         "krb5-17"
+#define FORMAT_LABEL_3          "krb5-3"
 #define FORMAT_NAME             "Kerberos 5 DB etype 18"
 #define FORMAT_NAME_17          "Kerberos 5 DB etype 17"
+#define FORMAT_NAME_3           "Kerberos 5 DB etype 3"
 #define FORMAT_TAG_18           "$krb18$"
 #define FORMAT_TAG_17           "$krb17$"
-#define TAG_LENGTH              (sizeof(FORMAT_TAG_18)-1) // common
+#define FORMAT_TAG_3            "$krb3$"
+#define TAG_LENGTH_18           (sizeof(FORMAT_TAG_18)-1)
+#define TAG_LENGTH_17           (sizeof(FORMAT_TAG_17)-1)
+#define TAG_LENGTH_3            (sizeof(FORMAT_TAG_3)-1)
 #if SIMD_COEF_32
-#define ALGORITHM_NAME          "PBKDF2-SHA1 " SHA1_ALGORITHM_NAME " AES"
+#define ALGORITHM_NAME          "DES / PBKDF2-SHA1 " SHA1_ALGORITHM_NAME " AES"
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA1 32/" ARCH_BITS_STR " AES"
+#define ALGORITHM_NAME          "DES / PBKDF2-SHA1 32/" ARCH_BITS_STR " AES"
 #endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        -1
 #define PLAINTEXT_LENGTH        64
 #define CIPHERTEXT_LENGTH_18    64
 #define CIPHERTEXT_LENGTH_17    32
-#define BINARY_SIZE             16 // MIN(32, 16)
+#define CIPHERTEXT_LENGTH_3     16
+#define BINARY_SIZE_18          32
+#define BINARY_SIZE_17          16
+#define BINARY_SIZE_3           8
 #define BINARY_ALIGN            4
 #define SALT_SIZE               sizeof(struct custom_salt)
 #define SALT_ALIGN              sizeof(uint32_t)
@@ -104,11 +117,21 @@ static struct fmt_tests kinit_tests_17[] = {
 	{NULL}
 };
 
+static struct fmt_tests kinit_tests_3[] = {
+	{FORMAT_TAG_3 "INTERNAL.CORP1user3$eafdc79b7620584a", "password"},
+	{FORMAT_TAG_3 "EXAMPLE.COMlulu$25bfb33132c11346", "password"},
+	{FORMAT_TAG_3 "EXAMPLE.COMluluaaaa$97076894ae025738", "password"},
+	{"$krb3$EXAMPLE.COMluluaaaa$79850e6e9e5e92d0", "password@123"},
+	// etype 2 hash
+	{"$krb3$EXAMPLE.COMluluaaaa$cbb5616879c26df8", "12345678"},
+	{NULL},
+};
+
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
-static uint32_t (*crypt_out)[16];
+static uint32_t (*crypt_out)[8];
 
 static struct custom_salt {
-	uint32_t type;
+	uint32_t etype;
 	char saved_salt[MAX_SALT_SIZE+1];  // XXX is this enough?
 } *cur_salt;
 
@@ -132,15 +155,11 @@ static void done(void)
 	MEM_FREE(saved_key);
 }
 
-static int valid(char *ciphertext, struct fmt_main *self)
+static int valid(char* ciphertext, int pos)
 {
 	char *p, *q;
 
-	p = ciphertext;
-
-	if (!strncmp(p, FORMAT_TAG_18, TAG_LENGTH) || !strncmp(p, FORMAT_TAG_17, TAG_LENGTH))
-		p += TAG_LENGTH;  // both the TAG lengths are same
-
+	p = ciphertext + pos;
 	p = strstr(p, "$");
 	if (p == NULL)
 		return 0;
@@ -155,19 +174,42 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		q++;
 	}
 
-	return !*q && (q - p == CIPHERTEXT_LENGTH_18 || q - p == CIPHERTEXT_LENGTH_17);
+	return !*q && (q - p == CIPHERTEXT_LENGTH_18 || q - p == CIPHERTEXT_LENGTH_17 || q - p == CIPHERTEXT_LENGTH_3);
 }
 
+static int valid_18(char* ciphertext, struct fmt_main *self)
+{
+	if (!strncmp(ciphertext, FORMAT_TAG_18, TAG_LENGTH_18))
+		return valid(ciphertext, TAG_LENGTH_18);
+	else
+		return valid(ciphertext, 0);
+}
 
+static int valid_17(char* ciphertext, struct fmt_main *self)
+{
+	if (strncmp(ciphertext, FORMAT_TAG_17, TAG_LENGTH_17))
+		return 0;
+	return valid(ciphertext, TAG_LENGTH_17);
+}
+
+static int valid_3(char* ciphertext, struct fmt_main *self)
+{
+	if (strncmp(ciphertext, FORMAT_TAG_3, TAG_LENGTH_3))
+		return 0;
+	return valid(ciphertext, TAG_LENGTH_3);
+}
+
+// Only supports bare hashes for etype 18
 static char *split(char *ciphertext, int index, struct fmt_main *self)
 {
-	static char out[TAG_LENGTH + CIPHERTEXT_LENGTH_18 + SALT_SIZE + 1];
+	static char out[TAG_LENGTH_18 + CIPHERTEXT_LENGTH_18 + SALT_SIZE + 1];
 
-	if (!strncmp(ciphertext, FORMAT_TAG_18, TAG_LENGTH) || !strncmp(ciphertext, FORMAT_TAG_17, TAG_LENGTH))
+	if (!strncmp(ciphertext, FORMAT_TAG_18, TAG_LENGTH_18) || !strncmp(ciphertext, FORMAT_TAG_17, TAG_LENGTH_17) || !strncmp(ciphertext, FORMAT_TAG_3, TAG_LENGTH_3))
 		return ciphertext;
 
-	memcpy(out, FORMAT_TAG_18, TAG_LENGTH);
-	strnzcpyn(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH_18 + SALT_SIZE + 1);
+	memcpy(out, FORMAT_TAG_18, TAG_LENGTH_18);
+	strnzcpyn(out + TAG_LENGTH_18, ciphertext, CIPHERTEXT_LENGTH_18 + SALT_SIZE + 1);
+
 	return out;
 }
 
@@ -177,11 +219,16 @@ static void *get_salt(char *ciphertext)
 	char *p, *q;
 
 	memset(&cs, 0, SALT_SIZE);
-	if (!strncmp(ciphertext, FORMAT_TAG_18, TAG_LENGTH))
-		cs.type = 18;
-	else
-		cs.type = 17;
-	p = ciphertext + TAG_LENGTH;
+	if (!strncmp(ciphertext, FORMAT_TAG_18, TAG_LENGTH_18)) {
+		cs.etype = 18;
+		p = ciphertext + TAG_LENGTH_18;
+	} else if (!strncmp(ciphertext, FORMAT_TAG_17, TAG_LENGTH_17)) {
+		cs.etype = 17;
+		p = ciphertext + TAG_LENGTH_17;
+	} else {
+		cs.etype = 3;
+		p = ciphertext + TAG_LENGTH_3;
+	}
 	q = strstr(p, "$");
 	strncpy(cs.saved_salt, p, q-p);
 	cs.saved_salt[MAX_SALT_SIZE] = 0;
@@ -199,19 +246,27 @@ static void *get_binary(char *ciphertext)
 	static unsigned char *out;
 	char *p;
 	int i = 0;
-
-	if (!out) out = mem_alloc_tiny(BINARY_SIZE, MEM_ALIGN_WORD);
+	unsigned int binary_size = 0;
 
 	p = ciphertext;
+	if (!strncmp(ciphertext, FORMAT_TAG_18, TAG_LENGTH_18)) {
+		binary_size = 32;
+		p = ciphertext + TAG_LENGTH_18;
+	} else if (!strncmp(ciphertext, FORMAT_TAG_17, TAG_LENGTH_17)) {
+		binary_size = 16;
+		p = ciphertext + TAG_LENGTH_17;
+	} else {
+		binary_size = 8;
+		p = ciphertext + TAG_LENGTH_3;
+	}
 
-	if (!strncmp(ciphertext, FORMAT_TAG_18, TAG_LENGTH) || !strncmp(ciphertext, FORMAT_TAG_17, TAG_LENGTH))
-		p += TAG_LENGTH;
+	if (!out) out = mem_alloc_tiny(binary_size, MEM_ALIGN_WORD);
 	p = strstr(p, "$") + 1;
 
-	for (; i < BINARY_SIZE; i++) {
-	        out[i] =
-		        (atoi16[ARCH_INDEX(*p)] << 4) |
-		        atoi16[ARCH_INDEX(p[1])];
+	for (; i < binary_size; i++) {
+		out[i] =
+			(atoi16[ARCH_INDEX(*p)] << 4) |
+			atoi16[ARCH_INDEX(p[1])];
 		p += 2;
 	}
 
@@ -233,45 +288,53 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 		unsigned char key[32], i;
 		AES_KEY aeskey;
 		int key_size;
+
+		if (cur_salt->etype == 18 || cur_salt->etype == 17) {
 #ifdef SSE_GROUP_SZ_SHA1
-		uint32_t Key[SSE_GROUP_SZ_SHA1][32/4];
-		int lens[SSE_GROUP_SZ_SHA1];
-		unsigned char *pin[SSE_GROUP_SZ_SHA1];
-		union {
-			uint32_t *pout[SSE_GROUP_SZ_SHA1];
-			unsigned char *poutc;
-		} x;
-		for (i = 0; i < SSE_GROUP_SZ_SHA1; ++i) {
-			lens[i] = strlen(saved_key[index+i]);
-			pin[i] = (unsigned char*)saved_key[index+i];
-			x.pout[i] = Key[i];
-		}
-		if (cur_salt->type == 18) {
-			key_size = 32;
-		} else {
-			key_size = 16;
-		}
-		pbkdf2_sha1_sse((const unsigned char **)pin, lens, (const unsigned char*)cur_salt->saved_salt, strlen(cur_salt->saved_salt), 4096, &(x.poutc), key_size, 0);
+			uint32_t Key[SSE_GROUP_SZ_SHA1][32/4];
+			int lens[SSE_GROUP_SZ_SHA1];
+			unsigned char *pin[SSE_GROUP_SZ_SHA1];
+			union {
+				uint32_t *pout[SSE_GROUP_SZ_SHA1];
+				unsigned char *poutc;
+			} x;
+			for (i = 0; i < SSE_GROUP_SZ_SHA1; ++i) {
+				lens[i] = strlen(saved_key[index+i]);
+				pin[i] = (unsigned char*)saved_key[index+i];
+				x.pout[i] = Key[i];
+			}
+			if (cur_salt->etype == 18) {
+				key_size = 32;
+			} else {
+				key_size = 16;
+			}
+			pbkdf2_sha1_sse((const unsigned char **)pin, lens, (const unsigned char*)cur_salt->saved_salt, strlen(cur_salt->saved_salt), 4096, &(x.poutc), key_size, 0);
 #else
-		if (cur_salt->type == 18) {
-			key_size = 32;
-		} else {
-			key_size = 16;
-		}
-		pbkdf2_sha1((const unsigned char*)saved_key[index], strlen(saved_key[index]), (const unsigned char*)cur_salt->saved_salt, strlen(cur_salt->saved_salt), 4096, key, key_size, 0);
+			if (cur_salt->etype == 18) {
+				key_size = 32;
+			} else {
+				key_size = 16;
+			}
+			pbkdf2_sha1((const unsigned char*)saved_key[index], strlen(saved_key[index]), (const unsigned char*)cur_salt->saved_salt, strlen(cur_salt->saved_salt), 4096, key, key_size, 0);
 #endif
-		i=0;
+			i = 0;
 #ifdef SSE_GROUP_SZ_SHA1
-		for (; i < SSE_GROUP_SZ_SHA1; ++i) {
-			memcpy(key, Key[i], key_size);
+			for (; i < SSE_GROUP_SZ_SHA1; ++i) {
+				memcpy(key, Key[i], key_size);
 #endif
-		AES_set_encrypt_key(key, key_size * 8, &aeskey);
-		AES_encrypt((unsigned char*)"kerberos{\x9b[+\x93\x13+\x93", (unsigned char*)(crypt_out[index+i]), &aeskey); // the weird constant string comes from "nfold" function
-		AES_encrypt((unsigned char*)(crypt_out[index+i]), (unsigned char*)&crypt_out[index+i][4], &aeskey);
+				AES_set_encrypt_key(key, key_size * 8, &aeskey);
+				AES_encrypt((unsigned char*)"kerberos{\x9b[+\x93\x13+\x93", (unsigned char*)(crypt_out[index+i]), &aeskey); // the weird constant string comes from "nfold" function
+				AES_encrypt((unsigned char*)(crypt_out[index+i]), (unsigned char*)&crypt_out[index+i][4], &aeskey);
 #ifdef SSE_GROUP_SZ_SHA1
-		}
+			}
 #endif
+		} else if (cur_salt->etype == 3) {
+			for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i) {
+				des_string_to_key_shishi(saved_key[index+i], strlen(saved_key[index+i]), cur_salt->saved_salt, strlen(cur_salt->saved_salt), (unsigned char*)(crypt_out[index+i]));
+			}
+		}
 	}
+
 	return count;
 }
 
@@ -282,7 +345,7 @@ static int cmp_all(void *binary, int count)
 #if defined(_OPENMP) || MAX_KEYS_PER_CRYPT > 1
 	for (; index < count; index++)
 #endif
-	        if (crypt_out[index][0] == *(uint32_t*)binary)
+		if (crypt_out[index][0] == *(uint32_t*)binary)
 			return 1;
 
 	return 0;
@@ -290,7 +353,7 @@ static int cmp_all(void *binary, int count)
 
 static int cmp_one(void *binary, int index)
 {
-	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE_3);
 }
 
 static int cmp_exact(char *source, int index)
@@ -300,11 +363,7 @@ static int cmp_exact(char *source, int index)
 
 static void set_key(char *key, int index)
 {
-	int saved_len = strlen(key);
-	if (saved_len > PLAINTEXT_LENGTH)
-		saved_len = PLAINTEXT_LENGTH;
-	memcpy(saved_key[index], key, saved_len);
-	saved_key[index][saved_len] = 0;
+	strnzcpy(saved_key[index], key, PLAINTEXT_LENGTH + 1);
 }
 
 static char *get_key(int index)
@@ -321,7 +380,7 @@ struct fmt_main fmt_krb5_18 = {
 		BENCHMARK_LENGTH,
 		0,
 		PLAINTEXT_LENGTH,
-		BINARY_SIZE,
+		BINARY_SIZE_18,
 		BINARY_ALIGN,
 		SALT_SIZE,
 		SALT_ALIGN,
@@ -336,7 +395,7 @@ struct fmt_main fmt_krb5_18 = {
 		done,
 		fmt_default_reset,
 		fmt_default_prepare,
-		valid,
+		valid_18,
 		split,
 		get_binary,
 		get_salt,
@@ -370,7 +429,7 @@ struct fmt_main fmt_krb5_17 = {
 		BENCHMARK_LENGTH,
 		0,
 		PLAINTEXT_LENGTH,
-		BINARY_SIZE,
+		BINARY_SIZE_17,
 		BINARY_ALIGN,
 		SALT_SIZE,
 		SALT_ALIGN,
@@ -385,7 +444,7 @@ struct fmt_main fmt_krb5_17 = {
 		done,
 		fmt_default_reset,
 		fmt_default_prepare,
-		valid,
+		valid_17,
 		split,
 		get_binary,
 		get_salt,
@@ -409,5 +468,55 @@ struct fmt_main fmt_krb5_17 = {
 		cmp_exact,
 	}
 };
+
+struct fmt_main fmt_krb5_3 = {
+	{
+		FORMAT_LABEL_3,
+		FORMAT_NAME_3,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE_3,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		{ NULL },
+		{ FORMAT_TAG_3 },
+		kinit_tests_3
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		valid_3,
+		split,
+		get_binary,
+		get_salt,
+		{ NULL },
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact,
+	}
+};
+
 
 #endif /* plugin stanza */


### PR DESCRIPTION
This fixes https://github.com/magnumripper/JohnTheRipper/issues/2824 and https://github.com/magnumripper/JohnTheRipper/issues/636.

Both etype 2 and etype 3 share the same hashing scheme. In other words, the `krb5-3` format can crack etype 3 and etype 2 hashes both.