### PR TITLE
Fix bash completion for ./john --show=types-json

### DIFF
--- a/run/john.bash_completion
+++ b/run/john.bash_completion
@@ -615,7 +615,7 @@ _john()
 			COMPREPLY=( $(compgen -W "--show --show=" -- ${cur}) )
 			return 0
 			;;
-		--show=?([Ll]|[Ll][Ee]|[Ll][Ee][Ff]|[Ll][Ee][Ff][Tt]|[Tt]|[Tt][Yy]|[Tt][Yy][Pp]|[Tt][Yy]|[Tt][Yy][Pp][Ee]|[Tt][Yy]|[Tt][Yy][Pp][Ee][Ss]|[Ii]|[Ii][Nn]|[Ii][Nn][Vv]|[Ii][Nn][Vv][Aa]|[Ii][Nn][Vv][Aa][Ll]|[Ii][Nn][Vv][Aa][Ll][Ii]|[Ii][Nn][Vv][Aa][Ll][Ii][Dd]))
+		--show=?(*))
 			cur=`echo ${cur#*[=:]} | tr A-Z a-z`
 			COMPREPLY=( $(compgen -W "left types types-json invalid" -- ${cur}) )
 			return 0


### PR DESCRIPTION
The old logic didn't work for ./john --show=types-[tab] ...
