### PR TITLE
Add EmulateBrokenEncoding feature

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -216,6 +216,12 @@ UnicodeStoreUTF8 = Y
 # This is needed e.g. for --loopback to crack LM->NT including non-ASCII.
 CPstoreUTF8 = Y
 
+# Normally, we try to handle Unicode characters not in our selected codepage
+# with best effort. Enabling this option will instead translate any such
+# character to "?" (default), to meet certain formats' behavior.
+EmulateBrokenEncoding = N
+ReplacementCharacter = ?
+
 # Default verbosity is 3, valid figures are 1-5 right now.
 # 4-5 enables some extra output and diagnostics.
 # 4 is same verbosity as "john proper" aka. non-jumbo.

--- a/src/john.c
+++ b/src/john.c
@@ -882,6 +882,16 @@ static void john_load_conf(void)
 			options.flags |= FLG_RULES;
 	}
 
+	/* EmulateBrokenEncoding feature */
+	options.replacement_character = 0;
+	if (cfg_get_bool(SECTION_OPTIONS, NULL, "EmulateBrokenEncoding", 0)) {
+		char *value;
+
+		value = cfg_get_param(SECTION_OPTIONS, NULL, "ReplacementCharacter");
+		if (value != NULL)
+			options.replacement_character = value[0];
+	}
+
 	options.secure = cfg_get_bool(SECTION_OPTIONS, NULL, "SecureMode", 0);
 	options.show_uid_in_cracks = cfg_get_bool(SECTION_OPTIONS, NULL, "ShowUIDinCracks", 0);
 	options.reload_at_crack =

--- a/src/options.h
+++ b/src/options.h
@@ -280,6 +280,9 @@ struct options_main {
 /* Input encoding for word lists, and/or pot file clear-texts. */
 	int input_enc;
 
+/* Replacement character for "EmulateBrokenEncoding" feature. */
+	unsigned char replacement_character;
+
 /* True if encoding was set from john.conf as opposed to command line. */
 	int default_enc;
 	int default_target_enc;

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -1238,39 +1238,42 @@ void initUnicode(int type)
 			CP_to_Unicode[i] = ISO_8859_1_to_unicode_high128[i-128];
 		}
 	}
-	memset(CP_from_Unicode, 0, sizeof(CP_from_Unicode));
+	memset(CP_from_Unicode, options.replacement_character, sizeof(CP_from_Unicode));
 	for (i = 0; i < 128; ++i)
 		CP_from_Unicode[i] = i;
 
-	/* Best-effort conversion hack */
-	for (i = 0; i < 128; ++i) {
-		switch (cp_class(encoding)) {
+	/* EmulateBrokenEncoding hack */
+	if (options.replacement_character == 0) {
+		/* Best-effort conversion hack */
+		for (i = 0; i < 128; ++i) {
+			switch (cp_class(encoding)) {
 
-		case CP_DOS:
-		CP_from_Unicode[CP437_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP720_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP737_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP850_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP852_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP858_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP866_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP868_to_unicode_high128[i]] = i+128;
-		break;
+				case CP_DOS:
+					CP_from_Unicode[CP437_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP720_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP737_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP850_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP852_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP858_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP866_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP868_to_unicode_high128[i]] = i+128;
+					break;
 
-		case CP_WIN:
-		CP_from_Unicode[CP1250_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP1251_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP1252_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[CP1253_to_unicode_high128[i]] = i+128;
-		break;
+				case CP_WIN:
+					CP_from_Unicode[CP1250_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP1251_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP1252_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[CP1253_to_unicode_high128[i]] = i+128;
+					break;
 
-		default:
-		CP_from_Unicode[ISO_8859_1_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[ISO_8859_2_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[ISO_8859_7_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[ISO_8859_15_to_unicode_high128[i]] = i+128;
-		CP_from_Unicode[KOI8_R_to_unicode_high128[i]] = i+128;
+				default:
+					CP_from_Unicode[ISO_8859_1_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[ISO_8859_2_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[ISO_8859_7_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[ISO_8859_15_to_unicode_high128[i]] = i+128;
+					CP_from_Unicode[KOI8_R_to_unicode_high128[i]] = i+128;
 
+			}
 		}
 	}
 


### PR DESCRIPTION
Normally, we try to handle Unicode characters not in our selected codepage with best effort. Enabling this option will instead translate any such character to "?" (default), to meet certain formats' behavior.

See https://github.com/magnumripper/JohnTheRipper/pull/2886 for discussion.

NOTE: ~~This is not 100% ready yet.~~ I would like to get some early feedback on this PR.