### PR TITLE
Remove a duplicate #include

### DIFF
--- a/src/opencl_electrum_modern_fmt_plug.c
+++ b/src/opencl_electrum_modern_fmt_plug.c
@@ -8,7 +8,6 @@
  * Based on opencl_pbkdf2_hmac_sha512_fmt_plug.c file.
  */
 
-#include "arch.h"
 #if !AC_BUILT
 #define HAVE_LIBZ 1
 #endif


### PR DESCRIPTION
It appears twice (the removed one outside the `#ifdef` OPENCL).