### PR TITLE
Merged memcpy and strlwr calls

### DIFF
--- a/src/LM_fmt.c
+++ b/src/LM_fmt.c
@@ -112,13 +112,11 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 	memcpy(out, FORMAT_TAG, FORMAT_TAG_LEN);
 
 	if (index)
-		memcpy(&out[FORMAT_TAG_LEN], &ciphertext[16], 16);
+		memcpylwr(&out[FORMAT_TAG_LEN], &ciphertext[16], 16);
 	else
-		memcpy(&out[FORMAT_TAG_LEN], ciphertext, 16);
+		memcpylwr(&out[FORMAT_TAG_LEN], ciphertext, 16);
 
 	out[20] = 0;
-
-	strlwr(&out[FORMAT_TAG_LEN]);
 
 	return out;
 }

--- a/src/NT_fmt.c
+++ b/src/NT_fmt.c
@@ -294,10 +294,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
 
-	memcpy(&out[TAG_LENGTH], ciphertext, 32);
+	memcpylwr(&out[TAG_LENGTH], ciphertext, 32);
 	out[36] = 0;
-
-	strlwr(&out[TAG_LENGTH]);
 
 	return out;
 }

--- a/src/jumbo.c
+++ b/src/jumbo.c
@@ -300,6 +300,19 @@ char *strlwr(char *s)
 }
 #endif
 
+void memcpylwr(char *dest, const char *src, size_t n)
+{
+	while (n--) {
+		if (*src >= 'A' && *src <= 'Z') {
+			*dest = *src | 0x20;
+		} else {
+			*dest = *src;
+		}
+		dest++;
+		src++;
+	}
+}
+
 #if (AC_BUILT && !HAVE_STRUPR) || (!AC_BUILT && !_MSC_VER)
 char *strupr(char *s)
 {

--- a/src/jumbo.h
+++ b/src/jumbo.h
@@ -290,6 +290,8 @@ extern long long jtr_atoll(const char *);
 #endif
 #endif
 
+void memcpylwr(char *, const char *, size_t);
+
 #if (__MINGW32__ || __MINGW64__) && __STRICT_ANSI__
 // since we added -std=c99 for Mingw builds (to handle printf/scanf %xxx specifiers better),
 // we had to make some 'changes'. Mostly, some of the string types are undeclared (but will

--- a/src/misc.c
+++ b/src/misc.c
@@ -264,11 +264,11 @@ char *strnzcpylwr(char *dst, const char *src, int size)
 
 	if (size)
 		while (--size) {
-			if (!*src) return dst;
 			if (*src >= 'A' && *src <= 'Z') {
 				*dptr = *src | 0x20;
 			} else {
 				*dptr = *src;
+				if (!*src) return dst;
 			}
 			dptr++;
 			src++;

--- a/src/misc.c
+++ b/src/misc.c
@@ -258,6 +258,26 @@ char *strnzcpy(char *dst, const char *src, int size)
 	return dst;
 }
 
+char *strnzcpylwr(char *dst, const char *src, int size)
+{
+	char *dptr = dst;
+
+	if (size)
+		while (--size) {
+			if (!*src) return dst;
+			if (*src >= 'A' && *src <= 'Z') {
+				*dptr = *src | 0x20;
+			} else {
+				*dptr = *src;
+			}
+			dptr++;
+			src++;
+		}
+	*dptr = 0;
+
+	return dst;
+}
+
 int strnzcpyn(char *dst, const char *src, int size)
 {
 	char *dptr;

--- a/src/misc.h
+++ b/src/misc.h
@@ -113,6 +113,11 @@ extern char *strnfcpy(char *dst, const char *src, int size);
 extern char *strnzcpy(char *dst, const char *src, int size);
 
 /*
+ * Similar to the above, but also converts to lowercase in a single pass
+ */
+extern char *strnzcpylwr(char *dst, const char *src, int size);
+
+/*
  * Similar to the strnzcpy, but returns the length of the string.
  */
 extern int strnzcpyn(char *dst, const char *src, int size);

--- a/src/nt2_fmt_plug.c
+++ b/src/nt2_fmt_plug.c
@@ -242,10 +242,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
 
-	memcpy(&out[TAG_LENGTH], ciphertext, 32);
+	memcpylwr(&out[TAG_LENGTH], ciphertext, 32);
 	out[36] = 0;
-
-	strlwr(&out[TAG_LENGTH]);
 
 	return out;
 }

--- a/src/opencl_lm_fmt_plug.c
+++ b/src/opencl_lm_fmt_plug.c
@@ -104,13 +104,11 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += FORMAT_TAG_LEN;
 
 	if (index)
-		memcpy(&out[FORMAT_TAG_LEN], &ciphertext[16], 16);
+		memcpylwr(&out[FORMAT_TAG_LEN], &ciphertext[16], 16);
 	else
-		memcpy(&out[FORMAT_TAG_LEN], ciphertext, 16);
+		memcpylwr(&out[FORMAT_TAG_LEN], ciphertext, 16);
 
 	out[20] = 0;
-
-	strlwr(&out[FORMAT_TAG_LEN]);
 
 	return out;
 }

--- a/src/opencl_nt_fmt_plug.c
+++ b/src/opencl_nt_fmt_plug.c
@@ -356,10 +356,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 	out[2] = 'T';
 	out[3] = '$';
 
-	memcpy(&out[FORMAT_TAG_LEN], ciphertext, 32);
+	memcpylwr(&out[FORMAT_TAG_LEN], ciphertext, 32);
 	out[36] = 0;
-
-	strlwr(&out[FORMAT_TAG_LEN]);
 
 	return out;
 }

--- a/src/pbkdf2_hmac_common_plug.c
+++ b/src/pbkdf2_hmac_common_plug.c
@@ -95,7 +95,7 @@ char *pbkdf2_hmac_md4_split(char *ciphertext, int index, struct fmt_main *self)
 {
 	static char out[PBKDF2_MD4_MAX_CIPHERTEXT_LENGTH + 1];
 	char *cp;
-	memcpylwr(out, ciphertext, sizeof(out));
+	strnzcpylwr(out, ciphertext, sizeof(out));
 	cp = strchr(out, '.');
 	while (cp) {
 		*cp = '$';
@@ -230,7 +230,7 @@ error:
 char *pbkdf2_hmac_md5_split(char *ciphertext, int index, struct fmt_main *self) {
 	static char out[PBKDF2_MD5_MAX_CIPHERTEXT_LENGTH + 1];
 	char *cp;
-	memcpylwr(out, ciphertext, sizeof(out));
+	strnzcpylwr(out, ciphertext, sizeof(out));
 	cp = strchr(out, '.');
 	while (cp) {
 		*cp = '$';
@@ -378,7 +378,7 @@ char *pbkdf2_hmac_sha1_split(char *ciphertext, int index, struct fmt_main *self)
 	static char out[PBKDF2_SHA1_MAX_CIPHERTEXT_LENGTH + 1];
 	char *cp;
 
-	memcpylwr(out, ciphertext, sizeof(out));
+	strnzcpylwr(out, ciphertext, sizeof(out));
 	cp = strchr(out, '.');
 	while (cp) {
 		*cp = '$';
@@ -720,7 +720,7 @@ char *pbkdf2_hmac_sha512_split(char *ciphertext, int index, struct fmt_main *sel
 	static char out[PBKDF2_SHA512_MAX_CIPHERTEXT_LENGTH + 1];
 	char *cp;
 
-	memcpylwr(out, ciphertext, sizeof(out));
+	strnzcpylwr(out, ciphertext, sizeof(out));
 	if (*out == '$') {
 		cp = strchr(&out[1], '$');
 		if (cp) {

--- a/src/pbkdf2_hmac_common_plug.c
+++ b/src/pbkdf2_hmac_common_plug.c
@@ -95,8 +95,7 @@ char *pbkdf2_hmac_md4_split(char *ciphertext, int index, struct fmt_main *self)
 {
 	static char out[PBKDF2_MD4_MAX_CIPHERTEXT_LENGTH + 1];
 	char *cp;
-	strnzcpy(out, ciphertext, sizeof(out));
-	strlwr(out);
+	memcpylwr(out, ciphertext, sizeof(out));
 	cp = strchr(out, '.');
 	while (cp) {
 		*cp = '$';
@@ -231,8 +230,7 @@ error:
 char *pbkdf2_hmac_md5_split(char *ciphertext, int index, struct fmt_main *self) {
 	static char out[PBKDF2_MD5_MAX_CIPHERTEXT_LENGTH + 1];
 	char *cp;
-	strnzcpy(out, ciphertext, sizeof(out));
-	strlwr(out);
+	memcpylwr(out, ciphertext, sizeof(out));
 	cp = strchr(out, '.');
 	while (cp) {
 		*cp = '$';
@@ -380,8 +378,7 @@ char *pbkdf2_hmac_sha1_split(char *ciphertext, int index, struct fmt_main *self)
 	static char out[PBKDF2_SHA1_MAX_CIPHERTEXT_LENGTH + 1];
 	char *cp;
 
-	strnzcpy(out, ciphertext, sizeof(out));
-	strlwr(out);
+	memcpylwr(out, ciphertext, sizeof(out));
 	cp = strchr(out, '.');
 	while (cp) {
 		*cp = '$';
@@ -723,8 +720,7 @@ char *pbkdf2_hmac_sha512_split(char *ciphertext, int index, struct fmt_main *sel
 	static char out[PBKDF2_SHA512_MAX_CIPHERTEXT_LENGTH + 1];
 	char *cp;
 
-	strnzcpy(out, ciphertext, sizeof(out));
-	strlwr(out);
+	memcpylwr(out, ciphertext, sizeof(out));
 	if (*out == '$') {
 		cp = strchr(&out[1], '$');
 		if (cp) {

--- a/src/radmin_fmt_plug.c
+++ b/src/radmin_fmt_plug.c
@@ -92,8 +92,7 @@ static void done(void)
 
 static char *split(char *ciphertext, int index, struct fmt_main *self) {
 	static char buf[CIPHERTEXT_LENGTH + FORMAT_TAG_LEN + 1];   // $radmin2$ is 9 bytes
-	strnzcpy(buf, ciphertext, CIPHERTEXT_LENGTH + FORMAT_TAG_LEN + 1);
-	strlwr(buf);
+	memcpylwr(buf, ciphertext, CIPHERTEXT_LENGTH + FORMAT_TAG_LEN + 1);
 	return buf;
 }
 

--- a/src/radmin_fmt_plug.c
+++ b/src/radmin_fmt_plug.c
@@ -92,7 +92,7 @@ static void done(void)
 
 static char *split(char *ciphertext, int index, struct fmt_main *self) {
 	static char buf[CIPHERTEXT_LENGTH + FORMAT_TAG_LEN + 1];   // $radmin2$ is 9 bytes
-	memcpylwr(buf, ciphertext, CIPHERTEXT_LENGTH + FORMAT_TAG_LEN + 1);
+	strnzcpylwr(buf, ciphertext, CIPHERTEXT_LENGTH + FORMAT_TAG_LEN + 1);
 	return buf;
 }
 

--- a/src/rawBLAKE2_512_fmt_plug.c
+++ b/src/rawBLAKE2_512_fmt_plug.c
@@ -130,8 +130,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
 		ciphertext += FORMAT_TAG_LEN;
 
 	memcpy(out, FORMAT_TAG, FORMAT_TAG_LEN);
-	memcpy(out + FORMAT_TAG_LEN, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + FORMAT_TAG_LEN);
+	memcpylwr(out + FORMAT_TAG_LEN, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 

--- a/src/rawKeccak_256_fmt_plug.c
+++ b/src/rawKeccak_256_fmt_plug.c
@@ -119,8 +119,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + TAG_LENGTH);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 

--- a/src/rawKeccak_512_fmt_plug.c
+++ b/src/rawKeccak_512_fmt_plug.c
@@ -114,8 +114,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
 		ciphertext += FORMAT_TAG_LEN;
 
 	memcpy(out, FORMAT_TAG, FORMAT_TAG_LEN);
-	memcpy(out + FORMAT_TAG_LEN, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + FORMAT_TAG_LEN);
+	memcpylwr(out + FORMAT_TAG_LEN, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -181,8 +181,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(&out[TAG_LENGTH]);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -201,8 +201,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 			!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
 		ciphertext += TAG_LENGTH;
 
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH);
-	strlwr(&out[TAG_LENGTH]);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 
 	return out;
 }

--- a/src/rawMD5flat_fmt_plug.c
+++ b/src/rawMD5flat_fmt_plug.c
@@ -152,8 +152,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(&out[TAG_LENGTH]);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 

--- a/src/rawSHA1_common_plug.c
+++ b/src/rawSHA1_common_plug.c
@@ -125,7 +125,7 @@ char *rawsha1_common_split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += TAG_LENGTH;
 
 	strncpy(out, FORMAT_TAG, sizeof(out));
-	memcpylwr(&out[TAG_LENGTH], ciphertext, HASH_LENGTH + 1);
+	strnzcpylwr(&out[TAG_LENGTH], ciphertext, HASH_LENGTH + 1);
 
 	return out;
 }

--- a/src/rawSHA1_common_plug.c
+++ b/src/rawSHA1_common_plug.c
@@ -125,8 +125,7 @@ char *rawsha1_common_split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += TAG_LENGTH;
 
 	strncpy(out, FORMAT_TAG, sizeof(out));
-	strnzcpy(&out[TAG_LENGTH], ciphertext, HASH_LENGTH + 1);
-	strlwr(out);
+	memcpylwr(&out[TAG_LENGTH], ciphertext, HASH_LENGTH + 1);
 
 	return out;
 }

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -170,8 +170,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + TAG_LENGTH);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 

--- a/src/rawSHA256_common_plug.c
+++ b/src/rawSHA256_common_plug.c
@@ -151,7 +151,6 @@ char * sha256_common_split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += HEX_TAG_LEN;
 
 	memcpy(out, HEX_TAG, HEX_TAG_LEN);
-	memcpy(out + HEX_TAG_LEN, ciphertext, HEX_CIPHERTEXT_LENGTH + 1);
-	strlwr(out + HEX_TAG_LEN);
+	memcpylwr(out + HEX_TAG_LEN, ciphertext, HEX_CIPHERTEXT_LENGTH + 1);
 	return out;
 }

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -180,8 +180,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + TAG_LENGTH);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 

--- a/src/rawSHA512_common_plug.c
+++ b/src/rawSHA512_common_plug.c
@@ -353,8 +353,7 @@ char * sha512_common_split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + TAG_LENGTH);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 
@@ -366,7 +365,6 @@ char * sha512_common_split_xsha512(char *ciphertext, int index, struct fmt_main 
 		return ciphertext;
 
 	memcpy(out, XSHA512_FORMAT_TAG, XSHA512_TAG_LENGTH);
-	memcpy(out + XSHA512_TAG_LENGTH, ciphertext, XSHA512_CIPHERTEXT_LENGTH + 1);
-	strlwr(out + XSHA512_TAG_LENGTH);
+	memcpylwr(out + XSHA512_TAG_LENGTH, ciphertext, XSHA512_CIPHERTEXT_LENGTH + 1);
 	return out;
 }

--- a/src/rawmd5u_fmt_plug.c
+++ b/src/rawmd5u_fmt_plug.c
@@ -154,10 +154,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 	strcpy(out, "$dynamic_29$");
 
-	memcpy(&out[12], ciphertext, 32);
+	memcpylwr(&out[12], ciphertext, CIPHERTEXT_LENGTH);
 	out[sizeof(out)-1] = 0;
-
-	strlwr(&out[12]);
 
 	return out;
 }

--- a/src/sha3_512_fmt_plug.c
+++ b/src/sha3_512_fmt_plug.c
@@ -109,8 +109,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
 		ciphertext += 8;
 
 	memcpy(out, "$keccak$", 8);
-	memcpy(out + 8, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + 8);
+	memcpylwr(out + 8, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 

--- a/src/skein_fmt_plug.c
+++ b/src/skein_fmt_plug.c
@@ -142,8 +142,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		ciphertext += TAG_LENGTH;
 
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	strnzcpy(out + TAG_LENGTH, ciphertext, BINARY_SIZE512*2 + 1);
-	strlwr(out + TAG_LENGTH);
+	strnzcpylwr(out + TAG_LENGTH, ciphertext, BINARY_SIZE512*2 + 1);
 	return out;
 }
 

--- a/src/stribog_fmt_plug.c
+++ b/src/stribog_fmt_plug.c
@@ -125,8 +125,7 @@ static char *split_256(char *ciphertext, int index, struct fmt_main *self)
 	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
 		ciphertext += TAG_LENGTH;
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + TAG_LENGTH);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 
@@ -179,8 +178,7 @@ static char *split_512(char *ciphertext, int index, struct fmt_main *self)
 	if (!strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
 		ciphertext += TAG_LENGTH;
 	memcpy(out, FORMAT_TAG, TAG_LENGTH);
-	memcpy(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
-	strlwr(out + TAG_LENGTH);
+	memcpylwr(out + TAG_LENGTH, ciphertext, CIPHERTEXT_LENGTH + 1);
 	return out;
 }
 


### PR DESCRIPTION
See discussion at the end of #2845, in case of MD5, this resulted in a 25% speedup.

FWIW it passed self-tests on my machine. (Let's see how it does here, as opening a PR is the most obvious way for me to trigger your CI.)

There are still some `*cpy` + `strlwr` combos I was unsure whether they could be transformed, these could be done later by me or other adventurous contributors.