### PR TITLE
Clear salt structure before usage

### DIFF
--- a/src/as400_des_fmt_plug.c
+++ b/src/as400_des_fmt_plug.c
@@ -202,6 +202,7 @@ static void *get_salt(char *ciphertext)
 	char *keeptr = ctcopy, *username;
 	static struct custom_salt cs;
 
+	memset(&cs, 0, sizeof(cs));
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$as400des$" */
 	username = strtokm(ctcopy, "*");
 	/* process username */

--- a/src/axcrypt_fmt_plug.c
+++ b/src/axcrypt_fmt_plug.c
@@ -157,6 +157,7 @@ static void *get_salt(char *ciphertext)
 	static struct custom_salt cs;
 	static void *ptr;
 
+	memset(&cs, 0, sizeof(cs));
 	cs.keyfile = NULL;
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$axcrypt$*" */
 	p = strtokm(ctcopy, "*");

--- a/src/chap_fmt_plug.c
+++ b/src/chap_fmt_plug.c
@@ -140,6 +140,8 @@ static void *get_salt(char *ciphertext)
 	char *p;
 	int i;
 	static struct custom_salt cs;
+
+	memset(&cs, 0, sizeof(cs));
 	ctcopy += FORMAT_TAG_LEN; /* skip over "$chap$" */
 	p = strtokm(ctcopy, "*");
 	cs.id = atoi(p);

--- a/src/lotus85_fmt_plug.c
+++ b/src/lotus85_fmt_plug.c
@@ -341,6 +341,7 @@ static void *get_salt(char *ciphertext)
 	int i,len;
 	static struct custom_salt cs;
 
+	memset(&cs, 0, sizeof(cs));
 	len = strlen(ciphertext) >> 1;
 
 	for (i = 0; i < len; i++)

--- a/src/mysql_netauth_fmt_plug.c
+++ b/src/mysql_netauth_fmt_plug.c
@@ -122,6 +122,8 @@ static void *get_salt(char *ciphertext)
 	char *p;
 	int i;
 	static struct custom_salt cs;
+
+	memset(&cs, 0, sizeof(cs));
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$mysqlna$" */
 	p = strtokm(ctcopy, "*");
 	for (i = 0; i < 20; i++)

--- a/src/nukedclan_fmt_plug.c
+++ b/src/nukedclan_fmt_plug.c
@@ -164,6 +164,8 @@ static void *get_salt(char *ciphertext)
 	char _ctcopy[256], *ctcopy=_ctcopy;
 	char *p;
 	int i;
+
+	memset(&cs, 0, sizeof(cs));
 	strnzcpy(ctcopy, ciphertext, 255);
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$nk$*" */
 	p = strtokm(ctcopy, "*");

--- a/src/openbsdsoftraid_fmt_plug.c
+++ b/src/openbsdsoftraid_fmt_plug.c
@@ -179,6 +179,7 @@ static void* get_salt(char *ciphertext)
 	int i;
 	char *p;
 
+	memset(&cs, 0, sizeof(cs));
 	ctcopy += FORMAT_TAG_LEN;
 	p = strtokm(ctcopy, "$"); /* iterations */
 	cs.num_iterations = atoi(p);

--- a/src/opencl_o5logon_fmt_plug.c
+++ b/src/opencl_o5logon_fmt_plug.c
@@ -233,6 +233,8 @@ static void *get_salt(char *ciphertext)
 	char *p;
 	int i;
 	static struct custom_salt cs;
+
+	memset(&cs, 0, sizeof(cs));
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$o5logon$" */
 	p = strtokm(ctcopy, "*");
 	for (i = 0; i < CIPHERTEXT_LENGTH; i++)

--- a/src/pwsafe_fmt_plug.c
+++ b/src/pwsafe_fmt_plug.c
@@ -156,6 +156,8 @@ static void *get_salt(char *ciphertext)
 	char *p;
 	int i;
 	static struct custom_salt cs;
+
+	memset(&cs, 0, sizeof(cs));
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$pwsafe$*" */
 	p = strtokm(ctcopy, "*");
 	cs.version = atoi(p);

--- a/src/racf_fmt_plug.c
+++ b/src/racf_fmt_plug.c
@@ -205,6 +205,7 @@ static void *get_salt(char *ciphertext)
 	char *keeptr = ctcopy, *username;
 	static struct custom_salt cs;
 
+	memset(&cs, 0, sizeof(cs));
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$racf$*" */
 	username = strtokm(ctcopy, "*");
 	/* process username */

--- a/src/vnc_fmt_plug.c
+++ b/src/vnc_fmt_plug.c
@@ -190,6 +190,8 @@ static void *get_salt(char *ciphertext)
 	static struct custom_salt cs;
 	char *ctcopy = strdup(ciphertext);
 	char *p, *keeptr = ctcopy;
+
+	memset(&cs, 0, sizeof(cs));
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$vnc$*" */
 	p = strtokm(ctcopy, "*");
 	for (i = 0; i < 16; i++)


### PR DESCRIPTION
I am not sure if this is actually required but I saw weird runtime cracking failures without this patch in `chap` format. 