### PR TITLE
Allow -max-len to bump Incremental's maxlen to beyond the conf

### DIFF
--- a/src/inc.c
+++ b/src/inc.c
@@ -547,7 +547,7 @@ void do_incremental_crack(struct db_main *db, char *mode)
 			min_length = 0;
 	}
 
-	if (options.req_maxlength && options.req_maxlength < max_length) {
+	if (options.req_maxlength && !maxlength_computed) {
 		max_length = options.req_maxlength;
 #if HAVE_REXGEN
 		if (regex)

--- a/src/mask.c
+++ b/src/mask.c
@@ -48,7 +48,7 @@ static unsigned long long rec_cl, cand_length;
 static struct fmt_main *mask_fmt;
 static int mask_bench_index;
 static int parent_fix_state_pending;
-int mask_add_len, mask_num_qw, mask_cur_len;
+int mask_add_len, mask_num_qw, mask_cur_len, maxlength_computed = 0;
 
 /*
  * This keeps track of whether we have any 8-bit in our non-hybrid mask.
@@ -2007,6 +2007,9 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 	mask_fmt = db->format;
 
 	fmt_maxlen = mask_fmt->params.plaintext_length;
+
+	// Track to know whether max-length is specified or computed
+	maxlength_computed = (options.req_maxlength == 0);
 
 	if (options.req_minlength >= 0 && !options.req_maxlength)
 		options.req_maxlength = fmt_maxlen;

--- a/src/mask.h
+++ b/src/mask.h
@@ -118,4 +118,7 @@ extern unsigned long long mask_parent_keys;
 /* Current length when pure mask mode iterates over lengths */
 extern int mask_cur_len;
 
+/* Set if max-length is computed (as opposed to specified by the user) */
+extern int maxlength_computed;
+
 #endif


### PR DESCRIPTION
See #2785

Tested with some stuff like:
```
../run/john --stdout --incremental | head -n 5
../run/john --stdout --incremental --min-len=14 --max-length=20 | head -n 5
../run/john --stdout --incremental --min-length=20 --max-length=20 | head -n 1
../run/john --incremental --stdout --min-length=40 --mask='?w?w?w' | head -n 5
../run/john --incremental --stdout --min-length=20 --mask='?w?w' | head -n 1
```