### PR TITLE
Change run-time CPU detection for AVX2 to actually only check for AVX2

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -1401,10 +1401,8 @@ Optional Features:
   --disable-rexgen        Disable use of rexgen library
   --disable-pcap          Do not build helpers depending on PCAP
   --disable-native-tests  Do not test build system for target features.
-                          Implies --disable-native-march.
-  --disable-native-march  Do not use things like -march=native even if valid
-                          compiler option(s). Native tests still can be run in
-                          this mode
+  --enable-native-march   Use things like -march=native if valid compiler
+                          option(s).
   --enable-ln-s           Use ln -s vs symlink.c wrappers (Cygwin only)
   --disable-pkg-config    do not use pkg-config for any probing tests
   --enable-nt-full-unicode
@@ -3591,7 +3589,7 @@ fi
 if test "${enable_native_march+set}" = set; then :
   enableval=$enable_native_march; enable_native_march=$enableval
 else
-  enable_native_march=auto
+  enable_native_march=no
 fi
 
 # Check whether --enable-ln-s was given.
@@ -5278,11 +5276,6 @@ $as_echo "$as_me: This is a cross-compile; all native tests disabled" >&6;}
    else
       enable_native_tests=yes
    fi
-fi
-
-# --disable-native-tests implies --disable-native-march
-if test "x$enable_native_tests" = xno; then
-   enable_native_march=no
 fi
 
 ###

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -78,8 +78,8 @@ AC_ARG_ENABLE([openmp-for-fast-formats], [AC_HELP_STRING([--enable-openmp-for-fa
 AC_ARG_ENABLE([mpi], [AC_HELP_STRING([--enable-mpi], [Use OpenMPI])], [enable_mpi=$enableval], [enable_mpi=no])
 AC_ARG_ENABLE([rexgen], [AC_HELP_STRING([--disable-rexgen], [Disable use of rexgen library])], [enable_rexgen=$enableval], [enable_rexgen=auto])
 AC_ARG_ENABLE([pcap], [AC_HELP_STRING([--disable-pcap], [Do not build helpers depending on PCAP])], [enable_pcap=$enableval], [enable_pcap=auto])
-AC_ARG_ENABLE([native-tests], [AC_HELP_STRING([--disable-native-tests], [Do not test build system for target features. Implies --disable-native-march.])], [enable_native_tests=$enableval], [enable_native_tests=auto])
-AC_ARG_ENABLE([native-march], [AC_HELP_STRING([--disable-native-march], [Do not use things like -march=native even if valid compiler option(s). Native tests still can be run in this mode])], [enable_native_march=$enableval], [enable_native_march=auto])
+AC_ARG_ENABLE([native-tests], [AC_HELP_STRING([--disable-native-tests], [Do not test build system for target features.])], [enable_native_tests=$enableval], [enable_native_tests=auto])
+AC_ARG_ENABLE([native-march], [AC_HELP_STRING([--enable-native-march], [Use things like -march=native if valid compiler option(s).])], [enable_native_march=$enableval], [enable_native_march=no])
 AC_ARG_ENABLE([ln-s], [AS_HELP_STRING([--enable-ln-s],[Use ln -s vs symlink.c wrappers (Cygwin only)])], [enable_ln_s=$enableval], [enable_ln_s=no])
 AC_ARG_ENABLE([pkg-config], [AS_HELP_STRING([--disable-pkg-config],[do not use pkg-config for any probing tests])], [enable_pkg_config=$enableval], [enable_pkg_config=auto])
 AC_ARG_ENABLE([nt-full-unicode], [AS_HELP_STRING([--enable-nt-full-unicode],[support 4-byte UTF-8 for MS formats])], [enable_nt_unicode=$enableval], [enable_nt_unicode=no])
@@ -120,11 +120,6 @@ if test "x$enable_native_tests" = xauto; then
    else
       enable_native_tests=yes
    fi
-fi
-
-# --disable-native-tests implies --disable-native-march
-if test "x$enable_native_tests" = xno; then
-   enable_native_march=no
 fi
 
 ###

--- a/src/x86-64.S
+++ b/src/x86-64.S
@@ -1641,17 +1641,15 @@ DES_bs_crypt_plain_loop:
  * CPU detection.
  */
 
-#define C7_AVX2                 $0x00000128 /* BMI2 + AVX2 + BMI1 */
+#define C7_AVX2                 $0x00000020 /* AVX2 */
 #define C7_AVX512F              $0x00010000
 #define C7_AVX512BW             $0x40010000 /* AVX512BW + AVX512F */
 
-#define CX_ABM                  $0x00000020 /* LZCNT (AVX2) */
 #define CX_XOP                  $0x00000800
 
 #define CF_SSSE3                $0x00000200 /* SSSE3 */
 #define CF_SSE4_1               $0x00080200 /* SSE4.1 + SSSE3 */
 #define CF_AVX                  $0x1C000000 /* AVX + XSAVE + OSXSAVE */
-#define CF_AVX2                 $0x1C401000 /* the above + MOVBE + FMA3 */
 
 .text
 
@@ -1670,11 +1668,7 @@ CPU_detect:
 /* First, leaf 1 checks */
 	movl $1,%eax
 	cpuid
-#if CPU_REQ_AVX2
-	andl CF_AVX2,%ecx
-	cmpl CF_AVX2,%ecx
-	jne CPU_detect_fail
-#elif CPU_REQ_AVX || CPU_REQ_XOP
+#if CPU_REQ_AVX2 || CPU_REQ_AVX || CPU_REQ_XOP
 	andl CF_AVX,%ecx
 	cmpl CF_AVX,%ecx
 	jne CPU_detect_fail
@@ -1698,7 +1692,7 @@ CPU_detect:
 #endif
 
 /* Extended feature tests (if required) */
-#if CPU_REQ_AVX2 || CPU_REQ_XOP
+#if CPU_REQ_XOP
 	movl $0x80000000,%eax
 	cpuid
 	movl $0x80000001,%edx
@@ -1706,11 +1700,7 @@ CPU_detect:
 	jl CPU_detect_fail
 	xchgl %edx,%eax
 	cpuid
-#if CPU_REQ_AVX2
-	testl CX_ABM,%ecx
-#elif CPU_REQ_XOP
 	testl CX_XOP,%ecx
-#endif
 	jz CPU_detect_fail
 #endif
 


### PR DESCRIPTION
...but neither of BMI1, BMI2, MOVBE and FMA3.

Change ./configure default to *not* use `-march=native` or the like.

Note: 32-bit x86 CPU detection still use the Quick'n'Dirty approach of inferring AVX2 from MOVBE+FMA3 (which is against recommendations but IMHO better than not testing at all).

See #2881, #2764, #2716, #2679, #2674, #2384 and a bunch of others.