### PR TITLE
Fix alignment problems in various OpenCL formats

### DIFF
--- a/src/opencl_cryptsha512.h
+++ b/src/opencl_cryptsha512.h
@@ -31,14 +31,14 @@
 
 //Constants.
 #define SALT_LENGTH             16
-#define SALT_ALIGN              4
+#define SALT_ALIGN              8
 #define PLAINTEXT_LENGTH        23
 #define CIPHERTEXT_LENGTH   86
 #define BUFFER_ARRAY            8
 #define SALT_ARRAY              (SALT_LENGTH / 8)
 #define PLAINTEXT_ARRAY         ((PLAINTEXT_LENGTH + 7) / 8)
 #define BINARY_SIZE             64
-#define BINARY_ALIGN            4
+#define BINARY_ALIGN            sizeof(uint64_t)
 #define SEED                    1024
 #define STEP                    0
 

--- a/src/opencl_fvde_fmt_plug.c
+++ b/src/opencl_fvde_fmt_plug.c
@@ -34,7 +34,7 @@ john_register_one(&fmt_opencl_fvde);
 #define BINARY_SIZE             0
 #define BINARY_ALIGN            MEM_ALIGN_WORD
 #define SALT_SIZE               sizeof(*cur_salt)
-#define SALT_ALIGN              1
+#define SALT_ALIGN              sizeof(uint64_t)
 #define PLAINTEXT_LENGTH        55
 #define KERNEL_NAME             "pbkdf2_sha256_kernel"
 #define SPLIT_KERNEL_NAME       "pbkdf2_sha256_loop"

--- a/src/opencl_krb5pa-sha1_fmt_plug.c
+++ b/src/opencl_krb5pa-sha1_fmt_plug.c
@@ -70,7 +70,7 @@ john_register_one(&fmt_opencl_krb5pa_sha1);
 #define BINARY_SIZE		12
 #define BINARY_ALIGN		4
 #define SALT_SIZE		sizeof(struct custom_salt)
-#define SALT_ALIGN		1
+#define SALT_ALIGN		4
 #define MAX_SALTLEN             52
 #define MAX_REALMLEN            MAX_SALTLEN
 #define MAX_USERLEN             MAX_SALTLEN

--- a/src/opencl_office_fmt_plug.c
+++ b/src/opencl_office_fmt_plug.c
@@ -45,7 +45,7 @@ john_register_one(&fmt_opencl_office);
 #define BINARY_SIZE         0
 #define BINARY_ALIGN        1
 #define SALT_SIZE           sizeof(*cur_salt)
-#define SALT_ALIGN          1
+#define SALT_ALIGN          sizeof(int)
 #define MIN_KEYS_PER_CRYPT  1
 #define MAX_KEYS_PER_CRYPT  1
 

--- a/src/opencl_rakp_fmt_plug.c
+++ b/src/opencl_rakp_fmt_plug.c
@@ -57,7 +57,7 @@ john_register_one(&fmt_opencl_rakp);
 #define FORMAT_TAG              "$rakp$"
 #define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
 
-#define BINARY_ALIGN            1
+#define BINARY_ALIGN            sizeof(uint32_t)
 #define SALT_ALIGN              1
 
 #define STEP                    0

--- a/src/opencl_rar5_fmt_plug.c
+++ b/src/opencl_rar5_fmt_plug.c
@@ -47,7 +47,7 @@ john_register_one(&fmt_ocl_rar5);
 #define SEED			1024
 
 #define BINARY_ALIGN		4
-#define SALT_ALIGN		1
+#define SALT_ALIGN		sizeof(int)
 
 #define PLAINTEXT_LENGTH	55
 #define BINARY_SIZE		SIZE_PSWCHECK

--- a/src/opencl_rawmd4_fmt_plug.c
+++ b/src/opencl_rawmd4_fmt_plug.c
@@ -42,7 +42,7 @@ john_register_one(&FMT_STRUCT);
 #define CIPHERTEXT_LENGTH   32
 #define DIGEST_SIZE         16
 #define BINARY_SIZE         16
-#define BINARY_ALIGN        1
+#define BINARY_ALIGN        sizeof(int)
 #define SALT_SIZE           0
 #define SALT_ALIGN          1
 

--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -44,10 +44,10 @@ john_register_one(&fmt_opencl_zip);
  #define SWAP(n) \
     (((n) << 24) | (((n) & 0xff00) << 8) | (((n) >> 8) & 0xff00) | ((n) >> 24))
 
-#define BINARY_ALIGN		MEM_ALIGN_NONE
+#define BINARY_ALIGN		sizeof(uint32_t)
 #define PLAINTEXT_LENGTH	64
 #define SALT_SIZE		sizeof(my_salt*)
-#define SALT_ALIGN		4
+#define SALT_ALIGN		sizeof(size_t)
 
 typedef struct {
 	uint32_t length;


### PR DESCRIPTION
I am not sure about the `SALT_ALIGN` change in `opencl_cryptsha512.h`. Rest all look OK to me.