### PR TITLE
Fix warnings in MinGW builds

### DIFF
--- a/src/genmkvpwd.c
+++ b/src/genmkvpwd.c
@@ -235,13 +235,13 @@ int main(int argc, char * * argv)
 			memset(nbparts, 0, 256*(max_lvl+1)*(max_len+1)*sizeof(long long));
 			nb_parts(0, 0, 0, max_lvl, max_len);
 			if (nbparts[0] > 1000000000)
-				printf(""LLu" G possible passwords ("LLu")\n", nbparts[0] / 1000000000, nbparts[0]);
+				printf("%"PRIu64" G possible passwords (%"PRIu64")\n", nbparts[0] / 1000000000, nbparts[0]);
 			else if (nbparts[0] > 10000000)
-				printf(""LLu" M possible passwords ("LLu")\n", nbparts[0] / 1000000, nbparts[0]);
+				printf("%"PRIu64" M possible passwords (%"PRIu64")\n", nbparts[0] / 1000000, nbparts[0]);
 			else if (nbparts[0] > 10000)
-				printf(""LLu" K possible passwords ("LLu")\n", nbparts[0] / 1000, nbparts[0]);
+				printf("%"PRIu64" K possible passwords (%"PRIu64")\n", nbparts[0] / 1000, nbparts[0]);
 			else
-				printf(""LLu" possible passwords\n", nbparts[0] );
+				printf("%"PRIu64" possible passwords\n", nbparts[0] );
 			MEM_FREE(nbparts);
 		}
 		goto fin;
@@ -256,13 +256,13 @@ int main(int argc, char * * argv)
 			memset(nbparts, 0, 256*(max_lvl+1)*(max_len+1)*sizeof(long long));
 			nb_parts(0, 0, 0, max_lvl, max_len);
 			if (nbparts[0] > 1000000000)
-				printf(""LLu" G possible passwords ("LLu")\n", nbparts[0] / 1000000000, nbparts[0]);
+				printf("%"PRIu64" G possible passwords (%"PRIu64")\n", nbparts[0] / 1000000000, nbparts[0]);
 			else if (nbparts[0] > 10000000)
-				printf(""LLu" M possible passwords ("LLu")\n", nbparts[0] / 1000000, nbparts[0]);
+				printf("%"PRIu64" M possible passwords (%"PRIu64")\n", nbparts[0] / 1000000, nbparts[0]);
 			else if (nbparts[0] > 10000)
-				printf(""LLu" K possible passwords ("LLu")\n", nbparts[0] / 1000, nbparts[0]);
+				printf("%"PRIu64" K possible passwords (%"PRIu64")\n", nbparts[0] / 1000, nbparts[0]);
 			else
-				printf(""LLu" possible passwords\n", nbparts[0] );
+				printf("%"PRIu64" possible passwords\n", nbparts[0] );
 			MEM_FREE(nbparts);
 		}
 		goto fin;
@@ -278,13 +278,13 @@ int main(int argc, char * * argv)
 
 	nb_parts(0, 0, 0, max_lvl, max_len);
 	if (nbparts[0] > 1000000000)
-		fprintf(stderr, ""LLu" G possible passwords ("LLu")\n", nbparts[0] / 1000000000, nbparts[0]);
+		fprintf(stderr, "%"PRIu64" G possible passwords (%"PRIu64")\n", nbparts[0] / 1000000000, nbparts[0]);
 	else if (nbparts[0] > 10000000)
-		fprintf(stderr, ""LLu" M possible passwords ("LLu")\n", nbparts[0] / 1000000, nbparts[0]);
+		fprintf(stderr, "%"PRIu64" M possible passwords (%"PRIu64")\n", nbparts[0] / 1000000, nbparts[0]);
 	else if (nbparts[0] > 10000)
-		fprintf(stderr, ""LLu" K possible passwords ("LLu")\n", nbparts[0] / 1000, nbparts[0]);
+		fprintf(stderr, "%"PRIu64" K possible passwords (%"PRIu64")\n", nbparts[0] / 1000, nbparts[0]);
 	else
-		fprintf(stderr, ""LLu" possible passwords\n", nbparts[0] );
+		fprintf(stderr, "%"PRIu64" possible passwords\n", nbparts[0] );
 
 	if (end == 0)
 		end = nbparts[0];
@@ -297,7 +297,7 @@ int main(int argc, char * * argv)
 	print_pwd(start, &pwd, max_lvl, max_len);
 	print_pwd(start, &pwd2, max_lvl, max_len);
 
-	fprintf(stderr, "starting with %s ("LLu" to "LLu", %f%% of the scope)\n", pwd.password, start, end, 100*((float) end-start)/((float) nbparts[0]) );
+	fprintf(stderr, "starting with %s (%"PRIu64" to %"PRIu64", %f%% of the scope)\n", pwd.password, start, end, 100*((float) end-start)/((float) nbparts[0]) );
 
 	show_pwd(start, end, max_lvl, max_len);
 

--- a/src/genmkvpwd.c
+++ b/src/genmkvpwd.c
@@ -22,7 +22,7 @@
 
 static void show_pwd_rnbs(struct s_pwd * pwd)
 {
-	unsigned long long i;
+	uint64_t i;
 	unsigned int k;
 	unsigned long lvl;
 
@@ -53,7 +53,7 @@ static void show_pwd_rnbs(struct s_pwd * pwd)
 
 static void show_pwd_r(struct s_pwd * pwd, unsigned int bs)
 {
-	unsigned long long i;
+	uint64_t i;
 	unsigned int k;
 	unsigned long lvl;
 	unsigned char curchar;
@@ -98,7 +98,7 @@ static void show_pwd_r(struct s_pwd * pwd, unsigned int bs)
 	pwd->level = lvl;
 }
 
-static void show_pwd(unsigned long long start, unsigned long long end, unsigned int max_level, unsigned int max_len)
+static void show_pwd(uint64_t start, uint64_t end, unsigned int max_level, unsigned int max_len)
 {
 	struct s_pwd pwd;
 	unsigned int i;
@@ -203,7 +203,7 @@ int main(int argc, char * * argv)
 	struct s_pwd pwd2;
 
 	unsigned int max_lvl = 0, max_len;
-	unsigned long long start, end;
+	uint64_t start, end;
 
 	max_len = 0;
 	start = 0;

--- a/src/gpg2john.c
+++ b/src/gpg2john.c
@@ -1038,7 +1038,7 @@ Symmetrically_Encrypted_Data_Packet(int len, int first, int partial, char *hash)
 		// let's hijack it for specifying tag values.
 		m_usage = 9; // Symmetrically Encrypted Data Packet (these lack MDC)
 		fprintf(stderr, "[gpg2john] MDC is missing, expect lots of false positives!\n");
-		printf("$gpg$*%d*"LLd"*%s*%d*%d*%d*%d*%d*", m_algorithm, (long long)totlen, hash, m_spec, m_usage, m_hashAlgorithm, m_cipherAlgorithm, m_count);
+		printf("$gpg$*%d*%"PRId64"*%s*%d*%d*%d*%d*%d*", m_algorithm, (int64_t)totlen, hash, m_spec, m_usage, m_hashAlgorithm, m_cipherAlgorithm, m_count);
 		cp = hash;
 		cp += print_hex(m_salt, 8, cp);
 		printf("%s\n", hash);
@@ -1159,7 +1159,7 @@ Symmetrically_Encrypted_and_MDC_Packet(int len, int first, int partial, char *ha
 	if (!partial) {
 		// we only dump the packet out when we get the 'non-partial' packet (i.e. last one).
 		m_usage = 18; // Sym. Encrypted Integrity Protected Data Packet (Tag 18)
-		printf("$gpg$*%d*"LLd"*%s*%d*%d*%d*%d*%d*", m_algorithm, (long long)totlen, hash, m_spec, m_usage, m_hashAlgorithm, m_cipherAlgorithm, m_count);
+		printf("$gpg$*%d*%"PRId64"*%s*%d*%d*%d*%d*%d*", m_algorithm, (int64_t)totlen, hash, m_spec, m_usage, m_hashAlgorithm, m_cipherAlgorithm, m_count);
 		cp = hash;
 		cp += print_hex(m_salt, 8, cp);
 		printf("%s\n", hash);

--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -257,7 +257,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 
 	/* we inline the content with the hash */
 	fprintf(stderr, "Inlining %s\n", encryptedDatabase);
-	printf("*1*%"PRIu64"*", datasize);
+	printf("*1*%"PRId64"*", datasize);
 	fseek(fp, 124, SEEK_SET);
 	if (fread(buffer, datasize, 1, fp) != 1) {
 		warn("%s: Error: read failed: %s.",

--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -166,14 +166,14 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 	uint32_t num_entries;
 	uint32_t key_transf_rounds;
 	unsigned char *buffer;
-	long long filesize = 0;
-	long long datasize;
+	int64_t filesize = 0;
+	int64_t datasize;
 	int algorithm = -1;
 	char *dbname;
 	FILE *kfp = NULL;
 
 	/* specific to keyfile handling */
-	long long filesize_keyfile = 0;
+	int64_t filesize_keyfile = 0;
 	SHA256_CTX ctx;
 	unsigned char hash[32];
 	int counter;
@@ -231,11 +231,11 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 			fprintf(stderr, "! %s : %s\n", keyfile, strerror(errno));
 			return;
 		}
-		filesize_keyfile = (long long)get_file_size(keyfile);
+		filesize_keyfile = (int64_t)get_file_size(keyfile);
 	}
 
 	dbname = strip_suffixes(basename(encryptedDatabase), extension, 1);
-	filesize = (long long)get_file_size(encryptedDatabase);
+	filesize = (int64_t)get_file_size(encryptedDatabase);
 	datasize = filesize - 124;
 	if (datasize < 0) {
 		warn("%s: Error in validating datasize.", encryptedDatabase);
@@ -324,7 +324,7 @@ static void process_database(char* encryptedDatabase)
 
 	/* specific to keyfile handling */
 	unsigned char *buffer;
-	long long filesize_keyfile = 0;
+	int64_t filesize_keyfile = 0;
 	char *p;
 	char *data;
 	char b64_decoded[64];
@@ -497,7 +497,7 @@ static void process_database(char* encryptedDatabase)
 			fprintf(stderr, "! %s : %s\n", keyfile, strerror(errno));
 			return;
 		}
-		filesize_keyfile = (long long)get_file_size(keyfile);
+		filesize_keyfile = (int64_t)get_file_size(keyfile);
 	}
 
 	dbname = strip_suffixes(basename(encryptedDatabase),extension, 1);

--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -257,7 +257,7 @@ static void process_old_database(FILE *fp, char* encryptedDatabase)
 
 	/* we inline the content with the hash */
 	fprintf(stderr, "Inlining %s\n", encryptedDatabase);
-	printf("*1*"LLd"*", datasize);
+	printf("*1*%"PRIu64"*", datasize);
 	fseek(fp, 124, SEEK_SET);
 	if (fread(buffer, datasize, 1, fp) != 1) {
 		warn("%s: Error: read failed: %s.",

--- a/src/mask.c
+++ b/src/mask.c
@@ -44,7 +44,7 @@ static mask_cpu_context cpu_mask_ctx, rec_ctx;
 static int *template_key_offsets;
 static char *mask = NULL, *template_key;
 static int max_keylen, fmt_maxlen, rec_len, restored_len, restored;
-static unsigned long long rec_cl, cand_length;
+static uint64_t rec_cl, cand_length;
 static struct fmt_main *mask_fmt;
 static int mask_bench_index;
 static int parent_fix_state_pending;
@@ -60,10 +60,10 @@ static int mask_has_8bit;
  * cand and rec_cand is the number of remaining candidates.
  * So, its value decreases as cracking progress.
  */
-static unsigned long long cand, rec_cand;
+static uint64_t cand, rec_cand;
 
-unsigned long long mask_tot_cand;
-unsigned long long mask_parent_keys;
+uint64_t mask_tot_cand;
+uint64_t mask_parent_keys;
 
 #define BUILT_IN_CHARSET "ludsaLUDSAbhBH123456789"
 
@@ -1537,7 +1537,7 @@ static MAYBE_INLINE char* mask_cp_to_utf8(char *in)
 		ranges(ps).chars[ranges(ps).iter];
 
 static int generate_keys(mask_cpu_context *cpu_mask_ctx,
-			  unsigned long long *my_candidates)
+			  uint64_t *my_candidates)
 {
 	char key_e[PLAINTEXT_BUFFER_SIZE];
 	char *key;
@@ -1619,7 +1619,7 @@ done:
 }
 
 static int bench_generate_keys(mask_cpu_context *cpu_mask_ctx,
-                               unsigned long long *my_candidates)
+                               uint64_t *my_candidates)
 {
 	int ps1 = MAX_NUM_MASK_PLHDR, ps2 = MAX_NUM_MASK_PLHDR,
 	    ps3 = MAX_NUM_MASK_PLHDR, ps4 = MAX_NUM_MASK_PLHDR, ps ;
@@ -1744,9 +1744,9 @@ static void skip_position(mask_cpu_context *cpu_mask_ctx, int *arr)
 		}
 }
 
-static unsigned long long divide_work(mask_cpu_context *cpu_mask_ctx)
+static uint64_t divide_work(mask_cpu_context *cpu_mask_ctx)
 {
-	unsigned long long offset, my_candidates, total_candidates, ctr;
+	uint64_t offset, my_candidates, total_candidates, ctr;
 	int ps;
 	double fract;
 
@@ -1796,7 +1796,7 @@ static unsigned long long divide_work(mask_cpu_context *cpu_mask_ctx)
  */
 static double get_progress(void)
 {
-	unsigned long long total = mask_tot_cand;
+	uint64_t total = mask_tot_cand;
 
 	emms();
 
@@ -1833,7 +1833,7 @@ int mask_restore_state(FILE *file)
 {
 	int i, d;
 	unsigned cu;
-	unsigned long long ull;
+	uint64_t ull;
 	int fail = !(options.flags & FLG_MASK_STACKED);
 
 	if (fscanf(file, "%"PRIu64"\n", &ull) == 1)

--- a/src/mask.c
+++ b/src/mask.c
@@ -1818,12 +1818,12 @@ void mask_save_state(FILE *file)
 {
 	int i;
 
-	fprintf(file, ""LLu"\n", rec_cand + 1);
+	fprintf(file, "%"PRIu64"\n", rec_cand + 1);
 	fprintf(file, "%d\n", rec_ctx.count);
 	fprintf(file, "%d\n", rec_ctx.offset);
 	if (!(options.flags & FLG_MASK_STACKED) && options.req_minlength >= 0) {
 		fprintf(file, "%d\n", rec_len);
-		fprintf(file, ""LLu"\n", cand_length + 1);
+		fprintf(file, "%"PRIu64"\n", cand_length + 1);
 	}
 	for (i = 0; i < rec_ctx.count; i++)
 		fprintf(file, "%u\n", (unsigned)rec_ctx.ranges[i].iter);
@@ -1836,7 +1836,7 @@ int mask_restore_state(FILE *file)
 	unsigned long long ull;
 	int fail = !(options.flags & FLG_MASK_STACKED);
 
-	if (fscanf(file, LLu"\n", &ull) == 1)
+	if (fscanf(file, "%"PRIu64"\n", &ull) == 1)
 		cand = ull;
 	else
 		return fail;
@@ -1856,7 +1856,7 @@ int mask_restore_state(FILE *file)
 			restored_len = d;
 		else
 			return fail;
-		if (fscanf(file, LLu"\n", &ull) == 1)
+		if (fscanf(file, "%"PRIu64"\n", &ull) == 1)
 			rec_cl = ull;
 		else
 			return fail;

--- a/src/mask.h
+++ b/src/mask.h
@@ -107,7 +107,7 @@ extern int mask_restore_state(FILE *file);
  * length.  The number includes the part that is processed on GPU, and is
  * used as a multiplier in native mask mode's and parent modes' get_progress().
  */
-extern unsigned long long mask_tot_cand;
+extern uint64_t mask_tot_cand;
 
 /* Hybrid mask's contribution to key length. Eg. for bc?l?d?w this will be 4. */
 extern int mask_add_len;
@@ -116,7 +116,7 @@ extern int mask_add_len;
 extern int mask_num_qw;
 
 /* Number of times parent mode called hybrid mask. */
-extern unsigned long long mask_parent_keys;
+extern uint64_t mask_parent_keys;
 
 /* Current length when pure mask mode iterates over lengths */
 extern int mask_cur_len;

--- a/src/mkv.c
+++ b/src/mkv.c
@@ -35,7 +35,7 @@
 
 extern struct fmt_main fmt_LM;
 
-static long long tidx, hybrid_tidx;
+static int64_t tidx, hybrid_tidx;
 #if HAVE_REXGEN
 static char *regex_alpha;
 static int regex_case;
@@ -71,7 +71,7 @@ void mkv_hybrid_fix_state(void)
 
 static int show_pwd_rnbs(struct db_main *db, struct s_pwd *pwd)
 {
-	unsigned long long i;
+	uint64_t i;
 	unsigned int k;
 	unsigned long lvl;
 	char pass_filtered[PLAINTEXT_BUFFER_SIZE];
@@ -132,7 +132,7 @@ static int show_pwd_rnbs(struct db_main *db, struct s_pwd *pwd)
 
 static int show_pwd_r(struct db_main *db, struct s_pwd *pwd, unsigned int bs)
 {
-	unsigned long long i;
+	uint64_t i;
 	unsigned int k;
 	unsigned long lvl;
 	unsigned char curchar;
@@ -236,7 +236,7 @@ static int show_pwd_r(struct db_main *db, struct s_pwd *pwd, unsigned int bs)
 	return 0;
 }
 
-static int show_pwd(struct db_main *db, unsigned long long start)
+static int show_pwd(struct db_main *db, uint64_t start)
 {
 	struct s_pwd pwd;
 	unsigned int i;
@@ -326,7 +326,7 @@ static int show_pwd(struct db_main *db, unsigned long long start)
 
 static double get_progress(void)
 {
-	unsigned long long mask_mult = mask_tot_cand ? mask_tot_cand : 1;
+	uint64_t mask_mult = mask_tot_cand ? mask_tot_cand : 1;
 
 	emms();
 
@@ -556,8 +556,8 @@ void get_markov_options(struct db_main *db,
 }
 
 void get_markov_start_end(char *start_token, char *end_token,
-                          unsigned long long mkv_max,
-                          unsigned long long *mkv_start, unsigned long long *mkv_end)
+                          uint64_t mkv_max,
+                          uint64_t *mkv_start, uint64_t *mkv_end)
 {
 	*mkv_start = 0;
 	*mkv_end = 0;
@@ -651,7 +651,7 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 	char *end_token = NULL;
 	char *param = NULL;
 	unsigned int mkv_minlevel, mkv_level, mkv_maxlen, mkv_minlen;
-	unsigned long long mkv_start, mkv_end;
+	uint64_t mkv_start, mkv_end;
 
 	if (mkv_param != NULL) {
 		param = str_alloc_copy(mkv_param);
@@ -688,10 +688,10 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 	gmin_len = mkv_minlen;
 
 	nbparts =
-	    mem_alloc(256 * (mkv_level + 1) * sizeof(long long) * (mkv_maxlen +
+	    mem_alloc(256 * (mkv_level + 1) * sizeof(int64_t) * (mkv_maxlen +
 	              1));
 	memset(nbparts, 0,
-	       256 * (mkv_level + 1) * (mkv_maxlen + 1) * sizeof(long long));
+	       256 * (mkv_level + 1) * (mkv_maxlen + 1) * sizeof(int64_t));
 
 	nb_parts(0, 0, 0, mkv_level, mkv_maxlen);
 
@@ -710,7 +710,7 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 	}
 
 	if (options.node_count > 1) {
-		unsigned long long mkv_size;
+		uint64_t mkv_size;
 
 		mkv_size = mkv_end - mkv_start + 1;
 		if (options.node_max != options.node_count)

--- a/src/mkv.c
+++ b/src/mkv.c
@@ -562,8 +562,8 @@ void get_markov_start_end(char *start_token, char *end_token,
 	*mkv_start = 0;
 	*mkv_end = 0;
 
-	if ((start_token != NULL) && (sscanf(start_token, "%"PRId64, mkv_start) == 1)) {
-		if ((end_token != NULL) && (sscanf(end_token, "%"PRId64, mkv_end) == 1)) {
+	if ((start_token != NULL) && (sscanf(start_token, "%"PRIu64, mkv_start) == 1)) {
+		if ((end_token != NULL) && (sscanf(end_token, "%"PRIu64, mkv_end) == 1)) {
 		}
 		/* NOTE, end_token can be an empty string. Treat "" and mkv_max as equal */
 		else if (end_token != NULL && *end_token) {
@@ -705,7 +705,7 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 		fprintf(stderr, "%d len=", mkv_level);
 		if (mkv_minlen > 0)
 			fprintf(stderr, "%d-", mkv_minlen);
-		fprintf(stderr, "%d pwd=%" PRId64 "%s)\n", mkv_maxlen, mkv_end - mkv_start,
+		fprintf(stderr, "%d pwd=%" PRIu64 "%s)\n", mkv_maxlen, mkv_end - mkv_start,
 		        options.node_count > 1 ? " split over nodes" : "");
 	}
 
@@ -731,7 +731,7 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 	log_event("- Statsfile: %s", statfile);
 	log_event("- Markov level: %d - %d", mkv_minlevel, mkv_level);
 	log_event("- Length: %d - %d", mkv_minlen, mkv_maxlen);
-	log_event("- Start-End: %" PRId64 " - %" PRId64, mkv_start, mkv_end);
+	log_event("- Start-End: %" PRIu64 " - %" PRIu64, mkv_start, mkv_end);
 
 	show_pwd(db, mkv_start);
 

--- a/src/mkv.c
+++ b/src/mkv.c
@@ -44,12 +44,12 @@ static char *regex;
 
 static void save_state(FILE *file)
 {
-	fprintf(file, LLd "\n", tidx);
+	fprintf(file, "%"PRId64 "\n", tidx);
 }
 
 static int restore_state(FILE *file)
 {
-	if (fscanf(file, LLd "\n", &gidx) != 1)
+	if (fscanf(file, "%"PRId64 "\n", &gidx) != 1)
 		return 1;
 
 	return 0;
@@ -562,8 +562,8 @@ void get_markov_start_end(char *start_token, char *end_token,
 	*mkv_start = 0;
 	*mkv_end = 0;
 
-	if ((start_token != NULL) && (sscanf(start_token, LLd, mkv_start) == 1)) {
-		if ((end_token != NULL) && (sscanf(end_token, LLd, mkv_end) == 1)) {
+	if ((start_token != NULL) && (sscanf(start_token, "%"PRId64, mkv_start) == 1)) {
+		if ((end_token != NULL) && (sscanf(end_token, "%"PRId64, mkv_end) == 1)) {
 		}
 		/* NOTE, end_token can be an empty string. Treat "" and mkv_max as equal */
 		else if (end_token != NULL && *end_token) {
@@ -578,7 +578,7 @@ void get_markov_start_end(char *start_token, char *end_token,
 	 * If that changes, I'll need
 	 * start_token = cfg_get_param(SECTION_MARKOV, mode, "MkvStart")
 	 * and
-	 * sscanf(start_token, LLd, start)
+	 * sscanf(start_token, "%"PRId64, start)
 	 * because the values could be too large for integers
 	 */
 	/* NOTE, start_token can be an empty string. Treat "" and "0" equal */
@@ -598,10 +598,10 @@ void get_markov_start_end(char *start_token, char *end_token,
 			exit(1);
 		} else if (*mkv_start > 0) {
 			*mkv_start *= mkv_max / 100;
-			log_event("- Start: %s converted to " LLd, start_token,
+			log_event("- Start: %s converted to %" PRId64, start_token,
 			          *mkv_start);
 			if (john_main_process)
-				fprintf(stderr, "Start: %s converted to " LLd
+				fprintf(stderr, "Start: %s converted to %" PRId64
 				        "\n", start_token, *mkv_start);
 		}
 	}
@@ -616,9 +616,9 @@ void get_markov_start_end(char *start_token, char *end_token,
 			*mkv_end = 0;
 		} else if (*mkv_end > 0) {
 			*mkv_end *= mkv_max / 100;
-			log_event("- End: %s converted to " LLd "", end_token, *mkv_end);
+			log_event("- End: %s converted to %" PRId64 "", end_token, *mkv_end);
 			if (john_main_process)
-				fprintf(stderr, "End: %s converted to " LLd
+				fprintf(stderr, "End: %s converted to %" PRId64
 				        "\n", end_token, *mkv_end);
 		}
 	}
@@ -626,19 +626,19 @@ void get_markov_start_end(char *start_token, char *end_token,
 		*mkv_end = mkv_max;
 
 	if (*mkv_end > mkv_max) {
-		log_event("! End = " LLd " is too large (max=" LLd ")", *mkv_end,
+		log_event("! End = %" PRId64 " is too large (max=%" PRId64 ")", *mkv_end,
 		          mkv_max);
 		if (john_main_process)
-			fprintf(stderr, "Warning: End = " LLd " is too large "
-			        "(max = " LLd ")\n", *mkv_end, mkv_max);
+			fprintf(stderr, "Warning: End = %" PRId64 " is too large "
+			        "(max = %" PRId64 ")\n", *mkv_end, mkv_max);
 		*mkv_end = mkv_max;
 	}
 
 	if (*mkv_start > *mkv_end) {
-		log_event("! MKV start > end (" LLd " > " LLd ")", *mkv_start,
+		log_event("! MKV start > end (%" PRId64 " > %" PRId64 ")", *mkv_start,
 		          *mkv_end);
 		if (john_main_process)
-			fprintf(stderr, "Error: MKV start > end (" LLd " > " LLd
+			fprintf(stderr, "Error: MKV start > end (%" PRId64 " > %" PRId64
 			        ")\n", *mkv_start, *mkv_end);
 		error();
 	}
@@ -705,7 +705,7 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 		fprintf(stderr, "%d len=", mkv_level);
 		if (mkv_minlen > 0)
 			fprintf(stderr, "%d-", mkv_minlen);
-		fprintf(stderr, "%d pwd=" LLd "%s)\n", mkv_maxlen, mkv_end - mkv_start,
+		fprintf(stderr, "%d pwd=%" PRId64 "%s)\n", mkv_maxlen, mkv_end - mkv_start,
 		        options.node_count > 1 ? " split over nodes" : "");
 	}
 
@@ -731,7 +731,7 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 	log_event("- Statsfile: %s", statfile);
 	log_event("- Markov level: %d - %d", mkv_minlevel, mkv_level);
 	log_event("- Length: %d - %d", mkv_minlen, mkv_maxlen);
-	log_event("- Start-End: " LLd " - " LLd, mkv_start, mkv_end);
+	log_event("- Start-End: %" PRId64 " - %" PRId64, mkv_start, mkv_end);
 
 	show_pwd(db, mkv_start);
 

--- a/src/mkvcalcproba.c
+++ b/src/mkvcalcproba.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 	unsigned int j;
 	unsigned int k;
 	unsigned int l;
-	unsigned long long index;
+	uint64_t index;
 	unsigned char position[256];
 	unsigned int charset;
 	unsigned int nb_lignes;
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
 			i++;
 		}
 		if (index < 8E18)
-			printf("\t%d\t%d\t" LLd "\t%d\n", k, i, index, l);
+			printf("\t%d\t%d\t%" PRIu64 "\t%d\n", k, i, index, l);
 		else
 			printf("\t%d\t%d\t-\t%d\n", k, i, l);
 	}

--- a/src/mkvlib.c
+++ b/src/mkvlib.c
@@ -16,7 +16,7 @@
 
 unsigned char *proba1;
 unsigned char *proba2;
-unsigned long long *nbparts;
+uint64_t *nbparts;
 unsigned char *first;
 unsigned char charsorted[256 * 256];
 
@@ -24,15 +24,15 @@ unsigned int gmax_level;
 unsigned int gmax_len;
 unsigned int gmin_level;
 unsigned int gmin_len;
-unsigned long long gidx;
-unsigned long long gstart;
-unsigned long long gend;
+uint64_t gidx;
+uint64_t gstart;
+uint64_t gend;
 
-unsigned long long nb_parts(unsigned char lettre, unsigned int len,
+uint64_t nb_parts(unsigned char lettre, unsigned int len,
                             unsigned int level, unsigned int max_lvl, unsigned int max_len)
 {
 	int i;
-	unsigned long long out = 1;
+	uint64_t out = 1;
 
 	if (level > max_lvl)
 		return 0;
@@ -57,7 +57,7 @@ unsigned long long nb_parts(unsigned char lettre, unsigned int len,
 	return out;
 }
 
-void print_pwd(unsigned long long index, struct s_pwd *pwd,
+void print_pwd(uint64_t index, struct s_pwd *pwd,
                unsigned int max_lvl, unsigned int max_len)
 {
 	unsigned int len = 1;

--- a/src/mkvlib.h
+++ b/src/mkvlib.h
@@ -6,6 +6,8 @@
 #ifndef _JOHN_MKVLIB_H
 #define _JOHN_MKVLIB_H
 
+#include <stdint.h>
+
 #define UNK_STR 255
 
 struct s_pwd {
@@ -17,7 +19,7 @@ struct s_pwd {
 
 extern unsigned char *proba1;
 extern unsigned char *proba2;
-extern unsigned long long *nbparts;
+extern uint64_t *nbparts;
 extern unsigned char *first;
 extern unsigned char charsorted[256 * 256];
 
@@ -25,13 +27,13 @@ extern unsigned int gmax_level;
 extern unsigned int gmax_len;
 extern unsigned int gmin_level;
 extern unsigned int gmin_len;
-extern unsigned long long gidx;
-extern unsigned long long gstart;
-extern unsigned long long gend;
+extern uint64_t gidx;
+extern uint64_t gstart;
+extern uint64_t gend;
 
-void print_pwd(unsigned long long index, struct s_pwd *pwd,
+void print_pwd(uint64_t index, struct s_pwd *pwd,
                unsigned int max_lvl, unsigned int max_len);
-unsigned long long nb_parts(unsigned char lettre, unsigned int len,
+uint64_t nb_parts(unsigned char lettre, unsigned int len,
                             unsigned int level, unsigned int max_lvl, unsigned int max_len);
 void init_probatables(char *filename);
 #endif

--- a/src/rar2john.c
+++ b/src/rar2john.c
@@ -350,7 +350,7 @@ next_file_header:
 
 		if (verbose) {
 			fprintf(stderr,
-			        "! HEAD_SIZE: %d, PACK_SIZE: "LLu", UNP_SIZE: "LLu"\n",
+			        "! HEAD_SIZE: %d, PACK_SIZE: %"PRIu64", UNP_SIZE: %"PRIu64"\n",
 			        file_header_head_size,
 			        (unsigned long long)file_header_pack_size,
 			        (unsigned long long)file_header_unp_size);
@@ -553,7 +553,7 @@ next_file_header:
 			//fprintf(stderr, "! file_header_flags is 0x%04x\n", file_header_head_flags);
 		}
 
-		best_len += sprintf(&best[best_len], "*"LLu"*"LLu"*",
+		best_len += sprintf(&best[best_len], "*%"PRIu64"*%"PRIu64"*",
 		        (unsigned long long)file_header_pack_size,
 		        (unsigned long long)file_header_unp_size);
 

--- a/src/rar2john.c
+++ b/src/rar2john.c
@@ -352,8 +352,8 @@ next_file_header:
 			fprintf(stderr,
 			        "! HEAD_SIZE: %d, PACK_SIZE: %"PRIu64", UNP_SIZE: %"PRIu64"\n",
 			        file_header_head_size,
-			        (unsigned long long)file_header_pack_size,
-			        (unsigned long long)file_header_unp_size);
+			        (uint64_t)file_header_pack_size,
+			        (uint64_t)file_header_unp_size);
 			fprintf(stderr, "! file_header_block:\n!  ");
 			for (i = 0; i < 32; ++i)
 				fprintf(stderr, " %02x", file_header_block[i]);
@@ -554,8 +554,8 @@ next_file_header:
 		}
 
 		best_len += sprintf(&best[best_len], "*%"PRIu64"*%"PRIu64"*",
-		        (unsigned long long)file_header_pack_size,
-		        (unsigned long long)file_header_unp_size);
+		        (uint64_t)file_header_pack_size,
+		        (uint64_t)file_header_unp_size);
 
 		/* We always store it inline */
 

--- a/src/rar_common.c
+++ b/src/rar_common.c
@@ -244,7 +244,7 @@ static void *get_salt(char *ciphertext)
 			jtr_fseek64(fp, pos, SEEK_SET);
 			count = fread(psalt->raw_data, 1, psalt->pack_size, fp);
 			if (count != psalt->pack_size) {
-				fprintf(stderr, "Error loading file from archive '%s', expected "LLu" bytes, got "Zu". Archive possibly damaged.\n", archive_name, psalt->pack_size, count);
+				fprintf(stderr, "Error loading file from archive '%s', expected %"PRIu64" bytes, got "Zu". Archive possibly damaged.\n", archive_name, psalt->pack_size, count);
 				error();
 			}
 			psalt->blob = psalt->raw_data;

--- a/src/rar_fmt_plug.c
+++ b/src/rar_fmt_plug.c
@@ -54,7 +54,7 @@ john_register_one(&fmt_rar);
 #endif
 #if _MSC_VER || __MINGW32__ || __MINGW64__ || __CYGWIN__ || HAVE_WINDOWS_H
 #include "win32_memmap.h"
-#if !defined(__CYGWIN__) && !defined(__MINGW64__)
+#if !defined(__CYGWIN__) && !defined(__MINGW64__) && !defined(__MINGW32__)
 #include "mmap-windows.c"
 #elif defined HAVE_MMAP
 #include <sys/mman.h>

--- a/src/unique.c
+++ b/src/unique.c
@@ -65,7 +65,7 @@ static FILE *output;
 static FILE *use_to_unique_but_not_add;
 static int do_not_unique_against_self=0;
 
-int64_t totLines=0,written_lines=0;
+uint64_t totLines=0, written_lines=0;
 int verbose=0, cut_len=0, LM=0;
 unsigned int vUNIQUE_HASH_LOG=UNIQUE_HASH_LOG, vUNIQUE_HASH_SIZE=UNIQUE_HASH_SIZE, vUNIQUE_BUFFER_SIZE=UNIQUE_BUFFER_SIZE;
 unsigned int vUNIQUE_HASH_MASK = UNIQUE_HASH_SIZE - 1;

--- a/src/unique.c
+++ b/src/unique.c
@@ -356,7 +356,7 @@ static void unique_run(void)
 		write_buffer();
 
 		if (verbose)
-			printf("\rTotal lines read "LLu" Unique lines written "LLu"\r", totLines, written_lines);
+			printf("\rTotal lines read %"PRIu64" Unique lines written %"PRIu64"\r", totLines, written_lines);
 	}
 }
 
@@ -473,7 +473,7 @@ int unique(int argc, char **argv)
 	unique_init(argv[1]);
 	unique_run();
 	unique_done();
-    printf("Total lines read "LLu" Unique lines written "LLu"\n", totLines, written_lines);
+    printf("Total lines read %"PRIu64" Unique lines written %"PRIu64"\n", totLines, written_lines);
 
 	return 0;
 }

--- a/src/unique.c
+++ b/src/unique.c
@@ -65,7 +65,7 @@ static FILE *output;
 static FILE *use_to_unique_but_not_add;
 static int do_not_unique_against_self=0;
 
-long long totLines=0,written_lines=0;
+int64_t totLines=0,written_lines=0;
 int verbose=0, cut_len=0, LM=0;
 unsigned int vUNIQUE_HASH_LOG=UNIQUE_HASH_LOG, vUNIQUE_HASH_SIZE=UNIQUE_HASH_SIZE, vUNIQUE_BUFFER_SIZE=UNIQUE_BUFFER_SIZE;
 unsigned int vUNIQUE_HASH_MASK = UNIQUE_HASH_SIZE - 1;

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -121,7 +121,7 @@ extern int rpp_real_run; /* set to 1 when we really get into wordlist mode */
 static void save_state(FILE *file)
 {
 	fprintf(file, "%d\n%" PRId64 "\n%" PRId64 "\n",
-	        rec_rule, (long long)rec_pos, (long long)rec_line);
+	        rec_rule, (int64_t)rec_pos, (int64_t)rec_line);
 }
 
 static int restore_rule_number(void)
@@ -180,8 +180,8 @@ static MAYBE_INLINE char *mgetl(char *res)
 
 #elif ARCH_SIZE >= 8 && ARCH_ALLOWS_UNALIGNED /* Eight chars at a time */
 
-	unsigned long long *ss = (unsigned long long*)map_pos;
-	unsigned long long *dd = (unsigned long long*)pos;
+	uint64_t *ss = (uint64_t*)map_pos;
+	uint64_t *dd = (uint64_t*)pos;
 	unsigned int *s = (unsigned int*)map_pos;
 	unsigned int *d = (unsigned int*)pos;
 
@@ -283,7 +283,7 @@ static void restore_line_number(void)
 
 static int restore_state(FILE *file)
 {
-	long long rule, line, pos;
+	int64_t rule, line, pos;
 
 	if (fscanf(file, "%"PRId64"\n%"PRId64"\n", &rule, &pos) != 2)
 		return 1;
@@ -390,7 +390,7 @@ static double get_progress(void)
 	struct stat file_stat;
 	int64_t pos;
 	uint64_t size;
-	unsigned long long mask_mult = mask_tot_cand ? mask_tot_cand : 1;
+	uint64_t mask_mult = mask_tot_cand ? mask_tot_cand : 1;
 
 	emms();
 
@@ -692,7 +692,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 		if (cfg_get_bool(SECTION_OPTIONS, NULL, "WordlistMemoryMap", 1))
 		{
 			log_event("- memory mapping wordlist (%"PRId64" bytes)",
-			          (long long)file_len);
+			          (int64_t)file_len);
 #if (SIZEOF_SIZE_T < 8)
 /*
  * Now even though we are 64 bit file size, we must still deal with some
@@ -803,7 +803,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 				          "wordfile %s into memory "
 				          "(%lu bytes of %"PRId64", max_size="Zu
 				          " avg/node)", name, my_size,
-				          (long long)file_len,
+				          (int64_t)file_len,
 				          options.max_wordfile_memory);
 				if (john_main_process)
 				fprintf(stderr,"Each node loaded 1/%d "
@@ -818,7 +818,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 			else {
 				log_event("- loading wordfile %s into memory "
 				          "(%"PRId64" bytes, max_size="Zu")",
-				          name, (long long)file_len,
+				          name, (int64_t)file_len,
 				          options.max_wordfile_memory);
 				if (options.node_count > 1 && john_main_process)
 				fprintf(stderr,"Each node loaded the whole "
@@ -859,8 +859,8 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 			words = mem_alloc((nWordFileLines + 1) * sizeof(char*));
 			log_event("- wordfile had %"PRId64" lines and required %"PRId64
 			          " bytes for index.",
-			          (long long)nWordFileLines,
-			          (long long)(nWordFileLines * sizeof(char*)));
+			          (int64_t)nWordFileLines,
+			          (int64_t)(nWordFileLines * sizeof(char*)));
 
 			i = 0;
 			cp = word_file_str;
@@ -879,7 +879,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 					"temporarily allocating %"PRId64" bytes",
 					hash_size,
 					(hash_size * sizeof(unsigned int)) +
-					((long long)nWordFileLines *
+					((int64_t)nWordFileLines *
 					 sizeof(element_st)));
 				buffer.hash = mem_alloc(hash_size *
 				                        sizeof(unsigned int));
@@ -942,10 +942,10 @@ skip:
 				if (ec == '\r' && *cp == '\n') cp++;
 				if (ec == '\n' && *cp == '\r') cp++;
 			} while (cp < aep);
-			if ((long long)nWordFileLines - i > 0)
+			if ((int64_t)nWordFileLines - i > 0)
 				log_event("- suppressed %"PRId64" duplicate lines "
 				          "and/or comments from wordlist.",
-				          (long long)nWordFileLines - i);
+				          (int64_t)nWordFileLines - i);
 			MEM_FREE(buffer.hash);
 			MEM_FREE(buffer.data);
 			nWordFileLines = i;
@@ -1051,7 +1051,7 @@ GRAB_NEXT_PIPE_LOAD:
 				if (options.verbosity == VERB_MAX) {
 					sprintf(msg_buf, "- Read block of %"PRId64" "
 					        "candidate passwords from pipe",
-					        (long long)nWordFileLines);
+					        (int64_t)nWordFileLines);
 					log_event("%s", msg_buf);
 				}
 			}

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -48,7 +48,7 @@
 #if _MSC_VER || __MINGW32__ || __MINGW64__ || __CYGWIN__ || HAVE_WINDOWS_H
 #include "win32_memmap.h"
 #undef MEM_FREE
-#if !defined(__CYGWIN__) && !defined(__MINGW64__)
+#if !defined(__CYGWIN__) && !defined(__MINGW64__) && !defined(__MINGW32__)
 #include "mmap-windows.c"
 #endif /* __CYGWIN */
 #endif /* _MSC_VER ... */
@@ -120,7 +120,7 @@ extern int rpp_real_run; /* set to 1 when we really get into wordlist mode */
 
 static void save_state(FILE *file)
 {
-	fprintf(file, "%d\n" LLd "\n" LLd "\n",
+	fprintf(file, "%d\n%" PRId64 "\n%" PRId64 "\n",
 	        rec_rule, (long long)rec_pos, (long long)rec_line);
 }
 
@@ -285,13 +285,13 @@ static int restore_state(FILE *file)
 {
 	long long rule, line, pos;
 
-	if (fscanf(file, LLd"\n"LLd"\n", &rule, &pos) != 2)
+	if (fscanf(file, "%"PRId64"\n%"PRId64"\n", &rule, &pos) != 2)
 		return 1;
 	rec_rule = rule;
 	rec_pos = pos;
 	rec_line = 0;
 	if (rec_version >= 4) {
-		if (fscanf(file, LLd"\n", &line) != 1)
+		if (fscanf(file, "%"PRId64"\n", &line) != 1)
 			return 1;
 		rec_line = line;
 	}
@@ -426,7 +426,7 @@ static double get_progress(void)
 		}
 	}
 #if 0
-	fprintf(stderr, "rule %d/%d mask "LLu" pos %"PRId64"/%"PRIu64"\n",
+	fprintf(stderr, "rule %d/%d mask %"PRIu64" pos %"PRId64"/%"PRIu64"\n",
 	        rule_number, rule_count, mask_mult, pos, size);
 #endif
 	return (100.0 * ((rule_number * size * mask_mult) + pos * mask_mult) /
@@ -691,7 +691,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 #ifdef HAVE_MMAP
 		if (cfg_get_bool(SECTION_OPTIONS, NULL, "WordlistMemoryMap", 1))
 		{
-			log_event("- memory mapping wordlist ("LLd" bytes)",
+			log_event("- memory mapping wordlist (%"PRId64" bytes)",
 			          (long long)file_len);
 #if (SIZEOF_SIZE_T < 8)
 /*
@@ -801,7 +801,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 				        " we read it\n");
 				log_event("- loaded this node's share of "
 				          "wordfile %s into memory "
-				          "(%lu bytes of "LLd", max_size="Zu
+				          "(%lu bytes of %"PRId64", max_size="Zu
 				          " avg/node)", name, my_size,
 				          (long long)file_len,
 				          options.max_wordfile_memory);
@@ -817,7 +817,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 			}
 			else {
 				log_event("- loading wordfile %s into memory "
-				          "("LLd" bytes, max_size="Zu")",
+				          "(%"PRId64" bytes, max_size="Zu")",
 				          name, (long long)file_len,
 				          options.max_wordfile_memory);
 				if (options.node_count > 1 && john_main_process)
@@ -857,7 +857,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 			if (aep[-1] != csearch)
 				++nWordFileLines;
 			words = mem_alloc((nWordFileLines + 1) * sizeof(char*));
-			log_event("- wordfile had "LLd" lines and required "LLd
+			log_event("- wordfile had %"PRId64" lines and required %"PRId64
 			          " bytes for index.",
 			          (long long)nWordFileLines,
 			          (long long)(nWordFileLines * sizeof(char*)));
@@ -876,7 +876,7 @@ void do_wordlist_crack(struct db_main *db, char *name, int rules)
 				hash_size = (1 << hash_log);
 				hash_mask = (hash_size - 1);
 				log_event("- dupe suppression: hash size %u, "
-					"temporarily allocating "LLd" bytes",
+					"temporarily allocating %"PRId64" bytes",
 					hash_size,
 					(hash_size * sizeof(unsigned int)) +
 					((long long)nWordFileLines *
@@ -943,7 +943,7 @@ skip:
 				if (ec == '\n' && *cp == '\r') cp++;
 			} while (cp < aep);
 			if ((long long)nWordFileLines - i > 0)
-				log_event("- suppressed "LLd" duplicate lines "
+				log_event("- suppressed %"PRId64" duplicate lines "
 				          "and/or comments from wordlist.",
 				          (long long)nWordFileLines - i);
 			MEM_FREE(buffer.hash);
@@ -1049,7 +1049,7 @@ GRAB_NEXT_PIPE_LOAD:
 					}
 				}
 				if (options.verbosity == VERB_MAX) {
-					sprintf(msg_buf, "- Read block of "LLd" "
+					sprintf(msg_buf, "- Read block of %"PRId64" "
 					        "candidate passwords from pipe",
 					        (long long)nWordFileLines);
 					log_event("%s", msg_buf);


### PR DESCRIPTION
This is related to https://github.com/magnumripper/JohnTheRipper/issues/2961.

We can probably drop some explicit typecasts too?

Update:

Probably not.