### PR TITLE
AIX compiler compatibility and unshadow skips white spaces

### DIFF
--- a/src/uaf_encode.c
+++ b/src/uaf_encode.c
@@ -49,11 +49,11 @@
 #include <descrip.h>
 #include <uaidef.h>
 #include <starlet.h>
-#define UAIsC_AD_II UAI$C_AD_II
-#define UAIsC_PURDY UAI$C_PURDY
-#define UAIsC_PURDY_V UAI$C_PURDY_V
-#define UAIsC_PURDY_S UAI$C_PURDY_S
-#define UAIsM_PWDMIX UAI$M_PWDMIX
+#define UAIsC_AD_II UAI_C_AD_II
+#define UAIsC_PURDY UAI_C_PURDY
+#define UAIsC_PURDY_V UAI_C_PURDY_V
+#define UAIsC_PURDY_S UAI_C_PURDY_S
+#define UAIsM_PWDMIX UAI_M_PWDMIX
 #else
 /*
  * Emulate symbols defined for VMS services.
@@ -64,12 +64,12 @@
 #define UAIsC_PURDY_S 3
 #define UAIsM_PWDMIX 0x2000000
 
-struct dsc$descriptor_s {
-    unsigned short int dsc$w_length;
-    unsigned char dsc$b_dtype, dsc$b_char;
-    char *dsc$a_pointer;
+struct dsc_descriptor_s {
+    unsigned short int dsc_w_length;
+    unsigned char dsc_b_dtype, dsc_b_char;
+    char *dsc_a_pointer;
 };
-#define $DESCRIPTOR(x,s) struct dsc$descriptor_s x={sizeof(s), 1, 1, s}
+#define _DESCRIPTOR(x,s) struct dsc_descriptor_s x={sizeof(s), 1, 1, s}
 #endif
 
 #ifdef HAVE_PTHREADS
@@ -103,9 +103,9 @@ static unsigned short r50_map[256];
  * system service but in different order.
  */
 static int hash_password ( uaf_qword *, 	/* Receives result hash */
-	struct dsc$descriptor_s *, 		/* Password */
+	struct dsc_descriptor_s *, 		/* Password */
 	unsigned char, unsigned short,		/* Algorithm code and salt */
-	struct dsc$descriptor_s *);		/* Username (eff. more salt) */
+	struct dsc_descriptor_s *);		/* Username (eff. more salt) */
 
 /****************************************************************************/
 /* Internal helper functions.
@@ -429,7 +429,7 @@ int uaf_getuai_info (
 {
    static long uai_ctx = -1;		/* protected by uaf_static mutex */
 #ifdef VMS
-     $DESCRIPTOR(username_dx,"");
+     _DESCRIPTOR(username_dx,"");
     char owner[32];			/* counted string */
     char defdev[32];			/* counted string */
     char defdir[64];			/* counted string */
@@ -471,9 +471,9 @@ int uaf_getuai_info (
      * Call system to get the information and fixup.  Serialize.
      */
     pthread_mutex_lock ( &uaf_static );
-    username_dx.dsc$a_pointer = (char *) username;
-    username_dx.dsc$w_length = strlen(username);
-    status = SYS$GETUAI ( 0, &uai_ctx, &username_dx, item, 0, 0, 0 );
+    username_dx.dsc_a_pointer = (char *) username;
+    username_dx.dsc_w_length = strlen(username);
+    status = SYS_GETUAI ( 0, &uai_ctx, &username_dx, item, 0, 0, 0 );
     pthread_mutex_unlock ( &uaf_static );
     if ( (status&1) == 0 ) {
 	return status;
@@ -527,8 +527,8 @@ int uaf_test_password (
 	int replace_if, uaf_qword *hashed_password )		/* Update pwd if false */
 {
     char uc_username[32], uc_password[32];
-    $DESCRIPTOR(username_dx, uc_username );
-    $DESCRIPTOR(password_dx,"");
+    _DESCRIPTOR(username_dx, uc_username );
+    _DESCRIPTOR(password_dx,"");
     int status, i, ulen;
     memset(hashed_password, 0, sizeof(uaf_qword));
     /*
@@ -537,19 +537,19 @@ int uaf_test_password (
     ulen = strlen ( pwd->username.s );
     if ( ulen > sizeof(uc_username)-1 ) return 0;	/* name too long */
     strcpy ( uc_username, pwd->username.s );
-    username_dx.dsc$w_length = ulen;
+    username_dx.dsc_w_length = ulen;
 
-    password_dx.dsc$w_length = strlen(password);
+    password_dx.dsc_w_length = strlen(password);
     if ( pwd->flags & UAIsM_PWDMIX ) {	/* take password verbatim */
-	password_dx.dsc$a_pointer = (char *) password;
+	password_dx.dsc_a_pointer = (char *) password;
     } else {
 	/*
 	 * Upcase password.
 	 */
-	password_dx.dsc$a_pointer = uc_password;
-	if ( password_dx.dsc$w_length > sizeof(uc_password) )
-		password_dx.dsc$w_length = sizeof(uc_password);
-	for ( i = 0; i < password_dx.dsc$w_length; i++ )
+	password_dx.dsc_a_pointer = uc_password;
+	if ( password_dx.dsc_w_length > sizeof(uc_password) )
+		password_dx.dsc_w_length = sizeof(uc_password);
+	for ( i = 0; i < password_dx.dsc_w_length; i++ )
 		uc_password[i] = toupper ( ARCH_INDEX(password[i]) );
     }
     /*

--- a/src/uaf_hash.c
+++ b/src/uaf_hash.c
@@ -27,9 +27,9 @@
 /*
  * Emulate symbols defined for VMS services.
  */
-#define SSs_ABORT	44
+#define SSs_ABORT        44
 #define SSs_BADPARAM     20
-#define SSs_NORMAL	1
+#define SSs_NORMAL        1
 #endif
 
 #include "memdbg.h"
@@ -77,7 +77,7 @@ Comments:	The overall speed of this routine is not great.  This is
 
 */
 
-typedef struct dsc$descriptor_s string;
+typedef struct dsc_descriptor_s string;
 
 
 /*
@@ -179,7 +179,7 @@ static int hash_password (
 	    return -1;
 //         exit(SSs_BADPARAM);
     }
-    if (username->dsc$w_length > 31) {
+    if (username->dsc_w_length > 31) {
 	    puts("2");
 	printf("Internal coding error, username is more than 31 bytes long.\n");
 	exit(SSs_ABORT);
@@ -189,7 +189,7 @@ static int hash_password (
     /* Setup pointer references */
     r3 = password;			/* 1st COLLAPSE uses the password desc.   */
     r4 = &qword;			/* @r4..@r4+7 equals obuf */
-    r5 = username->dsc$w_length;
+    r5 = username->dsc_w_length;
     r7 = (encrypt == 3);
 
     /* Clear the output buffer (zero the quadword) */
@@ -198,7 +198,7 @@ static int hash_password (
     UAF_QW_SET(*output_hash,0);
 
     /* Check for the null password and return zero as the hash value if so */
-    if (password->dsc$w_length == 0) {
+    if (password->dsc_w_length == 0) {
 	return SSs_NORMAL;
     }
 
@@ -212,9 +212,9 @@ static int hash_password (
 
 	/* Use a blank padded username */
 	strncpy(uname,"            ",sizeof(uname));
-	strncpy(uname, username->dsc$a_pointer, r5);
-	username->dsc$a_pointer = (char *)&uname;
-	username->dsc$w_length = 12;
+	strncpy(uname, username->dsc_a_pointer, r5);
+	username->dsc_a_pointer = (char *)&uname;
+	username->dsc_w_length = 12;
 	break;
 
       case UAIsC_PURDY_V:		/* Purdy with blanks stripped */
@@ -225,14 +225,14 @@ static int hash_password (
 	* 2 bytes of class information (4 bytes total), then the address of the
 	* buffer.  Usernames can not be longer than 31 characters.
 	*/
-	for ( ulen = username->dsc$w_length; ulen > 0; ulen-- ) {
-	    if ( username->dsc$a_pointer[ulen-1] != ' ' ) break;
-	    username->dsc$w_length--;
+	for ( ulen = username->dsc_w_length; ulen > 0; ulen-- ) {
+	    if ( username->dsc_a_pointer[ulen-1] != ' ' ) break;
+	    username->dsc_w_length--;
 	}
 
 	/* If Purdy_S:  Bytes 0-1 => plaintext length */
 	if (r7) {
-	   r4->ulw[0] = password->dsc$w_length;
+	   r4->ulw[0] = password->dsc_w_length;
 	}
 
 	break;
@@ -307,11 +307,11 @@ static void COLLAPSE_R2 (string *r3, quad *r4, char r7)
 
     /* --------------------------------------------------------------------- */
 
-    r0 = r3->dsc$w_length;		/* Obtain the number of input bytes */
+    r0 = r3->dsc_w_length;		/* Obtain the number of input bytes */
 
     if (r0 == 0) return;		/* Do nothing with empty string */
 
-    r2 = r3->dsc$a_pointer;		/* Obtain pointer to input string */
+    r2 = r3->dsc_a_pointer;		/* Obtain pointer to input string */
 
     for (; (r0 != 0); r0--) {		/* Loop until input string exhausted */
 


### PR DESCRIPTION
### Summary

Compatibility (variable and datatype) changes for older AIX systems.
Parser changes to skip white space in unshadow process.
