### PR TITLE
Raw-MD{4,5{,flat}}: handle uppercase hex digits

### DIFF
--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -167,7 +167,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 {
 	static char out[TAG_LENGTH + CIPHERTEXT_LENGTH + 1];
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
+	if (ciphertext[0] == '$' &&
+			!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -168,7 +168,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 	static char out[TAG_LENGTH + CIPHERTEXT_LENGTH + 1];
 
 	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		return ciphertext;
+		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
 	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -81,6 +81,7 @@ static struct fmt_tests tests[] = {
 	{"8a9d093f14f8701df17732b2bb182c74", "password"},
 	{FORMAT_TAG "6d78785c44ea8dfa178748b245d8c3ae", "magnum" },
 	{"6d78785c44ea8dfa178748b245d8c3ae", "magnum" },
+	{"6D78785C44EA8DFA178748B245D8C3AE", "magnum" },
 	{FORMAT_TAG "31d6cfe0d16ae931b73c59d7e0c089c0", "" },
 	{FORMAT_TAG "934eb897904769085af8101ad9dabca2", "John the ripper" },
 	{FORMAT_TAG "cafbb81fb64d9dd286bc851c4c6e0d21", "lolcode" },
@@ -157,7 +158,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		p += TAG_LENGTH;
 
 	q = p;
-	while (atoi16l[ARCH_INDEX(*q)] != 0x7F)
+	while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 		q++;
 	return !*q && q - p == CIPHERTEXT_LENGTH;
 }
@@ -171,6 +172,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
 	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
+	strlwr(&out[TAG_LENGTH]);
 	return out;
 }
 

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -451,7 +451,7 @@ struct fmt_main fmt_rawMD4 = {
 #ifdef _OPENMP
 		FMT_OMP | FMT_OMP_BAD |
 #endif
-		FMT_CASE | FMT_8_BIT,
+		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
 		{ NULL },
 		{ FORMAT_TAG },
 		tests

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -83,6 +83,7 @@ static struct fmt_tests tests[] = {
 	{"5a105e8b9d40e1329780d62ea2265d8a", "test1"},
 	{FORMAT_TAG "5a105e8b9d40e1329780d62ea2265d8a", "test1"},
 	{"098f6bcd4621d373cade4e832627b4f6", "test"},
+	{"098F6BCD4621D373CADE4E832627B4F6", "test"},
 	{FORMAT_TAG "378e2c4a07968da2eca692320136433d", "thatsworking"},
 	{FORMAT_TAG "8ad8757baa8564dc136c1e07507f4a98", "test3"},
 	{"d41d8cd98f00b204e9800998ecf8427e", ""},
@@ -177,7 +178,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		p += TAG_LENGTH;
 
 	q = p;
-	while (atoi16l[ARCH_INDEX(*q)] != 0x7F)
+	while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 		q++;
 	return !*q && q - p == CIPHERTEXT_LENGTH;
 }
@@ -191,6 +192,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		return ciphertext;
 
 	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH);
+	strlwr(&out[TAG_LENGTH]);
 
 	return out;
 }

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -472,7 +472,7 @@ struct fmt_main fmt_rawMD5 = {
 #ifdef _OPENMP
 		FMT_OMP | FMT_OMP_BAD |
 #endif
-		FMT_CASE | FMT_8_BIT,
+		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
 		{ NULL },
 		{ FORMAT_TAG, FORMAT_TAG2 },
 		tests

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -187,7 +187,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 {
 	static char out[TAG_LENGTH + CIPHERTEXT_LENGTH + 1] = FORMAT_TAG;
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
+	if (ciphertext[0] == '$' &&
+			!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH);

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -187,9 +187,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 {
 	static char out[TAG_LENGTH + CIPHERTEXT_LENGTH + 1] = FORMAT_TAG;
 
-	if (ciphertext[0] == '$' &&
-	    !strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		return ciphertext;
+	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
+		ciphertext += TAG_LENGTH;
 
 	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH);
 	strlwr(&out[TAG_LENGTH]);

--- a/src/rawMD5flat_fmt_plug.c
+++ b/src/rawMD5flat_fmt_plug.c
@@ -148,7 +148,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 	static char out[TAG_LENGTH + CIPHERTEXT_LENGTH + 1];
 
 	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		return ciphertext;
+		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
 	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);

--- a/src/rawMD5flat_fmt_plug.c
+++ b/src/rawMD5flat_fmt_plug.c
@@ -76,6 +76,7 @@ static struct fmt_tests tests[] = {
 	{"5a105e8b9d40e1329780d62ea2265d8a", "test1"},
 	{FORMAT_TAG "5a105e8b9d40e1329780d62ea2265d8a", "test1"},
 	{"098f6bcd4621d373cade4e832627b4f6", "test"},
+	{"098F6BCD4621D373CADE4E832627B4F6", "test"},
 	{FORMAT_TAG "378e2c4a07968da2eca692320136433d", "thatsworking"},
 	{FORMAT_TAG "8ad8757baa8564dc136c1e07507f4a98", "test3"},
 	{"d41d8cd98f00b204e9800998ecf8427e", ""},
@@ -137,8 +138,6 @@ static int valid(char *ciphertext, struct fmt_main *self)
 
 	q = p;
 	while (atoi16[ARCH_INDEX(*q)] != 0x7F) {
-		if (*q >= 'A' && *q <= 'F') /* support lowercase only */
-			return 0;
 		q++;
 	}
 	return !*q && q - p == CIPHERTEXT_LENGTH;
@@ -153,6 +152,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
 	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
+	strlwr(&out[TAG_LENGTH]);
 	return out;
 }
 

--- a/src/rawMD5flat_fmt_plug.c
+++ b/src/rawMD5flat_fmt_plug.c
@@ -147,7 +147,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 {
 	static char out[TAG_LENGTH + CIPHERTEXT_LENGTH + 1];
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
+	if (ciphertext[0] == '$' &&
+			!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);

--- a/src/rawMD5flat_fmt_plug.c
+++ b/src/rawMD5flat_fmt_plug.c
@@ -312,7 +312,7 @@ struct fmt_main fmt_rawMD5f = {
 #ifdef _OPENMP
 		FMT_OMP | FMT_OMP_BAD |
 #endif
-		FMT_CASE | FMT_8_BIT,
+		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
 		{ FORMAT_TAG },
 		tests
 	}, {


### PR DESCRIPTION
Although it shouldn't matter in case of hexadecimal encoding, the Raw MD4, MD5 and MD5 flat format not only couldn't handle uppercase characters, but the error message was not really helpful. This issue was discussed in #2842.