### PR TITLE
Revert "maint: remove a duplicate #include"

### DIFF
--- a/src/opencl_electrum_modern_fmt_plug.c
+++ b/src/opencl_electrum_modern_fmt_plug.c
@@ -8,6 +8,7 @@
  * Based on opencl_pbkdf2_hmac_sha512_fmt_plug.c file.
  */
 
+#include "arch.h"
 #if !AC_BUILT
 #define HAVE_LIBZ 1
 #endif


### PR DESCRIPTION
This reverts commit f8debd25b141837f43d86273359244b9b568a1a1.

I'll merge this soon. The revert can't be done using GitHub (itself) tools.