### PR TITLE
Some format fixes (split() function ...), and improved format self test

### DIFF
--- a/src/HDAA_fmt_plug.c
+++ b/src/HDAA_fmt_plug.c
@@ -82,8 +82,8 @@ static unsigned int omp_t = 1;
 
 #define SEPARATOR			'$'
 
-#define MAGIC				"$response$"
-#define MAGIC_LEN			(sizeof(MAGIC)-1)
+#define FORMAT_TAG				"$response$"
+#define TAG_LENGTH			(sizeof(FORMAT_TAG)-1)
 #define SIZE_TAB			12
 
 // This is 8 x 64 bytes, so in MMX/SSE2 we support up to 9 limbs of MD5
@@ -196,11 +196,11 @@ static int valid(char *ciphertext, struct fmt_main *self)
 {
 	char *ctcopy, *keeptr, *p;
 
-	if (strncmp(ciphertext, MAGIC, MAGIC_LEN) != 0)
+	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH) != 0)
 		return 0;
 	ctcopy = strdup(ciphertext);
 	keeptr = ctcopy;
-	ctcopy += MAGIC_LEN;
+	ctcopy += TAG_LENGTH;
 
 	if ((p = strtokm(ctcopy, "$")) == NULL) /* hash */
 		goto err;
@@ -240,9 +240,9 @@ err:
 static char *split(char *ciphertext, int index, struct fmt_main *self)
 {
 	char *cp;
-	if (strncmp(ciphertext, MAGIC, MAGIC_LEN))
+	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
 		return ciphertext;
-	cp = ciphertext + MAGIC_LEN;
+	cp = ciphertext + TAG_LENGTH;
 	cp = strchr(cp, '$'); if (!cp) return ciphertext;
 	cp = strchr(cp+1, '$'); if (!cp) return ciphertext;
 	cp = strchr(cp+1, '$'); if (!cp) return ciphertext;
@@ -711,7 +711,7 @@ static void *get_binary(char *ciphertext)
 	static unsigned int realcipher[BINARY_SIZE / sizeof(int)];
 	int i;
 
-	ciphertext += 10;
+	ciphertext += TAG_LENGTH;
 	for (i = 0; i < BINARY_SIZE; i++) {
 		((unsigned char*)realcipher)[i] = atoi16[ARCH_INDEX(ciphertext[i * 2])] * 16 +
 			atoi16[ARCH_INDEX(ciphertext[i * 2 + 1])];
@@ -758,7 +758,7 @@ struct fmt_main fmt_HDAA = {
 #endif
 		FMT_CASE | FMT_8_BIT,
 		{ NULL },
-		{ MAGIC },
+		{ FORMAT_TAG },
 		tests
 	}, {
 		init,

--- a/src/NT_fmt.c
+++ b/src/NT_fmt.c
@@ -339,8 +339,7 @@ static void *get_binary(char *ciphertext)
 	unsigned int i=0;
 	unsigned int temp;
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		ciphertext += TAG_LENGTH;
+	ciphertext += TAG_LENGTH;
 
 	for (; i<4; i++)
 	{

--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -379,7 +379,7 @@ struct fmt_main fmt_XSHA512 = {
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
 		{ NULL },
-		{ FORMAT_TAG },
+		{ XSHA512_FORMAT_TAG },
 		sha512_common_tests_xsha512
 	}, {
 		init,

--- a/src/formats.c
+++ b/src/formats.c
@@ -605,6 +605,23 @@ static char *fmt_self_test_body(struct fmt_main *format,
 		ciphertext = format->methods.split(ciphertext, 0, format);
 		if (!ciphertext)
 			return "split() returned NULL";
+
+		if (format->params.signature[0]) {
+			int i, error = 1;
+			for (i = 0; i < FMT_SIGNATURES && format->params.signature[i] && error; i++) {
+				error = strncmp(ciphertext, format->params.signature[i], strlen(format->params.signature[i]));
+			}
+			if (error) {
+#if DEBUG
+				fprintf(stderr, "ciphertext:%s\n", ciphertext);
+#endif
+				if (format->methods.split == fmt_default_split)
+					return "fmt_default_split() doesn't convert raw hashes";
+				else
+					return "split() doesn't add expected format tag";
+			}
+		}
+
 		plaintext = current->plaintext;
 
 		if (!sl)

--- a/src/krb5_db_fmt_plug.c
+++ b/src/krb5_db_fmt_plug.c
@@ -437,7 +437,7 @@ struct fmt_main fmt_krb5_17 = {
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
 		{ NULL },
-		{ FORMAT_TAG_18 },
+		{ FORMAT_TAG_17 },
 		kinit_tests_17
 	}, {
 		init,

--- a/src/md2_fmt_plug.c
+++ b/src/md2_fmt_plug.c
@@ -128,10 +128,8 @@ static void *get_binary(char *ciphertext)
 	char *p;
 	int i;
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		p = strrchr(ciphertext, '$') + 1;
-	else
-		p = ciphertext;
+	p = ciphertext + TAG_LENGTH;
+
 	for (i = 0; i < BINARY_SIZE; i++) {
 		out[i] =
 		    (atoi16[ARCH_INDEX(*p)] << 4) |

--- a/src/mdc2_fmt_plug.c
+++ b/src/mdc2_fmt_plug.c
@@ -95,6 +95,19 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	return 1;
 }
 
+static char *split(char *ciphertext, int index, struct fmt_main *self)
+{
+	static char out[TAG_LENGTH + 2 * BINARY_SIZE + 1];
+
+	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
+		return ciphertext;
+
+	strcpy(out, FORMAT_TAG);
+	strcpy(&out[TAG_LENGTH], ciphertext);
+
+	return out;
+}
+
 static void *get_binary(char *ciphertext)
 {
 	static union {
@@ -201,7 +214,7 @@ struct fmt_main fmt_mdc2 = {
 		fmt_default_reset,
 		fmt_default_prepare,
 		valid,
-		fmt_default_split,
+		split,
 		get_binary,
 		fmt_default_salt,
 		{ NULL },

--- a/src/odf_fmt_plug.c
+++ b/src/odf_fmt_plug.c
@@ -241,10 +241,8 @@ static void *get_binary(char *ciphertext)
 	unsigned char *out = buf.c;
 	char *p;
 	int i;
-	char *ctcopy = strdup(ciphertext);
-	char *keeptr = ctcopy;
+	char *ctcopy = strdup(ciphertext + FORMAT_TAG_LEN);
 
-	ctcopy += FORMAT_TAG_LEN;	/* skip over "$odf$*" */
 	strtokm(ctcopy, "*");
 	strtokm(NULL, "*");
 	strtokm(NULL, "*");
@@ -257,7 +255,7 @@ static void *get_binary(char *ciphertext)
 			atoi16[ARCH_INDEX(p[1])];
 		p += 2;
 	}
-	MEM_FREE(keeptr);
+	MEM_FREE(ctcopy);
 	return out;
 }
 

--- a/src/office_common_plug.c
+++ b/src/office_common_plug.c
@@ -56,14 +56,13 @@ void *ms_office_common_binary(char *ciphertext)
 {
 	static unsigned int out[4];
 	int i, length;
-	char *ctcopy = strdup(ciphertext);
-	char *keeptr = ctcopy, *p, Tmp[16];
+	char *ctcopy = strdup(ciphertext + FORMAT_TAG_OFFICE_LEN);
+	char *p, Tmp[16];
 
-	ctcopy += FORMAT_TAG_OFFICE_LEN;	/* skip over "$office$*" */
 	p = strtokm(ctcopy, "*");
 	if (atoi(p) != 2007) {
 		memset(out, 0, sizeof(out));
-		MEM_FREE(keeptr);
+		MEM_FREE(ctcopy);
 		return out;
 	}
 	p = strtokm(NULL, "*");
@@ -76,7 +75,7 @@ void *ms_office_common_binary(char *ciphertext)
 	for (i = 0; i < length && i < 16; i++)
 		Tmp[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
 			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	MEM_FREE(keeptr);
+	MEM_FREE(ctcopy);
 	memcpy(out, Tmp, 16);
 	return out;
 }

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -43,9 +43,7 @@ john_register_one(&FMT_STRUCT);
 
 #define PLAINTEXT_LENGTH		(55 - MAX_SALT_LEN)
 #define BUFSIZE				((PLAINTEXT_LENGTH+3)/4*4)
-#define CIPHERTEXT_LENGTH		((BINARY_SIZE + 1 + MAX_SALT_LEN + 2) / 3 * 4)
 
-#define BINARY_SIZE			20
 #define BINARY_ALIGN			4
 #define SALT_SIZE			(MAX_SALT_LEN + sizeof(unsigned int))
 #define SALT_ALIGN			4
@@ -53,8 +51,6 @@ john_register_one(&FMT_STRUCT);
 #define MIN_KEYS_PER_CRYPT		1
 #define MAX_KEYS_PER_CRYPT		1
 
-#define NSLDAP_MAGIC "{ssha}"
-#define NSLDAP_MAGIC_LENGTH 6
 #define BASE64_ALPHABET	  \
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 

--- a/src/opencl_xsha512_fmt_plug.c
+++ b/src/opencl_xsha512_fmt_plug.c
@@ -441,7 +441,7 @@ struct fmt_main fmt_opencl_xsha512 = {
 		FMT_CASE | FMT_8_BIT,
 #if FMT_MAIN_VERSION > 11
 		{ NULL },
-		{ FORMAT_TAG },
+		{ XSHA512_FORMAT_TAG },
 #endif
 	    sha512_common_tests_xsha512_20
 	}, {

--- a/src/palshop_fmt_plug.c
+++ b/src/palshop_fmt_plug.c
@@ -39,6 +39,7 @@ john_register_one(&fmt_palshop);
 #define BENCHMARK_LENGTH        -1
 #define PLAINTEXT_LENGTH        125
 #define BINARY_SIZE             10  /* 20 characters of "m2", now 10 binary bytes. */
+#define CIPHERTEXT_LENGTH       51
 #define SALT_SIZE               0
 #define BINARY_ALIGN            sizeof(uint32_t)
 #define SALT_ALIGN              sizeof(int)
@@ -95,10 +96,23 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	if (!ishex_oddOK(p))
 		return 0;
 
-	if (strlen(p) != 51)
+	if (strlen(p) != CIPHERTEXT_LENGTH)
 		return 0;
 
 	return 1;
+}
+
+static char *split(char *ciphertext, int index, struct fmt_main *self)
+{
+	static char out[TAG_LENGTH + CIPHERTEXT_LENGTH + 1];
+
+	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
+		return ciphertext;
+
+	strcpy(out, FORMAT_TAG);
+	strcpy(&out[TAG_LENGTH], ciphertext);
+
+	return out;
 }
 
 static void *get_binary(char *ciphertext)
@@ -108,10 +122,8 @@ static void *get_binary(char *ciphertext)
 		ARCH_WORD dummy;
 	} buf;
 	unsigned char *out = buf.c;
-	char *p = ciphertext;
+	char *p = ciphertext + TAG_LENGTH;
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		p = ciphertext + TAG_LENGTH;
 	++p; // skip the first 'nibble'.  Take next 10 bytes.
 	base64_convert(p, e_b64_hex, 20, out, e_b64_raw, 10, 0, 0);
 
@@ -239,7 +251,7 @@ struct fmt_main fmt_palshop = {
 		fmt_default_reset,
 		fmt_default_prepare,
 		valid,
-		fmt_default_split,
+		split,
 		get_binary,
 		fmt_default_salt,
 #if FMT_MAIN_VERSION > 11

--- a/src/panama_fmt_plug.c
+++ b/src/panama_fmt_plug.c
@@ -123,13 +123,9 @@ static void *get_binary(char *ciphertext)
 		ARCH_WORD dummy;
 	} buf;
 	unsigned char *out = buf.c;
-	char *p;
+	char *p = ciphertext + TAG_LENGTH;
 	int i;
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		p = strrchr(ciphertext, '$') + 1;
-	else
-		p = ciphertext;
 	for (i = 0; i < BINARY_SIZE; i++) {
 		out[i] =
 		    (atoi16[ARCH_INDEX(*p)] << 4) |

--- a/src/pst_fmt_plug.c
+++ b/src/pst_fmt_plug.c
@@ -152,7 +152,7 @@ static void *get_binary(char *ciphertext)
 	static uint32_t *out;
 	if (!out)
 		out = mem_alloc_tiny(sizeof(uint32_t), MEM_ALIGN_WORD);
-	sscanf(&ciphertext[5], "%x", out);
+	sscanf(&ciphertext[FORMAT_TAG_LEN], "%x", out);
 	return out;
 }
 

--- a/src/salted_sha1_common.h
+++ b/src/salted_sha1_common.h
@@ -7,7 +7,7 @@
 #if !defined (salted_sha1_common_h__)
 #define salted_sha1_common_h__
 
-#define NSLDAP_MAGIC         "{ssha}"
+#define NSLDAP_MAGIC         "{SSHA}"
 #define NSLDAP_MAGIC_LENGTH  6
 #define BINARY_SIZE          20
 #define MAX_SALT_LEN         16  // bytes, the base64 representation is longer

--- a/src/tiger_fmt_plug.c
+++ b/src/tiger_fmt_plug.c
@@ -138,10 +138,8 @@ static void *get_binary(char *ciphertext)
 	char *p;
 	int i;
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		p = strrchr(ciphertext, '$') + 1;
-	else
-		p = ciphertext;
+	p = ciphertext + TAG_LENGTH;
+
 	for (i = 0; i < BINARY_SIZE; i++) {
 		out[i] =
 		    (atoi16[ARCH_INDEX(*p)] << 4) |

--- a/src/whirlpool_fmt_plug.c
+++ b/src/whirlpool_fmt_plug.c
@@ -139,10 +139,8 @@ static void *get_binary(char *ciphertext)
 	char *p;
 	int i;
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		p = strrchr(ciphertext, '$') + 1;
-	else
-		p = ciphertext;
+	p = ciphertext + TAG_LENGTH;
+
 	for (i = 0; i < BINARY_SIZE; i++) {
 		out[i] =
 		    (atoi16[ARCH_INDEX(*p)] << 4) |

--- a/src/zipmonster_fmt_plug.c
+++ b/src/zipmonster_fmt_plug.c
@@ -114,6 +114,19 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	return 1;
 }
 
+static char *split(char *ciphertext, int index, struct fmt_main *self)
+{
+	static char out[TAG_LENGTH + 2 * BINARY_SIZE + 1];
+
+	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
+		return ciphertext;
+
+	strcpy(out, FORMAT_TAG);
+	strcpy(&out[TAG_LENGTH], ciphertext);
+
+	return out;
+}
+
 static void *get_binary(char *ciphertext)
 {
 	static union {
@@ -121,11 +134,9 @@ static void *get_binary(char *ciphertext)
 		ARCH_WORD dummy;
 	} buf;
 	unsigned char *out = buf.c;
-	char *p = ciphertext;
+	char *p = ciphertext + TAG_LENGTH;
 	int i;
 
-	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
-		p = ciphertext + TAG_LENGTH;
 	for (i = 0; i < BINARY_SIZE && *p; i++) {
 		out[i] =
 			(atoi16[ARCH_INDEX(*p)] << 4) |
@@ -309,7 +320,7 @@ struct fmt_main fmt_zipmonster = {
 		fmt_default_reset,
 		fmt_default_prepare,
 		valid,
-		fmt_default_split,
+		split,
 		get_binary,
 		fmt_default_salt,
 #if FMT_MAIN_VERSION > 11


### PR DESCRIPTION
Enhanced format self test, making sure that hash formats with format tags do have a split() function which adds the format tag when processing raw hashes.
(Otherwise, raw hashes end up in the pot file).

Plus fixes for problems uncovered with the enhanced self test

Some formats added the format tag in binary(), but that's the wrong place.
Some formats listed the wrong tag in the format's signatures.


The first commit includes the fixes for failed tests, the second commit includes the enhanced self test.
(I want to avoid `git bisect` trouble.) 