### PR TITLE
Correct casing for webEdition word

### DIFF
--- a/doc/DYNAMIC
+++ b/doc/DYNAMIC
@@ -281,9 +281,9 @@ dynamic_1007  md5(md5($p).$s) (vBulletin)
 dynamic_1008  md5($p.$s) (joomla)
 # and many other newer items, added from user requests.
 dynamic_1010  md5($p null_padded_to_len_100) RAdmin v2.x MD5
-dynamic_1011  md5($p.md5($s)) (WebEdition CMS)
-dynamic_1012  md5($p.md5($s)) (WebEdition CMS)  (much faster)
-dynamic_1013  md5($p.PMD5(username)) (WebEdition CMS)  (fast speed, but user name is stored in md5 hash format)
+dynamic_1011  md5($p.md5($s)) (webEdition CMS)
+dynamic_1012  md5($p.md5($s)) (webEdition CMS)  (much faster)
+dynamic_1013  md5($p.PMD5(username)) (webEdition CMS)  (fast speed, but user name is stored in md5 hash format)
 dynamic_1014  md5($p.$s) (long salt)
 dynamic_1015  md5(md5($p.$u).$s)
 dynamic_1018  md5(sha1(sha1($pass)))

--- a/run/dynamic.conf
+++ b/run/dynamic.conf
@@ -16,9 +16,9 @@
 # dynamic_1008: md5($p.$s) (RADIUS User-Password)
 # dynamic_1009: md5($s.$p) (RADIUS Responses)
 # dynamic_1010: md5($p null_padded_to_len_100) RAdmin v2.x MD5
-# dynamic_1011: md5($p.md5($s)) (WebEdition CMS)
-# dynamic_1012: md5($p.md5($s)) (WebEdition CMS)
-# dynamic_1013: md5($p.PMD5(username)) (WebEdition CMS)
+# dynamic_1011: md5($p.md5($s)) (webEdition CMS)
+# dynamic_1012: md5($p.md5($s)) (webEdition CMS)
+# dynamic_1013: md5($p.PMD5(username)) (webEdition CMS)
 # dynamic_1014: md5($p.$s) (long salt)
 # dynamic_1015: md5(md5($p.$u).$s) (PostgreSQL 'pass the hash')
 # dynamic_1018: md5(sha1(sha1($p)))
@@ -359,12 +359,12 @@ Test=$dynamic_1010$3d2c8cae4621edf8abb081408569482b:yamaha12345
 Test=$dynamic_1010$60cb8e411b02c10ecc3c98e29e830de8:xplicit
 
 ####################################################################
-# DYNAMIC type for WebEdition CMS md5($p.md5($s))
+# DYNAMIC type for webEdition CMS md5($p.md5($s))
 # > select username,passwd,UseSalt from tblUser
 # username is salt
 ####################################################################
 [List.Generic:dynamic_1011]
-Expression=md5($p.md5($s)) (WebEdition CMS)
+Expression=md5($p.md5($s)) (webEdition CMS)
 Flag=MGF_SALTED
 MaxInputLenX86=48
 SaltLen=-55
@@ -383,13 +383,13 @@ TestM=$dynamic_1011$b8db62204359efcbfc92da2d697d21cb$xkcR9B:12345678901234567890
 TestF=$dynamic_1011$61f55f04f8f4e05392415181bcf57420$rtJEIj:123456789012345678901234567890123456789012345678
 
 ####################################################################
-# DYNAMIC type for WebEdition CMS md5($p.md5($s))
+# DYNAMIC type for webEdition CMS md5($p.md5($s))
 # > select username,passwd,UseSalt from tblUser
 # username is salt
 # Twice as fast as dynamic_1011 since md5($s) is pre-computed!
 ####################################################################
 [List.Generic:dynamic_1012]
-Expression=md5($p.md5($s)) (WebEdition CMS)
+Expression=md5($p.md5($s)) (webEdition CMS)
 Flag=MGF_SALTED
 Flag=MGF_SALT_AS_HEX
 MaxInputLenX86=48
@@ -406,12 +406,12 @@ TestM=$dynamic_1012$b8db62204359efcbfc92da2d697d21cb$xkcR9B:12345678901234567890
 TestF=$dynamic_1012$61f55f04f8f4e05392415181bcf57420$rtJEIj:123456789012345678901234567890123456789012345678
 
 ####################################################################
-## DYNAMIC type for WebEdition CMS md5($p.PMD5(username))
+## DYNAMIC type for webEdition CMS md5($p.PMD5(username))
 ## > select md5(username),passwd,UseSalt from tblUser
 ## PMD5(username), pre-computed md5 of username is salt
 #####################################################################
 [List.Generic:dynamic_1013]
-Expression=md5($p.PMD5(username)) (WebEdition CMS)
+Expression=md5($p.PMD5(username)) (webEdition CMS)
 Flag=MGF_SALTED
 MaxInputLenX86=48
 MaxInputLen=23


### PR DESCRIPTION
It seems that we already support all the webEdition hash formats. I am documenting the webEdition hash formats below for reference purposes.


File `we_users_user.class.php` from webEdition_6390.tgz, 

``` PHP
public static function makeSaltedPassword(&$useSalt, $username, $passwd, $strength = 15){
	$passwd = substr($passwd, 0, 64);
	if(version_compare(PHP_VERSION, '5.3.7') >= 0){
		$useSalt = self::SALT_CRYPT;
		return crypt($passwd, '$2y$' . sprintf('%02d', $strength) . '$'.self::getHashIV(22));
	} else {
		$useSalt = self::SALT_MD5;
		return md5($passwd . md5($username));
	}
}
```

Under webEdition_6400.tgz,

``` PHP
public static function makeSaltedPassword(&$useSalt, $username, $passwd, $strength = 15){
	$passwd = substr($passwd, 0, 64);
	if(version_compare(PHP_VERSION, '5.3.7', '>=')){
		$useSalt = self::SALT_CRYPT;
		return crypt($passwd, '$2y$' . sprintf('%02d', $strength) . '$' . self::getHashIV(22));
	}
	$useSalt = self::SALT_MD5;
	return md5($passwd . md5($username));
}
```

Under webEdition_7040.tgz,

``` PHP
public static function getHashIV($len){
	static $WE_SALTCHARS = './0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
	$salt = '';
	for($i = 0; $i < $len; $i++){
		$tmp_str = str_shuffle($WE_SALTCHARS);
		$salt .= $tmp_str[0];
	}
	return $salt;
}

public static function makeSaltedPassword($passwd, $strength = 15){
	return crypt(substr($passwd, 0, 64), '$2y$' . sprintf('%02d', $strength) . '$' . self::getHashIV(22));
}
```

From http://php.net/manual/en/function.crypt.php,


CRYPT_BLOWFISH - Blowfish hashing with a salt as follows: "$2a$", "$2x$" or "$2y$", a two digit cost parameter, "$", and 22 characters from the alphabet "./0-9A-Za-z". Using characters outside of this range in the salt will cause crypt() to return a zero-length string. The two digit cost parameter is the base-2 logarithm of the iteration count for the underlying Blowfish-based hashing algorithmeter and must be in range 04-31, values outside this range will cause crypt() to fail. Versions of PHP before 5.3.7 only support "$2a$" as the salt prefix: PHP 5.3.7 introduced the new prefixes to fix a security weakness in the Blowfish implementation. Please refer to » this document for full details of the security fix, but to summarise, developers targeting only PHP 5.3.7 and later should use "$2y$" in preference to "$2a$".
