### PR TITLE
Simd helper code  #2915 GETPOS and set/get key logic

### DIFF
--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -190,6 +190,7 @@ static void set_salt(void *salt)
 }
 
 #define SALT_PREPENDED SALT_SIZE
+#define SET_SAVED_LEN_OSSL
 #include "common-simd-setkey64.h"
 
 static int crypt_all(int *pcount, struct db_salt *salt)

--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -61,11 +61,9 @@ john_register_one(&fmt_XSHA512);
 #define BINARY_SIZE				DIGEST_SIZE
 
 #ifdef SIMD_COEF_64
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#else
-#define GETPOS(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#endif
+#define FMT_IS_64BIT
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 static uint64_t (*saved_key)[SHA_BUF_SIZ*MAX_KEYS_PER_CRYPT];
 static uint64_t (*crypt_out);
 static int max_keys;
@@ -191,166 +189,8 @@ static void set_salt(void *salt)
 #endif
 }
 
-static void set_key(char *key, int index)
-{
-#ifndef SIMD_COEF_64
-	saved_len[index] = strnzcpyn(saved_key[index], key, sizeof(*saved_key));
-#else
-	uint64_t *keybuffer = &((uint64_t *)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
-	uint64_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint64_t temp;
-	unsigned char *wucp = (unsigned char*)saved_key;
-
-	// ok, first 4 bytes (if there are that many or more), we handle one offs.
-	// this is because we already have 4 byte salt loaded into our saved_key.
-	// IF there are more bytes of password, we drop into the multi loader.
-#if ARCH_ALLOWS_UNALIGNED
-	const uint64_t *wkey = (uint64_t*)&(key[4]);
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const uint64_t *wkey = is_aligned(key + 4, sizeof(uint64_t)) ?
-		(uint64_t*)(key + 4) : (uint64_t*)buf_aligned;
-	if ((char *)wkey == buf_aligned && strlen(key) >= 4)
-		strcpy(buf_aligned, key + 4);
-#endif
-	len = 4;
-	if (key[0] == 0) {wucp[GETPOS(4, index)] = 0x80; wucp[GETPOS(5, index)] = wucp[GETPOS(6, index)] = wucp[GETPOS(7, index)] = 0; goto key_cleaning; }
-	wucp[GETPOS(4, index)] = key[0];
-	++len;
-	if (key[1] == 0) {wucp[GETPOS(5, index)] = 0x80; wucp[GETPOS(6, index)] = wucp[GETPOS(7, index)] = 0; goto key_cleaning; }
-	wucp[GETPOS(5, index)] = key[1];
-	++len;
-	if (key[2] == 0) {wucp[GETPOS(6, index)] = 0x80; wucp[GETPOS(7, index)] = 0; goto key_cleaning; }
-	wucp[GETPOS(6, index)] = key[2];
-	++len;
-	if (key[3] == 0) {wucp[GETPOS(7, index)] = 0x80; goto key_cleaning; }
-	wucp[GETPOS(7, index)] = key[3];
-	++len;
-	keybuf_word += SIMD_COEF_64;
-#if ARCH_LITTLE_ENDIAN==1
-	while((unsigned char)(temp = *wkey++)) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffff) | (0x80ULL << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffff) | (0x80ULL << 32));
-			len+=4;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffULL) | (0x80ULL << 40));
-			len+=5;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffffULL) | (0x80ULL << 48));
-			len+=6;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffffffULL) | (0x80ULL << 56));
-			len+=7;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP64(temp);
-#else
-	while((temp = *wkey++)  & 0xff00000000000000ULL) {
-		if (!(temp & 0xff000000000000ULL))
-		{
-			*keybuf_word = (temp & 0xff00000000000000ULL) | (0x80ULL << 48);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000000000ULL))
-		{
-			*keybuf_word = (temp & 0xffff000000000000ULL) | (0x80ULL << 40);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000ULL))
-		{
-			*keybuf_word = (temp & 0xffffff0000000000ULL) | (0x80ULL << 32);
-			len+=3;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = (temp & 0xffffffff00000000ULL) | (0x80ULL << 24);
-			len+=4;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xffffffffff000000ULL) | (0x80 << 16);
-			len+=5;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffffffffffff0000ULL) | (0x80 << 8);
-			len+=6;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80;
-			len+=7;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 8;
-		keybuf_word += SIMD_COEF_64;
-	}
-	*keybuf_word = 0x8000000000000000ULL;
-key_cleaning:
-	keybuf_word += SIMD_COEF_64;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_64;
-	}
-	keybuffer[15*SIMD_COEF_64] = len << 3;
-#endif
-}
-
-static char *get_key(int index)
-{
-#ifndef SIMD_COEF_64
-	saved_key[index][saved_len[index]] = 0;
-	return saved_key[index];
-#else
-	static unsigned char key[PLAINTEXT_LENGTH+1];
-	int i;
-	unsigned char *wucp = (unsigned char*)saved_key;
-	uint64_t *keybuffer = &((uint64_t*)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
-	int len = (keybuffer[15*SIMD_COEF_64] >> 3) - SALT_SIZE;
-
-	for (i = 0; i < len; ++i)
-		key[i] = wucp[GETPOS(SALT_SIZE + i, index)];
-	key[i] = 0;
-	return (char*)key;
-#endif
-}
+#define SALT_PREPENDED SALT_SIZE
+#include "common-simd-setkey64.h"
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {

--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -190,7 +190,7 @@ static void set_salt(void *salt)
 }
 
 #define SALT_PREPENDED SALT_SIZE
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey64.h"
 
 static int crypt_all(int *pcount, struct db_salt *salt)

--- a/src/XSHA_fmt_plug.c
+++ b/src/XSHA_fmt_plug.c
@@ -277,6 +277,7 @@ static void set_salt(void *salt)
 }
 
 #define SALT_PREPENDED SALT_SIZE
+#define SET_SAVED_LEN_OSSL
 #include "common-simd-setkey32.h"
 
 static int crypt_all(int *pcount, struct db_salt *salt)

--- a/src/XSHA_fmt_plug.c
+++ b/src/XSHA_fmt_plug.c
@@ -55,12 +55,8 @@ static unsigned int omp_t = 1;
 
 #define MIN_KEYS_PER_CRYPT		NBKEYS
 #define MAX_KEYS_PER_CRYPT		NBKEYS
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 ) //for endianity conversion
-#else
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 ) //for endianity conversion
-#endif
-
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 #else
 
 #define MIN_KEYS_PER_CRYPT		1
@@ -280,100 +276,8 @@ static void set_salt(void *salt)
 #endif
 }
 
-static void set_key(char *key, int index)
-{
-#ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
-	const uint32_t *wkey = (uint32_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uint32_t *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
-	                                       key : strcpy(buf_aligned, key));
-#endif
-	uint32_t *keybuffer = &saved_key[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32 + SIMD_COEF_32];
-	uint32_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint32_t temp;
-
-	len = 4;
-#if ARCH_LITTLE_ENDIAN==1
-	while((temp = *wkey++) & 0xff) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP(temp | (0x80U << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP(temp);
-#else
-	while((temp = *wkey++) & 0xff000000) {
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xff000000) | (0x80 << 16);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffff0000) | (0x80 << 8);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80U;
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 4;
-		keybuf_word += SIMD_COEF_32;
-	}
-	*keybuf_word = 0x80000000;
-
-key_cleaning:
-	keybuf_word += SIMD_COEF_32;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_32;
-	}
-	keybuffer[14*SIMD_COEF_32] = len << 3;
-#else
-	saved_len[index] = strnzcpyn(saved_key[index], key, sizeof(*saved_key));
-#endif
-}
-
-static char *get_key(int index)
-{
-#ifdef SIMD_COEF_32
-	unsigned int i,s;
-	static char out[PLAINTEXT_LENGTH + 1];
-
-	s = ((unsigned int *)saved_key)[15*SIMD_COEF_32 + (index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32] >> 3;
-
-	for (i = 0; i < (s - SALT_SIZE); i++)
-		out[i] = ((char*)saved_key)[ GETPOS((i + SALT_SIZE), index) ];
-	out[i] = 0;
-
-	return (char *) out;
-#else
-	saved_key[index][saved_len[index]] = 0;
-	return saved_key[index];
-#endif
-}
+#define SALT_PREPENDED SALT_SIZE
+#include "common-simd-setkey32.h"
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {

--- a/src/XSHA_fmt_plug.c
+++ b/src/XSHA_fmt_plug.c
@@ -277,7 +277,7 @@ static void set_salt(void *salt)
 }
 
 #define SALT_PREPENDED SALT_SIZE
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey32.h"
 
 static int crypt_all(int *pcount, struct db_salt *salt)

--- a/src/common-simd-getpos.h
+++ b/src/common-simd-getpos.h
@@ -1,0 +1,80 @@
+#if !defined (__COMMON_SIMD_GETPOS_H__)
+#define __COMMON_SIMD_GETPOS_H__
+
+/*
+ * This software was written by JimF : jfoug AT cox dot net
+ * in 2017. No copyright is claimed, and the software is hereby
+ * placed in the public domain. In case this attempt to disclaim
+ * copyright and place the software in the public domain is deemed
+ * null and void, then the software is Copyright (c) 2017 JimF
+ * and it is hereby released to the general public under the following
+ * terms:
+ *
+ * This software may be modified, redistributed, and used for any
+ * purpose, in source and binary forms, with or without modification.
+ *
+ */
+
+#if !defined(FMT_IS_64BIT)
+
+#if defined (SIMD_COEF_32)
+
+#if !defined (MD5_BUF_SIZ)
+#define MD5_BUF_SIZ 16
+#endif
+#if !defined (MD4_BUF_SIZ)
+#define MD4_BUF_SIZ 16
+#endif
+
+#define GETPOSW32(i, index)             ( (index&(SIMD_COEF_32-1)) + i*SIMD_COEF_32 + (unsigned int)index/SIMD_COEF_32*16*SIMD_COEF_32 )
+// for MD4/5 use GETOUT4POSW32. SHA1 use #5.  For SHA224/256, use #8
+#define GETOUT4POSW32(i, index, WORDS)  ( (index&(SIMD_COEF_32-1)) + i*SIMD_COEF_32 + (unsigned int)index/SIMD_COEF_32*4*SIMD_COEF_32 )
+#define GETOUT5POSW32(i, index, WORDS)  ( (index&(SIMD_COEF_32-1)) + i*SIMD_COEF_32 + (unsigned int)index/SIMD_COEF_32*5*SIMD_COEF_32 )
+#define GETOUT8POSW32(i, index, WORDS)  ( (index&(SIMD_COEF_32-1)) + i*SIMD_COEF_32 + (unsigned int)index/SIMD_COEF_32*8*SIMD_COEF_32 )
+
+#if defined (FMT_IS_BE)
+#if ARCH_LITTLE_ENDIAN
+#define GETPOS(i, index)   ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*64*SIMD_COEF_32 )
+#else
+#define GETPOS(i, index)   ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 +     ((i)&3) + (unsigned int)index/SIMD_COEF_32*64*SIMD_COEF_32 )
+#endif
+#else
+#if ARCH_LITTLE_ENDIAN
+#define GETPOS(i, index)   ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 +    ((i)&3)  + (unsigned int)index/SIMD_COEF_32*64*SIMD_COEF_32 )
+#else
+#define GETPOS(i, index)   ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*64*SIMD_COEF_32 )
+#endif
+#endif
+#else
+// dummy macros if SIMD_COEF_32 is not defined
+#define GETPOSW32(i, index)
+#define GETOUTPOSW32(i, index, BYTES)
+#define GETPOS(i, index)
+
+#endif // SIMD_COEF_32
+
+#else // FMT_IS_64BIT
+
+#if defined (SIMD_COEF_64)
+
+#define GETPOSW64(i, index)             ( (index&(SIMD_COEF_64-1)) + i*SIMD_COEF_64 + (unsigned int)index/SIMD_COEF_64*16*SIMD_COEF_64 )
+#define GETOUTPOS8W64(i, index)  ( (index&(SIMD_COEF_64-1)) + i*SIMD_COEF_64 + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64 )
+
+// SHA512 defines for doing SIMD mixed buffer work.
+#if !ARCH_LITTLE_ENDIAN
+#define GETPOS(i, index)   ( (index&(SIMD_COEF_64-1))*8 + ((i)  &(0xffffffff-7))*SIMD_COEF_64 +    ((i)&7)  + (unsigned int)index/SIMD_COEF_64*128*SIMD_COEF_64 )
+#else
+#define GETPOS(i, index)   ( (index&(SIMD_COEF_64-1))*8 + ((i)  &(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*128*SIMD_COEF_64 )
+#endif
+
+#else
+// dummy macros if SIMD_COEF_64 is not defined
+#define GETPOS_SHA512_W64(i, index)
+#define GETOUTPOS_SHA512_W64(i, index)
+#define GETPOS_SHA512(i, index)
+
+#endif // SIMD_COEF_64
+
+#endif // FMT_IS_64BIT
+
+#endif // __COMMON_SIMD_GETPOS_H__

--- a/src/common-simd-getpos.h
+++ b/src/common-simd-getpos.h
@@ -2,17 +2,23 @@
 #define __COMMON_SIMD_GETPOS_H__
 
 /*
- * This software was written by JimF : jfoug AT cox dot net
- * in 2017. No copyright is claimed, and the software is hereby
- * placed in the public domain. In case this attempt to disclaim
- * copyright and place the software in the public domain is deemed
- * null and void, then the software is Copyright (c) 2017 JimF
- * and it is hereby released to the general public under the following
- * terms:
- *
- * This software may be modified, redistributed, and used for any
- * purpose, in source and binary forms, with or without modification.
- *
+ * This software is Copyright (c) 2017 jfoug : jfoug AT cox dot net
+ *  Parts taken from code previously written by:
+ *    magnumripper
+ *    Alain Espinosa
+ *    Simon Marechal
+ *    and possibly others.
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+/*
+ * !!NOTE!! if used on a BE format (SHA1/256/512), then before including
+ *   this file, define  'FMT_IS_BE'  so that the proper macros for the
+ *   hash typ[e are the being ones that will used.  the ARCH_LITTLE_ENDIAN,
+ *   SIMD_COEFp[32][64] are global defines, and will already be correctly
+ *   for your build. You DO NOT have to reset them before including this
+ *   generic code header.
  */
 
 #if !defined(FMT_IS_64BIT)

--- a/src/common-simd-setkey32.h
+++ b/src/common-simd-setkey32.h
@@ -163,13 +163,6 @@ key_cleaning:
 	keybuffer[14*SIMD_COEF_32] = len << 3;
 #	endif
 #endif
-//	if (!index)
-//		printf ("\n");
-//	printf ("(%d)", index);
-//	dump_stuff_mmx(saved_key, 64, index);
-//	fflush(stdout);
-//	if (index > 3)
-//		exit(0);
 }
 #else	// !defined SIMD_COEF_32
 static void set_key(char *key, int index)

--- a/src/common-simd-setkey32.h
+++ b/src/common-simd-setkey32.h
@@ -1,0 +1,210 @@
+
+/*
+ * This software was written by JimF : jfoug AT cox dot net
+ * in 2017. No copyright is claimed, and the software is hereby
+ * placed in the public domain. In case this attempt to disclaim
+ * copyright and place the software in the public domain is deemed
+ * null and void, then the software is Copyright (c) 2017 JimF
+ * and it is hereby released to the general public under the following
+ * terms:
+ *
+ * This software may be modified, redistributed, and used for any
+ * purpose, in source and binary forms, with or without modification.
+ *
+ */
+
+/*
+ * this include file is CODE.  It includes a 'standard' set_key() function,
+ * for both SIMD and flat loading.  The requisites for this function to work:
+ *   straight keys saved (no encoding, just ascii).
+ *   if built for SIMD, this this properly build static must be available:
+ *     static uint32_t (*saved_key)[MD5_BUF_SIZ*NBKEYS];
+ *       the important thing here, is the buffer must be large enough, aligned
+ *       to 16 bytes, and NAMED saved_key.  Also, saved_key should be expected
+ *       to be filled from the start with the password, and properly 'cleaned'
+ *       and then size filled when the function completes.
+ *     Proper GETPOS and GETPOSW macros myst be set for the format.
+ * for non_simd builds, these buffers must be there:
+ *    static int (*saved_len);
+ *    static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+ */
+
+
+#if defined(SIMD_COEF_32)
+
+#if !defined SALT_APPENDED
+#define SALT_APPENDED 0
+#endif
+#if !defined SALT_PREPENDED
+#define SALT_PREPENDED 0
+#endif
+
+
+#undef COMMON_SWAP
+
+#if defined(FMT_IS_BE)
+#  if ARCH_LITTLE_ENDIAN
+#    define COMMON_SWAP(a) JOHNSWAP(a)
+#  else
+#    define COMMON_SWAP(a) (a)
+#  endif
+#else
+#  if ARCH_LITTLE_ENDIAN
+#    define COMMON_SWAP(a) (a)
+#  else
+#    define COMMON_SWAP(a) JOHNSWAP(a)
+#  endif
+#endif
+
+static void set_key(char *_key, int index)
+{
+#if ARCH_ALLOWS_UNALIGNED
+	const uint32_t *key = (uint32_t*)_key;
+#else
+	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
+	const uint32_t *key = (uint32_t*)(is_aligned(_key, sizeof(uint32_t)) ?
+	                                      _key : strcpy(buf_aligned, _key));
+#endif
+	uint32_t *keybuffer = &((uint32_t*)saved_key)[GETPOSW32(0,index)];
+	uint32_t *keybuf_word = keybuffer;
+	unsigned int len=0;
+	uint32_t temp;
+
+#if SALT_PREPENDED
+#if SALT_PREPENDED/4*4 != SALT_PREPENDED
+#error the code in common-setkey32.h ONLY works for appended salts of fixed length evenly divisible by 4
+#endif
+	keybuf_word  += (SALT_PREPENDED/4)*SIMD_COEF_32;
+	len = SALT_PREPENDED;
+#endif
+
+#if ARCH_LITTLE_ENDIAN
+	while((temp = *key++) & 0xff) {
+		if (!(temp & 0xff00))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xff) | (0x80 << 8));
+			len++;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff0000))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffff) | (0x80 << 16));
+			len+=2;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff000000))
+		{
+			*keybuf_word = COMMON_SWAP(temp | (0x80U << 24));
+			len+=3;
+			goto key_cleaning;
+		}
+		*keybuf_word = COMMON_SWAP(temp);
+#else
+	while((temp = *key++) & 0xff000000) {
+		if (!(temp & 0xff0000))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xff000000) | (0x80 << 16));
+			len++;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff00))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffff0000) | (0x80 << 8));
+			len+=2;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff))
+		{
+			*keybuf_word = COMMON_SWAP(temp | 0x80U);
+			len+=3;
+			goto key_cleaning;
+		}
+		*keybuf_word = COMMON_SWAP(temp);
+#endif
+		len += 4;
+		keybuf_word += SIMD_COEF_32;
+	}
+	*keybuf_word = COMMON_SWAP(0x80);
+#ifdef DEBUG
+	/* This function is higly optimized and assumes that we are
+	   never ever given a key longer than fmt_params.plaintext_length.
+	   If we are, buffer overflows WILL happen */
+	if (len > PLAINTEXT_LENGTH) {
+		fprintf(stderr, "\n** Core bug: got len %u\n'%s'\n", len, _key);
+		error();
+	}
+#endif
+key_cleaning:
+	keybuf_word += SIMD_COEF_32;
+	while(*keybuf_word) {
+		*keybuf_word = 0;
+		keybuf_word += SIMD_COEF_32;
+	}
+#if defined (INCLUDE_TRAILING_NULL)
+	((unsigned char*)saved_key)[GETPOS(len,index)] = 0;
+	++len; /* Trailing null is included */
+	((unsigned char*)saved_key)[GETPOS(len,index)] = 0x80;
+#endif
+
+#if defined(SET_SAVED_LEN)
+	// some formats append salt, so need length, and outputting the length to
+	// uint32[14] is worthless.
+	saved_len[index] = len;
+#else
+#if SALT_APPENDED
+	len += SALT_APPENDED;
+	((unsigned char*)saved_key)[GETPOS(len,index)] = 0x80;
+#endif
+
+	// Normal key setting, set the bit length since we know it.
+#	if defined(FMT_IS_BE)
+	keybuffer[15*SIMD_COEF_32] = len << 3;
+#	else
+	keybuffer[14*SIMD_COEF_32] = len << 3;
+#	endif
+#endif
+//	if (!index)
+//		printf ("\n");
+//	printf ("(%d)", index);
+//	dump_stuff_mmx(saved_key, 64, index);
+//	fflush(stdout);
+//	if (index > 3)
+//		exit(0);
+}
+#else	// !defined SIMD_COEF_32
+static void set_key(char *key, int index)
+{
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
+}
+#endif  // SIMD_COEF_32
+
+#if defined(SIMD_COEF_32)
+static char *get_key(int index)
+{
+	static char out[PLAINTEXT_LENGTH + 1];
+	int32_t i;
+#if defined(SET_SAVED_LEN)
+	int32_t len = saved_len[index];
+#else
+# if defined(FMT_IS_BE)
+	uint32_t len = (((uint32_t*)saved_key)[GETPOSW32(15,index)] >> 3) - SALT_APPENDED - SALT_PREPENDED;
+# else
+	uint32_t len = (((uint32_t*)saved_key)[GETPOSW32(14,index)] >> 3) - SALT_APPENDED - SALT_PREPENDED;
+# endif
+#endif
+#if defined (INCLUDE_TRAILING_NULL)
+	--len;
+#endif
+
+	for (i=0;i<len;i++)
+		out[i] = ((char*)saved_key)[GETPOS(i+SALT_PREPENDED, index)];
+	out[i] = 0;
+	return (char*)out;
+}
+#else // !defined SIMD_COEF_32
+static char *get_key(int index)
+{
+	static char out [PLAINTEXT_LENGTH + 1];
+	return strnzcpy(out, saved_key[index], sizeof(out));
+}
+#endif  // SIMD_COEF_32

--- a/src/common-simd-setkey32.h
+++ b/src/common-simd-setkey32.h
@@ -28,6 +28,20 @@
  *    static int (*saved_len);
  *    static char (*saved_key)[PLAINTEXT_LENGTH + 1];
  *
+ * NOTE, the above requirements have been relaxed, to allow more formats to be
+ *  able to use this code.  To do this, #if logic was added at appropriate
+ *  locations in the code, to handle slightly different format behaviors and
+ *  requirements.  Here are a list of things which can be be predefined
+ *  before including this file, so that it behaves in a manner which the
+ *  format expects (variables, setup usages, etc).
+ *
+ *   SALT_APPENDED        Define to FIXED length of the salt!
+ *        The format will append a salt to the block of data. This code
+ *        will place the 0x80 AFTER the password and salt (salt is a place
+ *        holder buffer), and put the length of pw+salt_len into the
+ *        length field bits.  It is also used in get_key to return JUST
+ *        the password, and not the key.  ONLY impacts SIMD builds.
+ *
  *   SALT_PREPENDED       Define to FIXED length of the salt!
  *        Similar to the APPEND, but places the password SALT_PREPENDED
  *        bytes INTO the buffer.  Also within getkey, the code skips over

--- a/src/common-simd-setkey32.h
+++ b/src/common-simd-setkey32.h
@@ -167,7 +167,17 @@ key_cleaning:
 #else	// !defined SIMD_COEF_32
 static void set_key(char *key, int index)
 {
-	strnzcpy(saved_key[index], key, sizeof(*saved_key));
+#if defined (NON_SIMD_SINGLE_SAVED_KEY)
+#  if defined(SET_SAVED_LEN) || defined (SET_SAVED_LEN_OSSL)
+	saved_len =
+#  endif
+	strnzcpyn(saved_key, key, sizeof(saved_key));
+#else
+#  if defined(SET_SAVED_LEN) || defined (SET_SAVED_LEN_OSSL)
+	saved_len[index] =
+#  endif
+	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+#endif
 }
 #endif  // SIMD_COEF_32
 
@@ -197,7 +207,18 @@ static char *get_key(int index)
 #else // !defined SIMD_COEF_32
 static char *get_key(int index)
 {
+#if defined (NON_SIMD_SINGLE_SAVED_KEY)
+#  if defined(SET_SAVED_LEN) || defined (SET_SAVED_LEN_OSSL)
+	saved_key[saved_len] = 0;
+#  endif
+	return saved_key;
+#else
 	static char out [PLAINTEXT_LENGTH + 1];
+#  if defined(SET_SAVED_LEN) || defined (SET_SAVED_LEN_OSSL)
+	return strnzcpy(out, saved_key[index], saved_len[index]+1);
+#  else
 	return strnzcpy(out, saved_key[index], sizeof(out));
+#  endif
+#endif
 }
 #endif  // SIMD_COEF_32

--- a/src/common-simd-setkey32.h
+++ b/src/common-simd-setkey32.h
@@ -1,16 +1,13 @@
-
 /*
- * This software was written by JimF : jfoug AT cox dot net
- * in 2017. No copyright is claimed, and the software is hereby
- * placed in the public domain. In case this attempt to disclaim
- * copyright and place the software in the public domain is deemed
- * null and void, then the software is Copyright (c) 2017 JimF
- * and it is hereby released to the general public under the following
- * terms:
- *
- * This software may be modified, redistributed, and used for any
- * purpose, in source and binary forms, with or without modification.
- *
+ * This software is Copyright (c) 2017 jfoug : jfoug AT cox dot net
+ *  Parts taken from code previously written by:
+ *    magnumripper
+ *    Alain Espinosa
+ *    Simon Marechal
+ *    and possibly others.
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  */
 
 /*

--- a/src/common-simd-setkey64.h
+++ b/src/common-simd-setkey64.h
@@ -121,7 +121,7 @@ static void set_key(char *_key, int index)
 	keybuf_word  += ((SALT_PREPENDED+7)/8)*SIMD_COEF_64;
 	len = SALT_PREPENDED;
 	while (SALT_PREPENDED+idx < til) {
-		if (!_key[0]) { 
+		if (!_key[0]) {
 			((unsigned char*)saved_key)[GETPOS(idx+SALT_PREPENDED, index)] = 0x80;
 			while (++idx + SALT_PREPENDED < til)
 				((unsigned char*)saved_key)[GETPOS(idx+SALT_PREPENDED, index)] = 0;

--- a/src/common-simd-setkey64.h
+++ b/src/common-simd-setkey64.h
@@ -209,14 +209,6 @@ key_cleaning:
 	keybuffer[14*SIMD_COEF_64] = len << 3;
 #	endif
 #endif
-//	if (!index)
-//		printf ("\n");
-//	printf ("(%d)", index);
-//	dump_stuff_mmx64(saved_key, 128, index);
-//	fflush(stdout);
-//	if (index > 3)
-//		exit(0);
-//
 }
 #else	// !defined SIMD_COEF_64
 static void set_key(char *key, int index)

--- a/src/common-simd-setkey64.h
+++ b/src/common-simd-setkey64.h
@@ -27,6 +27,54 @@
  * for non_simd builds, these buffers must be there:
  *    static int (*saved_len);
  *    static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+ *
+ * NOTE, the above requirements have been relaxed, to allow more formats to be
+ *  able to use this code.  To do this, #if logic was added at appropriate
+ *  locations in the code, to handle slightly different format behaviors and
+ *  requirements.  Here are a list of things which can be be predefined
+ *  before including this file, so that it behaves in a manner which the
+ *  format expects (variables, setup usages, etc).
+ *
+ *   SALT_APPENDED        Define to FIXED length of the salt!
+ *        The format will append a salt to the block of data. This code
+ *        will place the 0x80 AFTER the password and salt (salt is a place
+ *        holder buffer), and put the length of pw+salt_len into the
+ *        length field bits.  It is also used in get_key to return JUST
+ *        the password, and not the key.  ONLY impacts SIMD builds.
+
+ *   SALT_PREPENDED       Define to FIXED length of the salt!
+ *        Similar to the APPEND, but places the password SALT_PREPENDED
+ *        bytes INTO the buffer.  Also within getkey, the code skips over
+ *        the salt, and only returns the password.
+ *
+ *   FMT_IS_BE            Simple define (set or not)
+ *        This needs set for any BE format (SHAx, etc). NOTE, this define
+ *        should have already been set before calling common-simd-getpos.h
+ *        so it normally is NOT a concern before including this file.
+ *
+ * INCLUDE_TRAILING_NULL  Simple define
+ *        citrix includes the NULL byte (before the 0x80) in the SIMD
+ *        code, so that logic was kept.  A pretty simple block of code
+ *        controlled by this define, impacting only that format, BUT
+ *        if other formats want a NULL trailing the password, simply
+ *        define this flag.
+ *
+ * SET_SAVED_LEN          Simple define
+ *        The format wants to save the length into 'saved_len'. This
+ *        logic will set the length (password) into saved_len[] array
+ *        in simd code. It will save it into saved_len[] array OR into
+ *        saved_len variable, based upon the next variable.  NOTE, simd
+ *        will ALWAYS use an array, IF it uses saved_len at all.
+ *
+ * NON_SIMD_SET_SAVED_LEN  Simple define
+ *        If this variable is set, then in the non-simd code, there is
+ *        a simple variable (not an array), so we store (and later use)
+ *        the save_len into a single variable.
+ *
+ * NON_SIMD_SINGLE_SAVED_KEY  simple define.
+ *        In a non-simd mode, there is only 1 saved_key variable (not
+ *        an array of them).
+ *
  */
 
 
@@ -214,12 +262,12 @@ key_cleaning:
 static void set_key(char *key, int index)
 {
 #if defined (NON_SIMD_SINGLE_SAVED_KEY)
-#  if defined(SET_SAVED_LEN) || defined (SET_SAVED_LEN_OSSL)
+#  if defined(SET_SAVED_LEN) || defined (NON_SIMD_SET_SAVED_LEN)
 	saved_len =
 #  endif
 	strnzcpyn(saved_key, key, sizeof(saved_key));
 #else
-#  if defined(SET_SAVED_LEN) || defined (SET_SAVED_LEN_OSSL)
+#  if defined(SET_SAVED_LEN) || defined (NON_SIMD_SET_SAVED_LEN)
 	saved_len[index] =
 #  endif
 	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
@@ -255,13 +303,13 @@ static char *get_key(int index)
 static char *get_key(int index)
 {
 #if defined (NON_SIMD_SINGLE_SAVED_KEY)
-#  if defined(SET_SAVED_LEN) || defined (SET_SAVED_LEN_OSSL)
+#  if defined(SET_SAVED_LEN) || defined (NON_SIMD_SET_SAVED_LEN)
 	saved_key[saved_len] = 0;
 #  endif
 	return saved_key;
 #else
 	static char out [PLAINTEXT_LENGTH + 1];
-#  if defined(SET_SAVED_LEN) || defined (SET_SAVED_LEN_OSSL)
+#  if defined(SET_SAVED_LEN) || defined (NON_SIMD_SET_SAVED_LEN)
 	return strnzcpy(out, saved_key[index], saved_len[index]+1);
 #  else
 	return strnzcpy(out, saved_key[index], sizeof(out));

--- a/src/common-simd-setkey64.h
+++ b/src/common-simd-setkey64.h
@@ -1,0 +1,262 @@
+
+/*
+ * This software was written by JimF : jfoug AT cox dot net
+ * in 2017. No copyright is claimed, and the software is hereby
+ * placed in the public domain. In case this attempt to disclaim
+ * copyright and place the software in the public domain is deemed
+ * null and void, then the software is Copyright (c) 2017 JimF
+ * and it is hereby released to the general public under the following
+ * terms:
+ *
+ * This software may be modified, redistributed, and used for any
+ * purpose, in source and binary forms, with or without modification.
+ *
+ */
+
+/*
+ * this include file is CODE.  It includes a 'standard' set_key() function,
+ * for both SIMD and flat loading.  The requisites for this function to work:
+ *   straight keys saved (no encoding, just ascii).
+ *   if built for SIMD, this this properly build static must be available:
+ *     static uint64_t (*saved_key)[MD5_BUF_SIZ*NBKEYS];
+ *       the important thing here, is the buffer must be large enough, aligned
+ *       to 16 bytes, and NAMED saved_key.  Also, saved_key should be expected
+ *       to be filled from the start with the password, and properly 'cleaned'
+ *       and then size filled when the function completes.
+ *     Proper GETPOS and GETPOSW macros myst be set for the format.
+ * for non_simd builds, these buffers must be there:
+ *    static int (*saved_len);
+ *    static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+ */
+
+
+#if defined(SIMD_COEF_64)
+
+#if !defined SALT_APPENDED
+#define SALT_APPENDED 0
+#endif
+#if !defined SALT_PREPENDED
+#define SALT_PREPENDED 0
+#endif
+
+#undef COMMON_SWAP
+
+#if defined(FMT_IS_BE)
+#  if ARCH_LITTLE_ENDIAN
+#    define COMMON_SWAP(a) JOHNSWAP64(a)
+#  else
+#    define COMMON_SWAP(a) (a)
+#  endif
+#else
+#  if ARCH_LITTLE_ENDIAN
+#    define COMMON_SWAP(a) (a)
+#  else
+#    define COMMON_SWAP(a) JOHNSWAP64(a)
+#  endif
+#endif
+
+static void set_key(char *_key, int index)
+{
+	const uint64_t *wkey;
+#if !ARCH_ALLOWS_UNALIGNED
+	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
+#endif
+	uint64_t *keybuffer = &((uint64_t*)saved_key)[GETPOSW64(0,index)];
+	uint64_t *keybuf_word = keybuffer;
+	unsigned int len=0;
+	uint64_t temp;
+
+#if SALT_PREPENDED
+	// Note, salts do NOT have to be evenly divisible by 8 bytes in size!
+	int til = ((SALT_PREPENDED+7)/8)*8;
+	int idx = 0;
+	keybuf_word  += ((SALT_PREPENDED+7)/8)*SIMD_COEF_64;
+	len = SALT_PREPENDED;
+	while (SALT_PREPENDED+idx < til) {
+		if (!_key[0]) { 
+			((unsigned char*)saved_key)[GETPOS(idx+SALT_PREPENDED, index)] = 0x80;
+			while (++idx + SALT_PREPENDED < til)
+				((unsigned char*)saved_key)[GETPOS(idx+SALT_PREPENDED, index)] = 0;
+			keybuf_word -= SIMD_COEF_64;
+			goto key_cleaning;
+		}
+		((unsigned char*)saved_key)[GETPOS(idx+SALT_PREPENDED, index)] = *_key++;
+		++idx;
+		++len;
+	}
+#endif
+
+#if ARCH_ALLOWS_UNALIGNED
+	wkey = (uint64_t*)_key;
+#else
+	wkey = (uint64_t*)(is_aligned(_key, sizeof(uint64_t)) ? _key : strcpy(buf_aligned, _key));
+#endif
+
+#if ARCH_LITTLE_ENDIAN
+	while((unsigned char)(temp = *wkey++)) {
+		if (!(temp & 0xff00))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xff) | (0x80 << 8));
+			len++;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff0000))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffff) | (0x80 << 16));
+			len+=2;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff000000))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffff) | (0x80ULL << 24));
+			len+=3;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff00000000ULL))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffffff) | (0x80ULL << 32));
+			len+=4;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff0000000000ULL))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffffffffULL) | (0x80ULL << 40));
+			len+=5;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff000000000000ULL))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffffffffffULL) | (0x80ULL << 48));
+			len+=6;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff00000000000000ULL))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffffffffffffULL) | (0x80ULL << 56));
+			len+=7;
+			goto key_cleaning;
+		}
+		*keybuf_word = COMMON_SWAP(temp);
+#else
+	while((temp = *wkey++)  & 0xff00000000000000ULL) {
+		if (!(temp & 0xff000000000000ULL))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xff00000000000000ULL) | (0x80ULL << 48));
+			len++;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff0000000000ULL))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffff000000000000ULL) | (0x80ULL << 40));
+			len+=2;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff00000000ULL))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffff0000000000ULL) | (0x80ULL << 32));
+			len+=3;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff000000))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffffff00000000ULL) | (0x80ULL << 24));
+			len+=4;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff0000))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffffffff000000ULL) | (0x80 << 16));
+			len+=5;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff00))
+		{
+			*keybuf_word = COMMON_SWAP((temp & 0xffffffffffff0000ULL) | (0x80 << 8));
+			len+=6;
+			goto key_cleaning;
+		}
+		if (!(temp & 0xff))
+		{
+			*keybuf_word = COMMON_SWAP(temp | 0x80);
+			len+=7;
+			goto key_cleaning;
+		}
+		*keybuf_word = COMMON_SWAP(temp);
+#endif
+		len += 8;
+		keybuf_word += SIMD_COEF_64;
+	}
+	*keybuf_word = COMMON_SWAP(0x80LL);
+
+key_cleaning:
+	keybuf_word += SIMD_COEF_64;
+	while(*keybuf_word) {
+		*keybuf_word = 0;
+		keybuf_word += SIMD_COEF_64;
+	}
+#if defined(SET_SAVED_LEN)
+	// some formats append salt, so need length, and outputting the length to
+	// uint64[14] is worthless.
+	saved_len[index] = len;
+#else
+#if SALT_APPENDED
+	len += SALT_APPENDED;
+	((unsigned char*)saved_key)[GETPOS(len,index)] = 0x80;
+#endif
+#	if defined(FMT_IS_BE)
+	keybuffer[15*SIMD_COEF_64] = len << 3;
+#	else
+	keybuffer[14*SIMD_COEF_64] = len << 3;
+#	endif
+#endif
+//	if (!index)
+//		printf ("\n");
+//	printf ("(%d)", index);
+//	dump_stuff_mmx64(saved_key, 128, index);
+//	fflush(stdout);
+//	if (index > 3)
+//		exit(0);
+//
+}
+#else	// !defined SIMD_COEF_64
+static void set_key(char *key, int index)
+{
+	int len = strlen(key);
+	saved_len[index] = len;
+	memcpy(saved_key[index], key, len);
+}
+#endif  // SIMD_COEF_64
+
+
+#if defined(SIMD_COEF_64)
+static char *get_key(int index)
+{
+	static char out[PLAINTEXT_LENGTH + 1];
+	uint64_t i;
+#if defined(SET_SAVED_LEN)
+	int32_t len = saved_len[index];
+#else
+#	if defined(FMT_IS_BE)
+	uint64_t len = (((uint64_t*)saved_key)[GETPOSW64(15,index)] >> 3) - SALT_PREPENDED - SALT_APPENDED;
+#	else
+	uint64_t len = (((uint64_t*)saved_key)[GETPOSW64(14,index)] >> 3) - SALT_PREPENDED - SALT_APPENDED;
+#	endif
+#endif
+#if defined (INCLUDE_TRAILING_NULL)
+	--len;
+#endif
+
+	for (i=0;i<len;i++)
+		out[i] = ((char*)saved_key)[GETPOS(i+SALT_PREPENDED, index)];
+	out[i] = 0;
+	return (char*)out;
+}
+#else // !defined SIMD_COEF_64
+static char *get_key(int index)
+{
+	static char out [PLAINTEXT_LENGTH + 1];
+	memcpy(out, saved_key[index], saved_len[index]);
+	out[saved_len[index]] = 0;
+	return out;
+}
+#endif  // SIMD_COEF_64

--- a/src/common-simd-setkey64.h
+++ b/src/common-simd-setkey64.h
@@ -1,16 +1,13 @@
-
 /*
- * This software was written by JimF : jfoug AT cox dot net
- * in 2017. No copyright is claimed, and the software is hereby
- * placed in the public domain. In case this attempt to disclaim
- * copyright and place the software in the public domain is deemed
- * null and void, then the software is Copyright (c) 2017 JimF
- * and it is hereby released to the general public under the following
- * terms:
- *
- * This software may be modified, redistributed, and used for any
- * purpose, in source and binary forms, with or without modification.
- *
+ * This software is Copyright (c) 2017 jfoug : jfoug AT cox dot net
+ *  Parts taken from code previously written by:
+ *    magnumripper
+ *    Alain Espinosa
+ *    Simon Marechal
+ *    and possibly others.
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  */
 
 /*

--- a/src/mysqlSHA1_fmt_plug.c
+++ b/src/mysqlSHA1_fmt_plug.c
@@ -154,6 +154,7 @@ static void init(struct fmt_main *self)
 #endif
 }
 
+#define NON_SIMD_SINGLE_SAVED_KEY
 #include "common-simd-setkey32.h"
 
 static int cmp_all(void *binary, int count) {

--- a/src/mysqlSHA1_fmt_plug.c
+++ b/src/mysqlSHA1_fmt_plug.c
@@ -68,11 +68,8 @@ john_register_one(&fmt_mysqlSHA1);
 
 #define MIN_KEYS_PER_CRYPT		NBKEYS
 #define MAX_KEYS_PER_CRYPT		NBKEYS
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3) )*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*4*SIMD_COEF_32 ) //for endianity conversion
-#else
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3) )*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*4*SIMD_COEF_32 ) //for endianity conversion
-#endif
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 
 #else
 
@@ -157,95 +154,7 @@ static void init(struct fmt_main *self)
 #endif
 }
 
-static void set_key(char *key, int index)
-{
-#ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
-	const uint32_t *wkey = (uint32_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uint32_t *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
-	                                       key : strcpy(buf_aligned, key));
-#endif
-	uint32_t *keybuf_word = &((uint32_t*)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
-	unsigned int len;
-	uint32_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN==1
-	while((temp = *wkey++) & 0xff) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP(temp | (0x80U << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP(temp);
-#else
-	while((temp = *wkey++) & 0xff000000) {
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xff000000) | (0x80 << 16);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffff0000) | (0x80 << 8);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80U;
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 4;
-		keybuf_word += SIMD_COEF_32;
-	}
-	*keybuf_word = 0x80000000;
-
-key_cleaning:
-	keybuf_word += SIMD_COEF_32;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_32;
-	}
-	((unsigned int *)saved_key)[15*SIMD_COEF_32 + (index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32] = len << 3;
-#else
-	strnzcpy(saved_key, key, PLAINTEXT_LENGTH + 1);
-#endif
-}
-
-static char *get_key(int index) {
-#ifdef SIMD_COEF_32
-	static char out[PLAINTEXT_LENGTH+1];
-	unsigned int i, s;
-
-	s = ((unsigned int *)saved_key)[15*SIMD_COEF_32 + (index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32] >> 3;
-	for (i = 0; i < s; i++)
-		out[i] = saved_key[ GETPOS(i, index) ];
-	out[i] = 0;
-	return out;
-#else
-	return saved_key;
-#endif
-}
+#include "common-simd-setkey32.h"
 
 static int cmp_all(void *binary, int count) {
 #ifdef SIMD_COEF_32

--- a/src/oracle11_fmt_plug.c
+++ b/src/oracle11_fmt_plug.c
@@ -206,7 +206,7 @@ static void clear_keys(void)
 
 #define SALT_APPENDED SALT_SIZE
 #define NON_SIMD_SINGLE_SAVED_KEY
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey32.h"
 
 static int cmp_all(void *binary, int count)

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -245,6 +245,7 @@ static char *source(char *source, void *binary)
 	return out;
 }
 
+#define SET_SAVED_LEN_OSSL
 #include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -245,7 +245,7 @@ static char *source(char *source, void *binary)
 	return out;
 }
 
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -266,6 +266,7 @@ static char *source(char *source, void *binary)
 	return out;
 }
 
+#define SET_SAVED_LEN_OSSL
 #include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -107,11 +107,7 @@ static struct fmt_tests tests[] = {
 #define PLAINTEXT_LENGTH		55
 #define MIN_KEYS_PER_CRYPT		NBKEYS
 #define MAX_KEYS_PER_CRYPT		NBKEYS
-#if ARCH_LITTLE_ENDIAN
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*MD5_BUF_SIZ*4*SIMD_COEF_32 )
-#else
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*MD5_BUF_SIZ*4*SIMD_COEF_32 )
-#endif
+#include "common-simd-getpos.h"
 #else
 #define PLAINTEXT_LENGTH		125
 #define MIN_KEYS_PER_CRYPT		1
@@ -270,114 +266,7 @@ static char *source(char *source, void *binary)
 	return out;
 }
 
-#ifdef SIMD_COEF_32
-static void set_key(char *_key, int index)
-{
-#if ARCH_ALLOWS_UNALIGNED
-	const uint32_t *key = (uint32_t*)_key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uint32_t *key = (uint32_t*)(is_aligned(_key, sizeof(uint32_t)) ?
-	                                      _key : strcpy(buf_aligned, _key));
-#endif
-	uint32_t *keybuffer = &((uint32_t*)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*MD5_BUF_SIZ*SIMD_COEF_32];
-	uint32_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint32_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN
-	while((temp = *key++) & 0xff) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xff) | (0x80 << 8);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xffff) | (0x80 << 16);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = temp | (0x80U << 24);
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#else
-	while((temp = *key++) & 0xff000000) {
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xff000000) | (0x80 << 16));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xffff0000) | (0x80 << 8));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = JOHNSWAP(temp | 0x80U);
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP(temp);
-#endif
-		len += 4;
-		keybuf_word += SIMD_COEF_32;
-	}
-	*keybuf_word = 0x80;
-#ifdef DEBUG
-	/* This function is higly optimized and assumes that we are
-	   never ever given a key longer than fmt_params.plaintext_length.
-	   If we are, buffer overflows WILL happen */
-	if (len > PLAINTEXT_LENGTH) {
-		fprintf(stderr, "\n** Core bug: got len %u\n'%s'\n", len, _key);
-		error();
-	}
-#endif
-key_cleaning:
-	keybuf_word += SIMD_COEF_32;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_32;
-	}
-	keybuffer[14*SIMD_COEF_32] = len << 3;
-}
-#else
-static void set_key(char *key, int index)
-{
-	int len = strlen(key);
-	saved_len[index] = len;
-	memcpy(saved_key[index], key, len);
-}
-#endif
-
-#ifdef SIMD_COEF_32
-static char *get_key(int index)
-{
-	static char out[PLAINTEXT_LENGTH + 1];
-	unsigned int i;
-	uint32_t len = ((uint32_t*)saved_key)[14*SIMD_COEF_32 + (index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*MD5_BUF_SIZ*SIMD_COEF_32] >> 3;
-
-	for (i=0;i<len;i++)
-		out[i] = ((char*)saved_key)[GETPOS(i, index)];
-	out[i] = 0;
-	return (char*)out;
-}
-#else
-static char *get_key(int index)
-{
-	saved_key[index][saved_len[index]] = 0;
-	return saved_key[index];
-}
-#endif
+#include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS
 #undef SSEi_REVERSE_STEPS

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -266,7 +266,7 @@ static char *source(char *source, void *binary)
 	return out;
 }
 
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA1_linkedIn_fmt_plug.c
+++ b/src/rawSHA1_linkedIn_fmt_plug.c
@@ -104,6 +104,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 	return ciphertext;
 }
 
+#define NON_SIMD_SINGLE_SAVED_KEY
 #include "common-simd-setkey32.h"
 
 static int cmp_all(void *binary, int count) {

--- a/src/rawSHA1_linkedIn_fmt_plug.c
+++ b/src/rawSHA1_linkedIn_fmt_plug.c
@@ -59,11 +59,8 @@ john_register_one(&fmt_rawSHA1_LI);
 #define PLAINTEXT_LENGTH		55
 #define MIN_KEYS_PER_CRYPT		NBKEYS
 #define MAX_KEYS_PER_CRYPT		NBKEYS
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 ) //for endianity conversion
-#else
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*4*SIMD_COEF_32 )
-#endif
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 #else
 #define PLAINTEXT_LENGTH		125
 #define MIN_KEYS_PER_CRYPT		1
@@ -88,7 +85,6 @@ static struct fmt_tests tests[] = {
 #ifdef SIMD_COEF_32
 JTR_ALIGN(MEM_ALIGN_SIMD) uint32_t saved_key[SHA_BUF_SIZ*NBKEYS];
 JTR_ALIGN(MEM_ALIGN_SIMD) uint32_t crypt_key[BINARY_SIZE/4*NBKEYS];
-static unsigned char out[PLAINTEXT_LENGTH + 1];
 #else
 static char saved_key[PLAINTEXT_LENGTH + 1];
 static uint32_t crypt_key[BINARY_SIZE / 4];
@@ -108,94 +104,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 	return ciphertext;
 }
 
-static void set_key(char *key, int index) {
-#ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
-	const uint32_t *wkey = (uint32_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uint32_t *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
-	                                       key : strcpy(buf_aligned, key));
-#endif
-	uint32_t *keybuffer = &saved_key[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
-	uint32_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint32_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN==1
-	while((unsigned char)(temp = *wkey++)) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP(temp | (0x80U << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP(temp);
-#else
-	while((temp = *wkey++) & 0xff000000) {
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xff000000) | (0x80 << 16);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffff0000) | (0x80 << 8);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80U;
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 4;
-		keybuf_word += SIMD_COEF_32;
-	}
-	*keybuf_word = 0x80000000;
-
-key_cleaning:
-	keybuf_word += SIMD_COEF_32;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_32;
-	}
-	keybuffer[15*SIMD_COEF_32] = len << 3;
-#else
-	strnzcpy(saved_key, key, PLAINTEXT_LENGTH+1);
-#endif
-}
-
-static char *get_key(int index) {
-#ifdef SIMD_COEF_32
-	unsigned int i,s;
-
-	s = saved_key[15*SIMD_COEF_32 + (index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32] >> 3;
-	for (i=0;i<s;i++)
-		out[i] = ((unsigned char*)saved_key)[ GETPOS(i, index) ];
-	out[i] = 0;
-	return (char *) out;
-#else
-	return saved_key;
-#endif
-}
+#include "common-simd-setkey32.h"
 
 static int cmp_all(void *binary, int count) {
 #ifdef SIMD_COEF_32

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -99,11 +99,8 @@ static struct fmt_tests tests[] = {
 };
 
 #ifdef SIMD_COEF_32
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
-#else
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*4*SIMD_COEF_32 )
-#endif
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 static uint32_t (*saved_key);
 static uint32_t (*crypt_out);
 #else
@@ -232,107 +229,7 @@ static int binary_hash_4(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK_6; }
 
-#ifdef SIMD_COEF_32
-static void set_key(char *key, int index) {
-#if ARCH_ALLOWS_UNALIGNED
-	const uint32_t *wkey = (uint32_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uint32_t *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
-	                                       key : strcpy(buf_aligned, key));
-#endif
-	uint32_t *keybuffer = &((uint32_t *)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
-	uint32_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint32_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN==1
-	while((unsigned char)(temp = *wkey++)) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP(temp | (0x80U << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP(temp);
-#else
-	while((temp = *wkey++) & 0xff000000) {
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xff000000) | (0x80 << 16);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffff0000) | (0x80 << 8);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80U;
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 4;
-		keybuf_word += SIMD_COEF_32;
-	}
-	*keybuf_word = 0x80000000;
-
-key_cleaning:
-	keybuf_word += SIMD_COEF_32;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_32;
-	}
-	keybuffer[15*SIMD_COEF_32] = len << 3;
-}
-#else
-static void set_key(char *key, int index)
-{
-	int len = strlen(key);
-	saved_len[index] = len;
-	if (len > PLAINTEXT_LENGTH)
-		len = saved_len[index] = PLAINTEXT_LENGTH;
-	memcpy(saved_key[index], key, len);
-}
-#endif
-
-#ifdef SIMD_COEF_32
-static char *get_key(int index) {
-	unsigned int i,s;
-	static char out[PLAINTEXT_LENGTH+1];
-	unsigned char *wucp = (unsigned char*)saved_key;
-
-	s = ((uint32_t *)saved_key)[15*SIMD_COEF_32 + (index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32] >> 3;
-	for (i=0;i<s;i++)
-		out[i] = wucp[ GETPOS(i, index) ];
-	out[i] = 0;
-	return (char*) out;
-}
-#else
-static char *get_key(int index)
-{
-	saved_key[index][saved_len[index]] = 0;
-	return saved_key[index];
-}
-#endif
+#include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS
 #undef SSEi_REVERSE_STEPS

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -229,7 +229,7 @@ static int binary_hash_4(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK_6; }
 
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -229,6 +229,7 @@ static int binary_hash_4(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint32_t*)binary)[3] & PH_MASK_6; }
 
+#define SET_SAVED_LEN_OSSL
 #include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -190,6 +190,7 @@ static int binary_hash_4(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK_6; }
 
+#define SET_SAVED_LEN_OSSL
 #include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -190,7 +190,7 @@ static int binary_hash_4(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK_6; }
 
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -87,11 +87,8 @@ john_register_one(&fmt_rawSHA256);
 #endif
 
 #ifdef SIMD_COEF_32
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
-#else
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*4*SIMD_COEF_32 )
-#endif
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 static uint32_t (*saved_key);
 static uint32_t (*crypt_out);
 #else
@@ -193,107 +190,7 @@ static int binary_hash_4(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint32_t*)binary)[0] & PH_MASK_6; }
 
-#ifdef SIMD_COEF_32
-static void set_key(char *key, int index) {
-#if ARCH_ALLOWS_UNALIGNED
-	const uint32_t *wkey = (uint32_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uint32_t *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
-	                                       key : strcpy(buf_aligned, key));
-#endif
-	uint32_t *keybuffer = &((uint32_t *)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
-	uint32_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint32_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN==1
-	while((unsigned char)(temp = *wkey++)) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP(temp | (0x80U << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP(temp);
-#else
-	while((temp = *wkey++) & 0xff000000) {
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xff000000) | (0x80 << 16);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffff0000) | (0x80 << 8);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80U;
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 4;
-		keybuf_word += SIMD_COEF_32;
-	}
-	*keybuf_word = 0x80000000;
-
-key_cleaning:
-	keybuf_word += SIMD_COEF_32;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_32;
-	}
-	keybuffer[15*SIMD_COEF_32] = len << 3;
-}
-#else
-static void set_key(char *key, int index)
-{
-	int len = strlen(key);
-	saved_len[index] = len;
-	if (len > PLAINTEXT_LENGTH)
-		len = saved_len[index] = PLAINTEXT_LENGTH;
-	memcpy(saved_key[index], key, len);
-}
-#endif
-
-#ifdef SIMD_COEF_32
-static char *get_key(int index) {
-	unsigned int i,s;
-	static char out[PLAINTEXT_LENGTH+1];
-	unsigned char *wucp = (unsigned char*)saved_key;
-
-	s = ((uint32_t *)saved_key)[15*SIMD_COEF_32 + (index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32] >> 3;
-	for (i=0;i<s;i++)
-		out[i] = wucp[ GETPOS(i, index) ];
-	out[i] = 0;
-	return (char*) out;
-}
-#else
-static char *get_key(int index)
-{
-	saved_key[index][saved_len[index]] = 0;
-	return saved_key[index];
-}
-#endif
+#include "common-simd-setkey32.h"
 
 #ifndef REVERSE_STEPS
 #undef SSEi_REVERSE_STEPS

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -240,7 +240,7 @@ static int binary_hash_4(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK_6; }
 
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey64.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -109,11 +109,9 @@ static struct fmt_tests tests[] = {
 };
 
 #ifdef SIMD_COEF_64
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#else
-#define GETPOS(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#endif
+#define FMT_IS_64BIT
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 static uint64_t (*saved_key);
 static uint64_t (*crypt_out);
 #else
@@ -242,152 +240,7 @@ static int binary_hash_4(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK_6; }
 
-static void set_key(char *key, int index)
-{
-#ifdef SIMD_COEF_64
-#if ARCH_ALLOWS_UNALIGNED
-	const uint64_t *wkey = (uint64_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const uint64_t *wkey = is_aligned(key, sizeof(uint64_t)) ?
-			(uint64_t*)key : (uint64_t*)strcpy(buf_aligned, key);
-#endif
-	uint64_t *keybuffer = &((uint64_t*)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
-	uint64_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint64_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN==1
-	while((unsigned char)(temp = *wkey++)) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffff) | (0x80ULL << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffff) | (0x80ULL << 32));
-			len+=4;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffULL) | (0x80ULL << 40));
-			len+=5;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffffULL) | (0x80ULL << 48));
-			len+=6;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffffffULL) | (0x80ULL << 56));
-			len+=7;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP64(temp);
-#else
-	while((temp = *wkey++)  & 0xff00000000000000ULL) {
-		if (!(temp & 0xff000000000000ULL))
-		{
-			*keybuf_word = (temp & 0xff00000000000000ULL) | (0x80ULL << 48);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000000000ULL))
-		{
-			*keybuf_word = (temp & 0xffff000000000000ULL) | (0x80ULL << 40);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000ULL))
-		{
-			*keybuf_word = (temp & 0xffffff0000000000ULL) | (0x80ULL << 32);
-			len+=3;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = (temp & 0xffffffff00000000ULL) | (0x80ULL << 24);
-			len+=4;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xffffffffff000000ULL) | (0x80 << 16);
-			len+=5;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffffffffffff0000ULL) | (0x80 << 8);
-			len+=6;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80;
-			len+=7;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 8;
-		keybuf_word += SIMD_COEF_64;
-	}
-	*keybuf_word = 0x8000000000000000ULL;
-
-key_cleaning:
-	keybuf_word += SIMD_COEF_64;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_64;
-	}
-	keybuffer[15*SIMD_COEF_64] = len << 3;
-#else
-	int len = strlen(key);
-	saved_len[index] = len;
-	if (len > PLAINTEXT_LENGTH)
-		len = saved_len[index] = PLAINTEXT_LENGTH;
-	memcpy(saved_key[index], key, len);
-#endif
-}
-
-static char *get_key(int index)
-{
-#ifdef SIMD_COEF_64
-	unsigned i;
-	uint64_t s;
-	static char out[PLAINTEXT_LENGTH + 1];
-	unsigned char *wucp = (unsigned char*)saved_key;
-
-	s = ((uint64_t*)saved_key)[15*SIMD_COEF_64 + (index&(SIMD_COEF_64-1)) + index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64] >> 3;
-	for (i = 0; i < (unsigned)s; i++)
-		out[i] = wucp[ GETPOS(i, index) ];
-	out[i] = 0;
-	return (char*) out;
-#else
-	saved_key[index][saved_len[index]] = 0;
-	return saved_key[index];
-#endif
-}
+#include "common-simd-setkey64.h"
 
 #ifndef REVERSE_STEPS
 #undef SSEi_REVERSE_STEPS

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -240,6 +240,7 @@ static int binary_hash_4(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint64_t*)binary)[3] & PH_MASK_6; }
 
+#define SET_SAVED_LEN_OSSL
 #include "common-simd-setkey64.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -186,7 +186,7 @@ static int binary_hash_4(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK_6; }
 
-#define SET_SAVED_LEN_OSSL
+#define NON_SIMD_SET_SAVED_LEN
 #include "common-simd-setkey64.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -186,6 +186,7 @@ static int binary_hash_4(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK_6; }
 
+#define SET_SAVED_LEN_OSSL
 #include "common-simd-setkey64.h"
 
 #ifndef REVERSE_STEPS

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -83,11 +83,9 @@ john_register_one(&fmt_raw0_SHA512);
 #endif
 
 #ifdef SIMD_COEF_64
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#else
-#define GETPOS(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#endif
+#define FMT_IS_64BIT
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 static uint64_t (*saved_key);
 static uint64_t (*crypt_out);
 #else
@@ -188,152 +186,7 @@ static int binary_hash_4(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK
 static int binary_hash_5(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK_5; }
 static int binary_hash_6(void *binary) { return ((uint64_t*)binary)[0] & PH_MASK_6; }
 
-static void set_key(char *key, int index)
-{
-#ifdef SIMD_COEF_64
-#if ARCH_ALLOWS_UNALIGNED
-	const uint64_t *wkey = (uint64_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const uint64_t *wkey = is_aligned(key, sizeof(uint64_t)) ?
-			(uint64_t*)key : (uint64_t*)strcpy(buf_aligned, key);
-#endif
-	uint64_t *keybuffer = &((uint64_t*)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
-	uint64_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint64_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN==1
-	while((unsigned char)(temp = *wkey++)) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffff) | (0x80ULL << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffff) | (0x80ULL << 32));
-			len+=4;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffULL) | (0x80ULL << 40));
-			len+=5;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffffULL) | (0x80ULL << 48));
-			len+=6;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64((temp & 0xffffffffffffffULL) | (0x80ULL << 56));
-			len+=7;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP64(temp);
-#else
-	while((temp = *wkey++)  & 0xff00000000000000ULL) {
-		if (!(temp & 0xff000000000000ULL))
-		{
-			*keybuf_word = (temp & 0xff00000000000000ULL) | (0x80ULL << 48);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000000000ULL))
-		{
-			*keybuf_word = (temp & 0xffff000000000000ULL) | (0x80ULL << 40);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000ULL))
-		{
-			*keybuf_word = (temp & 0xffffff0000000000ULL) | (0x80ULL << 32);
-			len+=3;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = (temp & 0xffffffff00000000ULL) | (0x80ULL << 24);
-			len+=4;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xffffffffff000000ULL) | (0x80 << 16);
-			len+=5;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffffffffffff0000ULL) | (0x80 << 8);
-			len+=6;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80;
-			len+=7;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 8;
-		keybuf_word += SIMD_COEF_64;
-	}
-	*keybuf_word = 0x8000000000000000ULL;
-
-key_cleaning:
-	keybuf_word += SIMD_COEF_64;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_64;
-	}
-	keybuffer[15*SIMD_COEF_64] = len << 3;
-#else
-	int len = strlen(key);
-	saved_len[index] = len;
-	if (len > PLAINTEXT_LENGTH)
-		len = saved_len[index] = PLAINTEXT_LENGTH;
-	memcpy(saved_key[index], key, len);
-#endif
-}
-
-static char *get_key(int index)
-{
-#ifdef SIMD_COEF_64
-	unsigned i;
-	uint64_t s;
-	static char out[PLAINTEXT_LENGTH + 1];
-	unsigned char *wucp = (unsigned char*)saved_key;
-
-	s = ((uint64_t*)saved_key)[15*SIMD_COEF_64 + (index&(SIMD_COEF_64-1)) + index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64] >> 3;
-	for (i = 0; i < (unsigned)s; i++)
-		out[i] = wucp[ GETPOS(i, index) ];
-	out[i] = 0;
-	return (char*) out;
-#else
-	saved_key[index][saved_len[index]] = 0;
-	return saved_key[index];
-#endif
-}
+#include "common-simd-setkey64.h"
 
 #ifndef REVERSE_STEPS
 #undef SSEi_REVERSE_STEPS

--- a/src/salted_sha1_fmt_plug.c
+++ b/src/salted_sha1_fmt_plug.c
@@ -64,11 +64,8 @@ john_register_one(&fmt_saltedsha);
 #ifdef SIMD_COEF_32
 #define MIN_KEYS_PER_CRYPT		NBKEYS
 #define MAX_KEYS_PER_CRYPT		NBKEYS
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*4*SIMD_COEF_32 ) //for endianity conversion
-#else
-#define GETPOS(i, index)		( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*4*SIMD_COEF_32 ) //for endianity conversion
-#endif
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 #else
 #define MIN_KEYS_PER_CRYPT		1
 #define MAX_KEYS_PER_CRYPT		1
@@ -90,7 +87,6 @@ static struct s_salt *saved_salt;
 static uint32_t (*saved_key)[SHA_BUF_SIZ*NBKEYS];
 static uint32_t (*crypt_key)[BINARY_SIZE/4*NBKEYS];
 static unsigned int *saved_len;
-static unsigned char out[PLAINTEXT_LENGTH + 1];
 static int last_salt_size;
 #else
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
@@ -145,82 +141,8 @@ static void * get_binary(char *ciphertext) {
 	return (void *)realcipher;
 }
 
-static void set_key(char *key, int index)
-{
-#ifdef SIMD_COEF_32
-#if ARCH_ALLOWS_UNALIGNED
-	const uint32_t *wkey = (uint32_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint32_t));
-	const uint32_t *wkey = (uint32_t*)(is_aligned(key, sizeof(uint32_t)) ?
-	                                       key : strcpy(buf_aligned, key));
-#endif
-	uint32_t *keybuffer = &((uint32_t*)saved_key)[(index&(SIMD_COEF_32-1)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32];
-	uint32_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint32_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN==1
-	while((unsigned char)(temp = *wkey++)) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xff) | (0x80 << 8));
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP((temp & 0xffff) | (0x80 << 16));
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP(temp | (0x80U << 24));
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP(temp);
-#else
-	while((temp = *wkey++) & 0xff000000) {
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xff000000) | (0x80 << 16);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffff0000) | (0x80 << 8);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80U;
-			len+=3;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 4;
-		keybuf_word += SIMD_COEF_32;
-	}
-	*keybuf_word = 0x80000000;
-
-key_cleaning:
-	keybuf_word += SIMD_COEF_32;
-	while(*keybuf_word) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_32;
-	}
-
-	saved_len[index] = len;
-#else
-	strnzcpy(saved_key[index], key, PLAINTEXT_LENGTH + 1);
-#endif
-}
+#define SET_SAVED_LEN
+#include "common-simd-setkey32.h"
 
 static void * get_salt(char * ciphertext)
 {
@@ -236,20 +158,6 @@ static void * get_salt(char * ciphertext)
 
 	memcpy(cursalt.data.c, realcipher+BINARY_SIZE, cursalt.len);
 	return &cursalt;
-}
-
-static char *get_key(int index) {
-#ifdef SIMD_COEF_32
-	unsigned int i,s;
-
-	s = saved_len[index];
-	for (i=0;i<s;i++)
-		out[i] = ((char*)saved_key)[GETPOS(i, index)];
-	out[i] = 0;
-	return (char *) out;
-#else
-	return saved_key[index];
-#endif
 }
 
 static int cmp_all(void *binary, int count) {

--- a/src/salted_sha1_fmt_plug.c
+++ b/src/salted_sha1_fmt_plug.c
@@ -91,6 +91,7 @@ static int last_salt_size;
 #else
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static uint32_t (*crypt_key)[BINARY_SIZE / 4];
+static unsigned int *saved_len;
 #endif
 
 static void init(struct fmt_main *self)
@@ -109,22 +110,20 @@ static void init(struct fmt_main *self)
 	crypt_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*crypt_key));
 #else
-	saved_len = mem_calloc(self->params.max_keys_per_crypt,
-	                       sizeof(*saved_len));
 	saved_key = mem_calloc_align(self->params.max_keys_per_crypt/NBKEYS,
 	                             sizeof(*saved_key), MEM_ALIGN_SIMD);
 	crypt_key = mem_calloc_align(self->params.max_keys_per_crypt/NBKEYS,
 	                             sizeof(*crypt_key), MEM_ALIGN_SIMD);
 #endif
+	saved_len = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*saved_len));
 }
 
 static void done(void)
 {
 	MEM_FREE(crypt_key);
 	MEM_FREE(saved_key);
-#ifdef SIMD_COEF_32
 	MEM_FREE(saved_len);
-#endif
 }
 
 static void * get_binary(char *ciphertext) {

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -84,7 +84,7 @@ static uint64_t (**len_ptr64);
 static int max_count;
 #else
 static uint32_t (*crypt_out)[DIGEST_SIZE / 4];
-static uint64_t (*saved_key)[PLAINTEXT_LENGTH + 1];
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 #endif
 static int *saved_len;
 

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -75,11 +75,9 @@ struct s_salt
 static struct s_salt *saved_salt;
 
 #ifdef SIMD_COEF_64
-#if ARCH_LITTLE_ENDIAN==1
-#define GETPOS(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#else
-#define GETPOS(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#endif
+#define FMT_IS_64BIT
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
 static uint64_t (*saved_key)[SHA_BUF_SIZ*SIMD_COEF_64];
 static uint64_t (*crypt_out)[8*SIMD_COEF_64];
 static uint64_t (**len_ptr64);
@@ -138,133 +136,8 @@ static void done(void)
 	MEM_FREE(saved_len);
 }
 
-#ifdef SIMD_COEF_64
-static void set_key(char *key, int index) {
-#if ARCH_ALLOWS_UNALIGNED
-	const uint64_t *wkey = (uint64_t*)key;
-#else
-	char buf_aligned[PLAINTEXT_LENGTH + 1] JTR_ALIGN(sizeof(uint64_t));
-	const uint64_t *wkey = is_aligned(key, sizeof(uint64_t)) ?
-			(uint64_t*)key : (uint64_t*)strcpy(buf_aligned, key);
-#endif
-	uint64_t *keybuffer = &((uint64_t *)saved_key)[(index&(SIMD_COEF_64-1)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64];
-	uint64_t *keybuf_word = keybuffer;
-	unsigned int len;
-	uint64_t temp;
-
-	len = 0;
-#if ARCH_LITTLE_ENDIAN==1
-	while((unsigned char)(temp = *wkey++)) {
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = JOHNSWAP64(temp & 0xff);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = JOHNSWAP64(temp & 0xffff);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = JOHNSWAP64(temp & 0xffffff);
-			len+=3;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64(temp & 0xffffffff);
-			len+=4;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64(temp & 0xffffffffffULL);
-			len+=5;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64(temp & 0xffffffffffffULL);
-			len+=6;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000000000ULL))
-		{
-			*keybuf_word = JOHNSWAP64(temp & 0xffffffffffffffULL);
-			len+=7;
-			goto key_cleaning;
-		}
-		*keybuf_word = JOHNSWAP64(temp);
-#else
-	while((temp = *wkey++)  & 0xff00000000000000ULL) {
-		if (!(temp & 0xff000000000000ULL))
-		{
-			*keybuf_word = (temp & 0xff00000000000000ULL) | (0x80ULL << 48);
-			len++;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000000000ULL))
-		{
-			*keybuf_word = (temp & 0xffff000000000000ULL) | (0x80ULL << 40);
-			len+=2;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00000000ULL))
-		{
-			*keybuf_word = (temp & 0xffffff0000000000ULL) | (0x80ULL << 32);
-			len+=3;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff000000))
-		{
-			*keybuf_word = (temp & 0xffffffff00000000ULL) | (0x80ULL << 24);
-			len+=4;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff0000))
-		{
-			*keybuf_word = (temp & 0xffffffffff000000ULL) | (0x80 << 16);
-			len+=5;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff00))
-		{
-			*keybuf_word = (temp & 0xffffffffffff0000ULL) | (0x80 << 8);
-			len+=6;
-			goto key_cleaning;
-		}
-		if (!(temp & 0xff))
-		{
-			*keybuf_word = temp | 0x80;
-			len+=7;
-			goto key_cleaning;
-		}
-		*keybuf_word = temp;
-#endif
-		len += 8;
-		keybuf_word += SIMD_COEF_64;
-	}
-
-key_cleaning:
-	saved_len[index] = len;
-	keybuf_word += SIMD_COEF_64;
-	while(*keybuf_word && keybuf_word < &keybuffer[15*SIMD_COEF_64]) {
-		*keybuf_word = 0;
-		keybuf_word += SIMD_COEF_64;
-	}
-}
-#else
-static void set_key(char *key, int index)
-{
-	int len = strlen(key);
-
-	saved_len[index] = len;
-	memcpy(saved_key[index], key, len + 1);
-}
-#endif
+#define SET_SAVED_LEN
+#include "common-simd-setkey64.h"
 
 static void * get_salt(char * ciphertext)
 {
@@ -288,25 +161,6 @@ static void * get_salt(char * ciphertext)
 	memcpy(cursalt.data.c, realcipher+DIGEST_SIZE, cursalt.len);
 	return &cursalt;
 }
-
-#ifdef SIMD_COEF_64
-static char *get_key(int index) {
-	unsigned i;
-	uint64_t s;
-	static char out[PLAINTEXT_LENGTH + 1];
-	unsigned char *wucp = (unsigned char*)saved_key;
-
-	s = saved_len[index];
-	for (i=0;i<(unsigned)s;i++)
-		out[i] = wucp[ GETPOS(i, index) ];
-	out[i] = 0;
-	return (char*) out;
-}
-#else
-static char *get_key(int index) {
-	return (char*)saved_key[index];
-}
-#endif
 
 static int cmp_all(void *binary, int count) {
 	unsigned int index;


### PR DESCRIPTION
This block of common code, add common GETPOS header.  

It also handles get/set key logic for the complex SIMD formats. The formats NOT added into this code are formats doing complex SIMD mixing, but with unicode passwords.  Also, the complex SIMD mixing code from the HMAC* formats are not here, since that code is pretty much one off, being that the hash type is required to be know within the set_key function (for longer password handling), thus making them non-generic.