### PR TITLE
Small tweaks for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     env: ASAN=""
 
   - os: linux
-    compiler: gcc
+    compiler: clang
     env: ASAN="--enable-asan"
 
   - os: linux
@@ -40,7 +40,7 @@ matrix:
 
   allow_failures:
   - os: linux
-    compiler: gcc
+    compiler: clang
     env: ASAN="--enable-asan"
 
   fast_finish: true

--- a/.travis/check.sh
+++ b/.travis/check.sh
@@ -35,7 +35,7 @@ elif [[ -z "$TEST" || "$TEST" == "encoding" ]]; then
     fi
 
     # Configure and build
-    ./configure CPPFLAGS=-mno-avx2 $ASAN
+    ./configure $ASAN
     make -sj4
 
     ../.travis/test.sh "$TEST"
@@ -46,7 +46,7 @@ elif [[ "$TEST" == "fresh test" ]]; then
       cd /cwd/src; \
       apt-get update -qq; \
       apt-get install -y build-essential libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev libbz2-dev libomp-dev; \
-      ./configure CPPFLAGS=-mno-avx2 --enable-asan; \
+      ./configure --enable-asan; \
       make -sj4; \
       export OPENCL="""$OPENCL"""; \
       PROBLEM='slow' ../.travis/test.sh


### PR DESCRIPTION
* Probably due to its ancient version, gcc is much slower than clang for ASAN.
* No workaround is needed.