### PR TITLE
Fix salt alignment in phpass and ethereum formats

### DIFF
--- a/src/ethereum_common_plug.c
+++ b/src/ethereum_common_plug.c
@@ -118,7 +118,7 @@ void *ethereum_common_get_salt(char *ciphertext)
 	char *p;
 	static custom_salt *cur_salt;
 
-	cur_salt = mem_calloc_tiny(sizeof(custom_salt), MEM_ALIGN_WORD);
+	cur_salt = mem_calloc_tiny(sizeof(custom_salt), MEM_ALIGN_SIMD); // 64-bit alignment is required
 
 	ctcopy += TAG_LENGTH;
 	p = strtokm(ctcopy, "*");

--- a/src/phpassMD5_fmt_plug.c
+++ b/src/phpassMD5_fmt_plug.c
@@ -308,13 +308,14 @@ static int crypt_all(int *pcount, struct db_salt *salt) {
 	return count;
 }
 
-static void * salt(char *ciphertext)
+static void *get_salt(char *ciphertext)
 {
 	static union {
 		unsigned char salt[SALT_SIZE+2];
-		uint32_t x;
+		uint64_t dummy;
 	} x;
 	unsigned char *salt = x.salt;
+
 	// store off the 'real' 8 bytes of salt
 	memcpy(salt, &ciphertext[4], 8);
 	// append the 1 byte of loop count information.
@@ -364,7 +365,7 @@ struct fmt_main fmt_phpassmd5 = {
 		phpass_common_valid,
 		phpass_common_split,
 		phpass_common_binary,
-		salt,
+		get_salt,
 		{
 			phpass_common_iteration_count,
 		},

--- a/src/phpass_common_plug.c
+++ b/src/phpass_common_plug.c
@@ -140,7 +140,6 @@ char *phpass_common_prepare(char *split_fields[10], struct fmt_main *self)
 	return phpass_common_split(split_fields[1], 0, self);
 }
 
-
 unsigned int phpass_common_iteration_count(void *salt)
 {
 	return 1U<<atoi64[(((unsigned char*)salt)[8])];


### PR DESCRIPTION
I am not sure about the `phpass` fix but it works fine (TM).