### PR TITLE
Re-fix alignment problem in OpenVMS format

### DIFF
--- a/src/vms_fmt_plug.c
+++ b/src/vms_fmt_plug.c
@@ -65,7 +65,7 @@ static int omp_t = 1;
 #define BINARY_SIZE			8
 #define BINARY_ALIGN		4
 #define SALT_SIZE			sizeof(struct uaf_hash_info)
-#define SALT_ALIGN			sizeof(long)
+#define SALT_ALIGN			sizeof(uaf_qword)
 
 #define MIN_KEYS_PER_CRYPT		1
 #define MAX_KEYS_PER_CRYPT		1


### PR DESCRIPTION
The earlier fix (https://github.com/magnumripper/JohnTheRipper/pull/2904) was not enough for 32-bit builds it seems. 