### PR TITLE
ppc64 and ppc32 ports.  With/without ALTIVEC code builds.  Some forma…

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -668,6 +668,7 @@ M_LIBS
 OPENSSL_LIBS
 OPENSSL_CFLAGS
 COMMONCRYPTO_LIBS
+SIMD_var
 EGREP
 PKG_CONFIG_LIBDIR
 PKG_CONFIG_PATH
@@ -8169,10 +8170,8 @@ _ACEOF
 # mips32.h (we override the BE defined within it)
 # mips64.h
 # pa-risc.h
-# ppc32.h
-# ppc32alt.h (-maltivec)
-# ppc64.h (-m64 -maltivec)
-# ppc64alt.h (-maltivec -faltivec)
+# ppc32.h  (with or without -maltivec)
+# ppc64.h (-m64 with or without -maltivec)
 # sparc32.h
 # sparc64.h (-m64 -mcpu=ultrasparc) (-xarch=native64)
 # vax.h
@@ -8895,8 +8894,610 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 	;;
-  powerpcle) ARCH_LINK=ppc32.h endian=little ;;
-  powerpc*) ARCH_LINK=ppc32.h endian=big ;;
+  powerpcle) ARCH_LINK=ppc32.h endian=little
+  	echo "checking special compiler flags... PPC32le"
+
+  echo "checking special compiler flags... PowerPC32"
+  CPU_BEST_FLAGS=""
+  INLINE_FLAGS=""	# taken from Makefile.legacy:  OPT_INLINE="-finline-functions -finline-limit=4000 -fno-strict-aliasing -maltivec"
+  ac_saved_cflags_ex="$CFLAGS_EX"
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -finline-functions" >&5
+$as_echo_n "checking if $CC supports -finline-functions... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -finline-functions"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -finline-functions"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -finline-functions" ; fi
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -finline-limit=4000" >&5
+$as_echo_n "checking if $CC supports -finline-limit=4000... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -finline-limit=4000"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -finline-limit=4000"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -finline-limit=4000" ; fi
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -fno-strict-aliasing" >&5
+$as_echo_n "checking if $CC supports -fno-strict-aliasing... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -fno-strict-aliasing"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -fno-strict-aliasing"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -fno-strict-aliasing" ; fi
+
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -maltivec" >&5
+$as_echo_n "checking if $CC supports -maltivec... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -maltivec"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -maltivec"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -maltivec" INLINE_FLAGS="$INLINE_FLAGS -maltivec" CPU_STR="ALTIVEC" ; fi
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -mvsx" >&5
+$as_echo_n "checking if $CC supports -mvsx... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -mvsx"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -mvsx"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -mvsx" ; fi
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -mpower8-vector" >&5
+$as_echo_n "checking if $CC supports -mpower8-vector... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -mpower8-vector"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -mpower8-vector"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -mpower8-vector" ; fi
+  CFLAGS_EX="$ac_saved_cflags_ex"
+
+  OPT_INLINE_FLAGS="${INLINE_FLAGS}"
+
+
+	;;
+  powerpc*) ARCH_LINK=ppc32.h endian=big
+  	echo "checking special compiler flags... PPC32"
+
+  echo "checking special compiler flags... PowerPC32"
+  CPU_BEST_FLAGS=""
+  INLINE_FLAGS=""	# taken from Makefile.legacy:  OPT_INLINE="-finline-functions -finline-limit=4000 -fno-strict-aliasing -maltivec"
+  ac_saved_cflags_ex="$CFLAGS_EX"
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -finline-functions" >&5
+$as_echo_n "checking if $CC supports -finline-functions... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -finline-functions"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -finline-functions"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -finline-functions" ; fi
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -finline-limit=4000" >&5
+$as_echo_n "checking if $CC supports -finline-limit=4000... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -finline-limit=4000"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -finline-limit=4000"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -finline-limit=4000" ; fi
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -fno-strict-aliasing" >&5
+$as_echo_n "checking if $CC supports -fno-strict-aliasing... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -fno-strict-aliasing"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -fno-strict-aliasing"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -fno-strict-aliasing" ; fi
+
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -maltivec" >&5
+$as_echo_n "checking if $CC supports -maltivec... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -maltivec"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -maltivec"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -maltivec" INLINE_FLAGS="$INLINE_FLAGS -maltivec" CPU_STR="ALTIVEC" ; fi
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -mvsx" >&5
+$as_echo_n "checking if $CC supports -mvsx... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -mvsx"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -mvsx"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -mvsx" ; fi
+  CFLAGS_EX=""
+    if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -mpower8-vector" >&5
+$as_echo_n "checking if $CC supports -mpower8-vector... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -mpower8-vector"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -mpower8-vector"
+
+else
+  if test "1" = 1; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -mpower8-vector" ; fi
+  CFLAGS_EX="$ac_saved_cflags_ex"
+
+  OPT_INLINE_FLAGS="${INLINE_FLAGS}"
+
+
+	;;
   sparc64) ARCH_LINK=sparc64.h endian=big ;;
   sparc*) ARCH_LINK=sparc32.h endian=big ;;
   vax*) ARCH_LINK=vax.h endian=little ;;
@@ -9128,76 +9729,60 @@ fi
   CC="$CC_BACKUP -mssse3"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SSSE3" >&5
 $as_echo_n "checking for SSSE3... " >&6; }
-  if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
 
-    #include <tmmintrin.h>
-        #include <stdio.h>
-        extern void exit(int);
-        int main(){__m128i t;*((long long*)&t)=1;t=_mm_shuffle_epi8(t,t);if((*(unsigned*)&t)==88)printf(".");exit(0);}
+  if test "$(uname -m)" = "x86_64"; then
+    CPUID_ASM="x86-64.S"
+    CPUID_FILE="x86-64.h"
+  else
+    CPUID_ASM="x86.S"
+    CPUID_FILE="x86-any.h"
+  fi
 
+  if test ! -f arch.h; then
+      cp $CPUID_FILE arch.h
+  fi
+  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSSE3 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
-  CPU_BEST_FLAGS="-mssse3"     CPU_STR="SSSE3"
+  SIMD_var=$( ./test_SIMD; echo $? )
+
+  if test "x$SIMD_var" = x1; then :
+  CPU_BEST_FLAGS="-mssse3"
+     CPU_STR="SSSE3"
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
 else
-  CPU_NOTFOUND=1
+  CPU_NOTFOUND="1"
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
 
 
 fi
+
   if test "x$CPU_NOTFOUND" = x0; then :
 
   CC="$CC_BACKUP -msse4.1"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SSE4.1" >&5
 $as_echo_n "checking for SSE4.1... " >&6; }
-  if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
 
-    #include <smmintrin.h>
-        #include <stdio.h>
-        extern void exit(int);
-        int main(){__m128d t;*((long long*)&t)=1;t=_mm_round_pd(t,1);if((*(long long*)&t)==88)printf(".");exit(0);}
+  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSE4_1 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
+  SIMD_var=$( ./test_SIMD; echo $? )
 
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
-  CPU_BEST_FLAGS="-msse4.1"     CPU_STR="SSE4.1"
+  if test "x$SIMD_var" = x1; then :
+  CPU_BEST_FLAGS="-msse4.1"
+     CPU_STR="SSE4.1"
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
 else
-  CPU_NOTFOUND=1
+  CPU_NOTFOUND="1"
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
 
 
 fi
@@ -9207,37 +9792,22 @@ fi
   CC="$CC_BACKUP -mavx"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for AVX" >&5
 $as_echo_n "checking for AVX... " >&6; }
-  if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
 
-    #include <immintrin.h>
-        #include <stdio.h>
-        extern void exit(int);
-        int main(){__m256d t;*((long long*)&t)=1;t=_mm256_movedup_pd(t);if((*(long long*)&t)==88)printf(".");exit(0);}
+  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
+  SIMD_var=$( ./test_SIMD; echo $? )
 
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+  if test "x$SIMD_var" = x1; then :
   CPU_BEST_FLAGS="-mavx"     CPU_STR="AVX"
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
 else
-  CPU_NOTFOUND=1
+  CPU_NOTFOUND="1"
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
 
 
 fi
@@ -9247,23 +9817,12 @@ fi
   CC="$CC_BACKUP -mxop"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XOP" >&5
 $as_echo_n "checking for XOP... " >&6; }
-  if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
 
-    #include <x86intrin.h>
-        #include <stdio.h>
-        extern void exit(int);
-        int main(){__m128i t;*((long long*)&t)=1;t=_mm_roti_epi32(t,5);if((*(long long*)&t)==88)printf(".");exit(0);}
+  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_XOP -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
+  SIMD_var=$( ./test_SIMD; echo $? )
 
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+  if test "x$SIMD_var" = x1; then :
   CPU_BEST_FLAGS="-mxop"     CPU_STR="XOP"
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
@@ -9273,10 +9832,6 @@ else
 $as_echo "no" >&6; }
 
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
 
 
 fi
@@ -9286,23 +9841,12 @@ fi
   CC="$CC_BACKUP -mavx2"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for AVX2" >&5
 $as_echo_n "checking for AVX2... " >&6; }
-  if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
 
-    #include <immintrin.h>
-        #include <stdio.h>
-        extern void exit(int);
-        int main(){__m256i t, t1;*((long long*)&t)=1;t1=t;t=_mm256_mul_epi32(t1,t);if((*(long long*)&t)==88)printf(".");exit(0);}
+  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX2 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
+  SIMD_var=$( ./test_SIMD; echo $? )
 
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+  if test "x$SIMD_var" = x1; then :
   CPU_BEST_FLAGS="-mavx2"     CPU_STR="AVX2"
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
@@ -9313,10 +9857,6 @@ else
 $as_echo "no" >&6; }
 
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
 
 
 fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -376,10 +376,8 @@ dnl AC_CHECK_SIZEOF([int *function()]
 # mips32.h (we override the BE defined within it)
 # mips64.h
 # pa-risc.h
-# ppc32.h
-# ppc32alt.h (-maltivec)
-# ppc64.h (-m64 -maltivec)
-# ppc64alt.h (-maltivec -faltivec)
+# ppc32.h  (with or without -maltivec)
+# ppc64.h (-m64 with or without -maltivec)
 # sparc32.h
 # sparc64.h (-m64 -mcpu=ultrasparc) (-xarch=native64)
 # vax.h
@@ -422,8 +420,14 @@ case "$host_cpu" in
   	[echo "checking special compiler flags... PPC64"]
   	JTR_PPC64_SPECIAL_LOGIC
 	;;
-  powerpcle) ARCH_LINK=ppc32.h endian=little ;;
-  powerpc*) ARCH_LINK=ppc32.h endian=big ;;
+  powerpcle) ARCH_LINK=ppc32.h endian=little
+  	[echo "checking special compiler flags... PPC32le"]
+  	JTR_PPC32_SPECIAL_LOGIC
+	;;
+  powerpc*) ARCH_LINK=ppc32.h endian=big
+  	[echo "checking special compiler flags... PPC32"]
+  	JTR_PPC32_SPECIAL_LOGIC
+	;;
   sparc64) ARCH_LINK=sparc64.h endian=big ;;
   sparc*) ARCH_LINK=sparc32.h endian=big ;;
   vax*) ARCH_LINK=vax.h endian=little ;;

--- a/src/m4/jtr_generic_logic.m4
+++ b/src/m4/jtr_generic_logic.m4
@@ -78,7 +78,7 @@ case "${host_cpu}_${CFLAGS}" in
    mic*)
       [CC_ASM_OBJS="simd-intrinsics.o"]
       ;;
-   powerpc64*)
+   powerpc*)
       [CC_ASM_OBJS="simd-intrinsics.o"]
       ;;
    arm*)

--- a/src/m4/jtr_ppc_logic.m4
+++ b/src/m4/jtr_ppc_logic.m4
@@ -2,9 +2,46 @@ dnl Redistribution and use in source or binary forms, with or without
 dnl modification, are permitted.
 dnl
 dnl Special compiler flags for Power.
-
+dnl
+dnl from Makefile.legacy, checks we want to test against
+dnl "-finline-functions -finline-limit=4000 -fno-strict-aliasing -maltivec"
+dnl Also added -mvsx and -mpower8-vector
+dnl 
 AC_DEFUN([JTR_PPC64_SPECIAL_LOGIC], [
   echo "checking special compiler flags... PowerPC64"
+  CPU_BEST_FLAGS=""
+  INLINE_FLAGS=""	# taken from Makefile.legacy:  OPT_INLINE="-finline-functions -finline-limit=4000 -fno-strict-aliasing -maltivec"
+  ac_saved_cflags_ex="$CFLAGS_EX"
+  CFLAGS_EX=""
+  JTR_FLAG_CHECK([-finline-functions], 1)
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -finline-functions" ; fi
+  CFLAGS_EX=""
+  JTR_FLAG_CHECK([-finline-limit=4000], 1)
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -finline-limit=4000" ; fi
+  CFLAGS_EX=""
+  JTR_FLAG_CHECK([-fno-strict-aliasing], 1)
+  if test "x$CFLAGS_EX" != x ; then INLINE_FLAGS="$INLINE_FLAGS -fno-strict-aliasing" ; fi
+
+  CFLAGS_EX=""
+  JTR_FLAG_CHECK([-maltivec], 1)
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -maltivec" INLINE_FLAGS="$INLINE_FLAGS -maltivec" CPU_STR="ALTIVEC" ; fi
+  CFLAGS_EX=""
+  JTR_FLAG_CHECK([-mvsx], 1)
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -mvsx" ; fi
+  CFLAGS_EX=""
+  JTR_FLAG_CHECK([-mpower8-vector], 1)
+  if test "x$CFLAGS_EX" != x ; then CPU_BEST_FLAGS="$CPU_BEST_FLAGS -mpower8-vector" ; fi
+  CFLAGS_EX="$ac_saved_cflags_ex"
+
+  AC_SUBST([OPT_INLINE_FLAGS],["${INLINE_FLAGS}"])
+])
+dnl
+dnl from Makefile.legacy, checks we want to test against
+dnl -finline-functions -finline-limit=4000 -fno-strict-aliasing -maltivec
+dnl Also added -mvsx and -mpower8-vector
+dnl
+AC_DEFUN([JTR_PPC32_SPECIAL_LOGIC], [
+  echo "checking special compiler flags... PowerPC32"
   CPU_BEST_FLAGS=""
   INLINE_FLAGS=""	# taken from Makefile.legacy:  OPT_INLINE="-finline-functions -finline-limit=4000 -fno-strict-aliasing -maltivec"
   ac_saved_cflags_ex="$CFLAGS_EX"

--- a/src/ppc32.h
+++ b/src/ppc32.h
@@ -10,10 +10,22 @@
 
 /*
  * Architecture specific parameters for 32-bit PowerPC.
+ *   (On configure builds, this header may passthru to ppc32alt.h)
  */
 
 #ifndef _JOHN_ARCH_H
 #define _JOHN_ARCH_H
+
+#if defined (JOHN_ALTIVEC)
+// in autoconfig builds, we always link to this header,
+// but later KNOW that we are ALTIVEC, so once we know
+// we then include the proper header
+#undef _JOHN_ARCH_H
+#include "ppc32alt.h"
+
+#else
+
+// Settings for a NON ALTIVEC build.
 
 #if AC_BUILT
 #include "autoconfig.h"
@@ -41,15 +53,18 @@
 #define DES_COPY			0
 #define DES_BS_ASM			0
 #define DES_BS				1
-#define DES_BS_VECTOR			0
 #define DES_BS_EXPAND			1
+#define DES_BS_VECTOR			0
 
 #define MD5_ASM				0
 #define MD5_X2				1
-#define MD5_IMM				0
+#define MD5_IMM			0
 
 #define BF_ASM				0
 #define BF_SCALE			0
 #define BF_X2				0
 
+#define SHA_BUF_SIZ			16
+
+#endif
 #endif

--- a/src/ppc32alt.h
+++ b/src/ppc32alt.h
@@ -68,4 +68,57 @@
 #define BF_SCALE			0
 #define BF_X2				0
 
+#if defined(JOHN_ALTIVEC)
+#define SIMD_COEF_32		4
+#define SIMD_COEF_64		2
+
+#ifndef SIMD_PARA_MD4
+#define SIMD_PARA_MD4		1
+#endif
+#ifndef SIMD_PARA_MD5
+#define SIMD_PARA_MD5		1
+#endif
+#ifndef SIMD_PARA_SHA1
+#define SIMD_PARA_SHA1		1
+#endif
+#ifndef SIMD_PARA_SHA256
+#define SIMD_PARA_SHA256	1
+#endif
+#ifndef SIMD_PARA_SHA512
+#define SIMD_PARA_SHA512	1
+#endif
+
+#define STR_VALUE(arg)		#arg
+#define PARA_TO_N(n)		STR_VALUE(n) "x"
+#define PARA_TO_MxN(m, n)	STR_VALUE(m) "x" STR_VALUE(n)
+
+#if SIMD_PARA_MD4 > 1
+#define MD4_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_MD4)
+#else
+#define MD4_N_STR			PARA_TO_N(SIMD_COEF_32)
+#endif
+#if SIMD_PARA_MD5 > 1
+#define MD5_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_MD5)
+#else
+#define MD5_N_STR			PARA_TO_N(SIMD_COEF_32)
+#endif
+#if SIMD_PARA_SHA1 > 1
+#define SHA1_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_SHA1)
+#else
+#define SHA1_N_STR			PARA_TO_N(SIMD_COEF_32)
+#endif
+#if SIMD_PARA_SHA256 > 1
+#define SHA256_N_STR		PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_SHA256)
+#else
+#define SHA256_N_STR		PARA_TO_N(SIMD_COEF_32)
+#endif
+#if SIMD_PARA_SHA512 > 1
+#define SHA512_N_STR		PARA_TO_MxN(SIMD_COEF_64, SIMD_PARA_SHA512)
+#else
+#define SHA512_N_STR		PARA_TO_N(SIMD_COEF_64)
+#endif
+
+#define SHA_BUF_SIZ			16
+
+#endif
 #endif

--- a/src/ppc64.h
+++ b/src/ppc64.h
@@ -15,6 +15,15 @@
 #ifndef _JOHN_ARCH_H
 #define _JOHN_ARCH_H
 
+#if defined (JOHN_ALTIVEC)
+// in autoconfig builds, we always link to this header,
+// but later KNOW that we are ALTIVEC, so once we know
+// we then include the proper header
+#undef _JOHN_ARCH_H
+#include "ppc64alt.h"
+
+#else
+
 #if AC_BUILT
 #include "autoconfig.h"
 #else
@@ -45,90 +54,18 @@
 #define DES_COPY			0
 #define DES_BS_ASM			0
 #define DES_BS				1
-#if defined(JOHN_ALTIVEC)
-#define DES_BS_EXPAND			3
-#if 1
-#define DES_BS_VECTOR			2
-#define DES_BS_ALGORITHM_NAME		"DES 128/128 AltiVec"
-#elif 0
-/* It is likely unreasonable to use S-box expressions requiring vsel when this
- * operation is only available in one of the two instruction sets.
- * So let's revert to less demanding S-box expressions. */
-#define DES_BS_VECTOR			3
-#define DES_BS_VECTOR_SIZE		4
-#define DES_BS_ALGORITHM_NAME		"DES 128/128 AltiVec + 64/64"
-#else
-#define DES_BS_VECTOR			4
-#define DES_BS_ALGORITHM_NAME		"DES 128/128 X2 AltiVec"
-#endif
-#else
 #define DES_BS_EXPAND			1
 #define DES_BS_VECTOR			0
-#endif
 
 #define MD5_ASM			0
 #define MD5_X2				1
-#if HAVE_ALTIVEC
-#define MD5_IMM			1
-#else
 #define MD5_IMM			0
-#endif
 
 #define BF_ASM				0
 #define BF_SCALE			0
 #define BF_X2				0
 
-#if defined(JOHN_ALTIVEC)
-#define SIMD_COEF_32		4
-#define SIMD_COEF_64		2
-#endif
-
-#ifndef SIMD_PARA_MD4
-#define SIMD_PARA_MD4		1
-#endif
-#ifndef SIMD_PARA_MD5
-#define SIMD_PARA_MD5		1
-#endif
-#ifndef SIMD_PARA_SHA1
-#define SIMD_PARA_SHA1		1
-#endif
-#ifndef SIMD_PARA_SHA256
-#define SIMD_PARA_SHA256	1
-#endif
-#ifndef SIMD_PARA_SHA512
-#define SIMD_PARA_SHA512	1
-#endif
-
-#define STR_VALUE(arg)		#arg
-#define PARA_TO_N(n)		STR_VALUE(n) "x"
-#define PARA_TO_MxN(m, n)	STR_VALUE(m) "x" STR_VALUE(n)
-
-#if SIMD_PARA_MD4 > 1
-#define MD4_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_MD4)
-#else
-#define MD4_N_STR			PARA_TO_N(SIMD_COEF_32)
-#endif
-#if SIMD_PARA_MD5 > 1
-#define MD5_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_MD5)
-#else
-#define MD5_N_STR			PARA_TO_N(SIMD_COEF_32)
-#endif
-#if SIMD_PARA_SHA1 > 1
-#define SHA1_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_SHA1)
-#else
-#define SHA1_N_STR			PARA_TO_N(SIMD_COEF_32)
-#endif
-#if SIMD_PARA_SHA256 > 1
-#define SHA256_N_STR		PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_SHA256)
-#else
-#define SHA256_N_STR		PARA_TO_N(SIMD_COEF_32)
-#endif
-#if SIMD_PARA_SHA512 > 1
-#define SHA512_N_STR		PARA_TO_MxN(SIMD_COEF_64, SIMD_PARA_SHA512)
-#else
-#define SHA512_N_STR		PARA_TO_N(SIMD_COEF_64)
-#endif
-
 #define SHA_BUF_SIZ			16
 
+#endif
 #endif

--- a/src/ppc64alt.h
+++ b/src/ppc64alt.h
@@ -68,4 +68,57 @@
 #define BF_SCALE			0
 #define BF_X2				0
 
+#if defined(JOHN_ALTIVEC)
+#define SIMD_COEF_32		4
+#define SIMD_COEF_64		2
+
+#ifndef SIMD_PARA_MD4
+#define SIMD_PARA_MD4		1
+#endif
+#ifndef SIMD_PARA_MD5
+#define SIMD_PARA_MD5		1
+#endif
+#ifndef SIMD_PARA_SHA1
+#define SIMD_PARA_SHA1		1
+#endif
+#ifndef SIMD_PARA_SHA256
+#define SIMD_PARA_SHA256	1
+#endif
+#ifndef SIMD_PARA_SHA512
+#define SIMD_PARA_SHA512	1
+#endif
+
+#define STR_VALUE(arg)		#arg
+#define PARA_TO_N(n)		STR_VALUE(n) "x"
+#define PARA_TO_MxN(m, n)	STR_VALUE(m) "x" STR_VALUE(n)
+
+#if SIMD_PARA_MD4 > 1
+#define MD4_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_MD4)
+#else
+#define MD4_N_STR			PARA_TO_N(SIMD_COEF_32)
+#endif
+#if SIMD_PARA_MD5 > 1
+#define MD5_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_MD5)
+#else
+#define MD5_N_STR			PARA_TO_N(SIMD_COEF_32)
+#endif
+#if SIMD_PARA_SHA1 > 1
+#define SHA1_N_STR			PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_SHA1)
+#else
+#define SHA1_N_STR			PARA_TO_N(SIMD_COEF_32)
+#endif
+#if SIMD_PARA_SHA256 > 1
+#define SHA256_N_STR		PARA_TO_MxN(SIMD_COEF_32, SIMD_PARA_SHA256)
+#else
+#define SHA256_N_STR		PARA_TO_N(SIMD_COEF_32)
+#endif
+#if SIMD_PARA_SHA512 > 1
+#define SHA512_N_STR		PARA_TO_MxN(SIMD_COEF_64, SIMD_PARA_SHA512)
+#else
+#define SHA512_N_STR		PARA_TO_N(SIMD_COEF_64)
+#endif
+#endif
+
+#define SHA_BUF_SIZ			16
+
 #endif

--- a/src/pseudo_intrinsics.h
+++ b/src/pseudo_intrinsics.h
@@ -101,7 +101,7 @@ inline static int vanyeq_epi32(vtype x, vtype y)
 #include <altivec.h>
 
 typedef vector unsigned int vtype32;
-typedef vector unsigned long vtype64;
+typedef vector unsigned long long vtype64;
 typedef union {
 	vtype32 v32;
 	vtype64 v64;


### PR DESCRIPTION
Pull request added, so Solar can easily test this also.

There are still formats failing.  I will be working through those.

However:

1. both 32 bit and 64 bit ppc now build with altivec (if the compiler allows)

2. neither 32 or 64 bit probe IF altivec builds 'work', just that the compiler allows  (TODO)

3. ppc32.h and ppc64.h are much close to core john versions. The call the *alt.h if using ALTIVEC

4. ppc32alt.h and ppc64alt.h have the SIMD_PARA defines in them (only used on jumbo)

5. At one time, I thought I had all formats working on altivec builds, but now, I am having 14 format failures.  I may have missed the format file porting logic.

6. The non-SIMD builds have not been tested yet (I need to find a good way to do that using configure).  I can always build using Makefile.legacy however until I figure it out  ;)