### PR TITLE
Relax CRC validation check in 7z format

### DIFF
--- a/src/7z_fmt_plug.c
+++ b/src/7z_fmt_plug.c
@@ -247,7 +247,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL) /* crc */
 		goto err;
-	if (!isdecu(p))
+	if (!isdecu(p) && !isdec_negok(p))
 		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL) /* data length */
 		goto err;


### PR DESCRIPTION
This helps with https://github.com/magnumripper/JohnTheRipper/issues/2889. Also see https://github.com/magnumripper/JohnTheRipper/pull/2891.

It seems to work fine in practice.


