### PR TITLE
Add support for cracking Neo wallets

### DIFF
--- a/run/dynamic.conf
+++ b/run/dynamic.conf
@@ -1188,6 +1188,23 @@ Test=$dynamic_1600$e6155f87b073451076d81e3505f8b9fcd3f53b5a$HEX$7100000004030201
 Test=$dynamic_1600$b5e335754127b25ba6f99a94c738e24cd634c35a$HEX$aa07d396f5038a6cbeded88d78d1d6c907e4079b3dc2e12fddee409a51cc05ae73e8cc24d518c923a2f79e49376594503e6238b806bfe33fa8516f4903a9b4:hashcat
 Test=$dynamic_1600$ac869d82e768c1af0e2b80679ddee8efe769d480$HEX$650000000403020101000000bc0200000000000004500053000645004e0047000e50005300460054005f00480052003432003000310035002d00300037002d00300031002d00300038002e00300036002e00340036002e0039003900390035003400330000:password@12345
 
+# https://github.com/neo-project/neo-gui (tested with Neo GUI v2.3.2)
+[List.Generic:dynamic_1608]
+Expression=sha256(sha256_raw(sha256_raw($p))) [Neo Wallet]
+Flag=MGF_FLAT_BUFFERS
+Flag=MGF_INPUT_32_BYTE
+MaxInputLenX86=110
+MaxInputLen=110
+Func=DynamicFunc__clean_input_kwik
+Func=DynamicFunc__LargeHash_OUTMode_raw
+Func=DynamicFunc__append_keys
+Func=DynamicFunc__SHA256_crypt_input1_overwrite_input2
+Func=DynamicFunc__SHA256_crypt_input2_overwrite_input2
+Func=DynamicFunc__SHA256_crypt_input2_to_output1_FINAL
+Test=$dynamic_1608$f2a778f1a6ed3d5bc59a5d79104c598f3f07093f240ca4e91333fb09ed4f36da:abc
+Test=$dynamic_1608$8b12147de49a2832aca47a5bf6fbca12689420ac14c2547ab90f6d495f21f6dc:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEF
+Test=$dynamic_1608$2a1a9918abe22f14d737462301e0c17b125a5f9ba11dc1e872b5320180437d12:openwall
+
 # Newer SunShop Shopping Cart. Older SunShop 4.1.0 uses md5($p) as the hashing
 # scheme. It seems that both these hash types can live together in a single
 # SunShop database.

--- a/run/neo2john.py
+++ b/run/neo2john.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+# This software is Copyright (c) 2017, Dhiru Kholia <kholia at kth.se> and it is
+# hereby released to the general public under the following terms:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.
+
+import os
+import sys
+import sqlite3
+import binascii
+
+PY3 = sys.version_info[0] == 3
+
+
+def process_file(filename):
+    db = sqlite3.connect(filename)
+    cursor = db.cursor()
+    rows = cursor.execute("SELECT * FROM Key""")
+    for row in rows:
+        if row[0] == 'PasswordHash':
+            h = binascii.hexlify(row[1])
+            if PY3:
+                h = str(h, 'ascii')
+            print("%s:$dynamic_1608$%s" % (os.path.basename(filename), h))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: %s [.db3 files]\n" % sys.argv[0])
+        sys.exit(-1)
+
+    for i in range(1, len(sys.argv)):
+        process_file(sys.argv[i])


### PR DESCRIPTION
@frank-dittrich Is using the `dynamic_1608` number OK or should I use something else?

[Sample Neo Wallets.zip](https://github.com/magnumripper/JohnTheRipper/files/1424842/Sample.Neo.Wallets.zip) (for testing).

This code was generated by the dynamic compiler.