### PR TITLE
An OpenCL #define was defined in the wrong place

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -269,7 +269,7 @@ common.o:	common.c arch.h common.h memory.h memdbg.h os.h os-autoconf.h autoconf
 
 common-gpu.o:	common-gpu.c autoconfig.h Win32-dlfcn-port.h common-gpu.h gpu_sensors.h john.h os.h os-autoconf.h jumbo.h arch.h memory.h params.h logger.h config.h signals.h memdbg.h
 
-common-opencl.o:	common-opencl.c os.h os-autoconf.h autoconfig.h jumbo.h arch.h options.h list.h loader.h params.h formats.h misc.h getopt.h common.h memory.h config.h logger.h common-opencl.h common-gpu.h gpu_sensors.h path.h opencl_device_info.h mask_ext.h mask.h opencl_mask.h dyna_salt.h signals.h recovery.h status.h math.h john.h md5.h john-mpi.h memdbg.h
+common-opencl.o:	common-opencl.c os.h os-autoconf.h autoconfig.h jumbo.h arch.h options.h list.h loader.h params.h formats.h misc.h getopt.h common.h memory.h config.h logger.h common-opencl.h common-gpu.h gpu_sensors.h path.h opencl_device_info.h mask_ext.h mask.h dyna_salt.h signals.h recovery.h status.h math.h john.h md5.h john-mpi.h memdbg.h
 
 compiler.o:	compiler.c arch.h params.h memory.h compiler.h memdbg.h os.h os-autoconf.h autoconfig.h jumbo.h
 
@@ -277,7 +277,7 @@ config.o:	config.c misc.h jumbo.h arch.h autoconfig.h params.h path.h memory.h c
 
 cprepair.o:	cprepair.c autoconfig.h unicode.h options.h list.h loader.h params.h arch.h formats.h misc.h jumbo.h getopt.h common.h memory.h memdbg.h os.h os-autoconf.h
 
-cracker.o:	cracker.c os.h os-autoconf.h autoconfig.h jumbo.h arch.h misc.h math.h params.h memory.h signals.h idle.h formats.h dyna_salt.h loader.h list.h logger.h status.h recovery.h external.h compiler.h options.h getopt.h common.h mask_ext.h mask.h opencl_mask.h unicode.h john.h fake_salts.h john-mpi.h path.h common-gpu.h gpu_sensors.h memdbg.h
+cracker.o:	cracker.c os.h os-autoconf.h autoconfig.h jumbo.h arch.h misc.h math.h params.h memory.h signals.h idle.h formats.h dyna_salt.h loader.h list.h logger.h status.h recovery.h external.h compiler.h options.h getopt.h common.h mask_ext.h mask.h unicode.h john.h fake_salts.h john-mpi.h path.h common-gpu.h gpu_sensors.h memdbg.h
 
 crc32.o:	crc32.c memory.h arch.h crc32.h memdbg.h os.h os-autoconf.h autoconfig.h jumbo.h
 
@@ -367,9 +367,9 @@ loader.o:	loader.c autoconfig.h jumbo.h arch.h os.h os-autoconf.h misc.h params.
 
 logger.o:	logger.c os.h os-autoconf.h autoconfig.h jumbo.h arch.h misc.h params.h path.h memory.h status.h math.h options.h list.h loader.h formats.h getopt.h common.h config.h recovery.h unicode.h dynamic.h simd-intrinsics.h pseudo_intrinsics.h aligned.h simd-intrinsics-load-flags.h john-mpi.h cracker.h signals.h memdbg.h
 
-mask.o:	mask.c misc.h jumbo.h arch.h autoconfig.h logger.h recovery.h loader.h params.h list.h formats.h os.h os-autoconf.h signals.h status.h math.h options.h getopt.h common.h memory.h config.h external.h compiler.h cracker.h john.h mask.h unicode.h encoding_data.h memdbg.h mask_ext.h opencl_mask.h
+mask.o:	mask.c misc.h jumbo.h arch.h autoconfig.h logger.h recovery.h loader.h params.h list.h formats.h os.h os-autoconf.h signals.h status.h math.h options.h getopt.h common.h memory.h config.h external.h compiler.h cracker.h john.h mask.h unicode.h encoding_data.h memdbg.h mask_ext.h
 
-mask_ext.o:	mask_ext.c mask_ext.h mask.h loader.h params.h arch.h list.h formats.h misc.h jumbo.h autoconfig.h opencl_mask.h options.h getopt.h common.h memory.h memdbg.h os.h os-autoconf.h
+mask_ext.o:	mask_ext.c mask_ext.h mask.h loader.h params.h arch.h list.h formats.h misc.h jumbo.h autoconfig.h options.h getopt.h common.h memory.h memdbg.h os.h os-autoconf.h
 
 math.o:	math.c arch.h math.h memdbg.h os.h os-autoconf.h autoconfig.h jumbo.h memory.h
 

--- a/src/mask.h
+++ b/src/mask.h
@@ -19,6 +19,9 @@
 
 #include "loader.h"
 
+// See also opencl_mask.h.
+#define MASK_FMT_INT_PLHDR 4
+
 // Maximum number of placeholders in a mask.
 #define MAX_NUM_MASK_PLHDR 127
 

--- a/src/mask_ext.h
+++ b/src/mask_ext.h
@@ -12,7 +12,6 @@
 #define _JOHN_MASK_EXT_H
 
 #include "mask.h"
-#include "opencl_mask.h"
 
 typedef union {
 	unsigned char x[4];

--- a/src/opencl_mask.h
+++ b/src/opencl_mask.h
@@ -1,6 +1,16 @@
+/*
+ * OpenCL mask defines
+ *
+ * This file needs only one #define that is also needed by
+ * non-OpenCL mask routines. The 'define' was copied here
+ * to be used by Kernels ('*.cl') source code.
+ *
+ */
+
 #ifndef _JOHN_OPENCL_MASK_H
 #define _JOHN_OPENCL_MASK_H
 
+// See also mask.h.
 #define MASK_FMT_INT_PLHDR 		4
 
 #endif

--- a/src/opencl_mask_extras.h
+++ b/src/opencl_mask_extras.h
@@ -14,8 +14,6 @@
 #ifndef _JOHN_OPENCL_MASK_H
 #define _JOHN_OPENCL_MASK_H
 
-#include "opencl_mask.h"
-
 #ifdef _OPENCL_COMPILER
 //To keep Sayantan license, some code was moved to this file.
 

--- a/src/opencl_mask_extras.h
+++ b/src/opencl_mask_extras.h
@@ -11,8 +11,8 @@
  *    modifications, are permitted.
  */
 
-#ifndef _JOHN_OPENCL_MASK_H
-#define _JOHN_OPENCL_MASK_H
+#ifndef _JOHN_OPENCL_MASK_EXTRAS_H
+#define _JOHN_OPENCL_MASK_EXTRAS_H
 
 #ifdef _OPENCL_COMPILER
 //To keep Sayantan license, some code was moved to this file.


### PR DESCRIPTION
It is not OpenCL related. That said, a 'core' file like cracker.c
cannot depend on any OpenCL (opencl_*.h) file.