### PR TITLE
Fixes for new CPU detection in ./configure (eg. non-Linux)

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -3348,6 +3348,15 @@ ac_config_headers="$ac_config_headers autoconfig.h"
 
 
 
+# This file is Copyright (C) 2014-2017 magnum & JimF,
+# and is hereby released to the general public under the following terms:
+# Redistribution and use in source and binary forms, with or without
+# modifications, are permitted.
+#
+# All tests in this file are supposed to be cross compile compliant
+#
+
+
 # JtR configure Intel-SIMD instruction active probe test
 # Copyright (C) 2014 Jim Fougeron, for John Ripper project.
 # This file put into public domain. unlimited permission to
@@ -9515,6 +9524,115 @@ esac
 # macros for each environment.  We probably should fall back to calling
 # make -f Makefile.legacy clean generic or failing with an echo of that message,
 # for any environment we do not handle.
+
+CC_BACKUP=$CC
+CFLAGS_BACKUP=$CFLAGS
+
+#############################################################################
+# ASM_MAGIC code.  Here we add certain 'magic' values. Things like
+#  -DUNDERSCORES -DBSD -DALIGN_LOG   (for macosx-x86-*)
+#  -DUNDERSCORES -DALIGN_LOG for (dos-djgpp-x86-*)
+#  -DUNDERSCORES for cygwin / MinGW / VC
+#############################################################################
+EXTRA_AS_FLAGS=
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for extra ASFLAGS" >&5
+$as_echo_n "checking for extra ASFLAGS... " >&6; }
+CC="$CC_BACKUP"
+CFLAGS="$CFLAGS -O0"
+if echo "int long_ident;" > conftest.c && ${CC} -c conftest.c && strings - conftest.${OBJEXT} | ${GREP} _long_ident > conftest.out; then :
+
+   for i in -DUNDERSCORES; do
+      jtr_list_add_dupe=0
+      for j in $EXTRA_AS_FLAGS; do
+         if test "x$i" = "x$j"; then
+            jtr_list_add_dupe=1
+            break
+         fi
+      done
+      if test $jtr_list_add_dupe = 0; then
+         EXTRA_AS_FLAGS="$EXTRA_AS_FLAGS $i"
+         jtr_list_add_result="$jtr_list_add_result $i"
+      fi
+   done
+
+fi
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+extern void exit(int);
+	int main() {
+	#if defined(__APPLE__) && defined(__MACH__)
+        exit(0);
+    #else
+        BORK!
+	#endif
+	}
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+
+   for i in -DBSD -DALIGN_LOG; do
+      jtr_list_add_dupe=0
+      for j in $EXTRA_AS_FLAGS; do
+         if test "x$i" = "x$j"; then
+            jtr_list_add_dupe=1
+            break
+         fi
+      done
+      if test $jtr_list_add_dupe = 0; then
+         EXTRA_AS_FLAGS="$EXTRA_AS_FLAGS $i"
+         jtr_list_add_result="$jtr_list_add_result $i"
+      fi
+   done
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+if test "x$EXTRA_AS_FLAGS" = x; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: None needed" >&5
+$as_echo "None needed" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${EXTRA_AS_FLAGS}" >&5
+$as_echo "${EXTRA_AS_FLAGS}" >&6; }
+fi
+
+#############################################################################
+# Extra code for X32 ABI test.  We need this for dynamic AES-NI support.
+#############################################################################
+if test "x$cpu_family" = xintel -a "x$ax_intel_x32" != xno; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for X32 ABI" >&5
+$as_echo_n "checking for X32 ABI... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+extern void exit(int);
+     int main() {
+     #if defined(__x86_64__) && defined(__ILP32__)
+         exit(0);}
+     #else
+         BORK!
+     #endif
+
+
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+   ax_intel_x32=yes
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+fi
+
+CC="$CC_BACKUP"
+CFLAGS="$CFLAGS_BACKUP"
+
 if test "x$cpu_family" = xintel; then :
   echo "checking special compiler flags... Intel X86*"
 CC_BACKUP=$CC
@@ -9741,7 +9859,7 @@ $as_echo_n "checking for SSSE3... " >&6; }
   if test ! -f arch.h; then
       cp $CPUID_FILE arch.h
   fi
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSSE3 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSSE3 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   SIMD_var=$( ./test_SIMD; echo $? )
 
@@ -9767,7 +9885,7 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SSE4.1" >&5
 $as_echo_n "checking for SSE4.1... " >&6; }
 
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSE4_1 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSE4_1 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   SIMD_var=$( ./test_SIMD; echo $? )
 
@@ -9793,7 +9911,7 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for AVX" >&5
 $as_echo_n "checking for AVX... " >&6; }
 
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   SIMD_var=$( ./test_SIMD; echo $? )
 
@@ -9818,7 +9936,7 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XOP" >&5
 $as_echo_n "checking for XOP... " >&6; }
 
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_XOP -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_XOP -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   SIMD_var=$( ./test_SIMD; echo $? )
 
@@ -9842,7 +9960,7 @@ fi
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for AVX2" >&5
 $as_echo_n "checking for AVX2... " >&6; }
 
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX2 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX2 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   SIMD_var=$( ./test_SIMD; echo $? )
 
@@ -10344,7 +10462,7 @@ fi
    mic*)
       CC_ASM_OBJS="simd-intrinsics.o"
       ;;
-   powerpc64*)
+   powerpc*)
       CC_ASM_OBJS="simd-intrinsics.o"
       ;;
    arm*)
@@ -10357,109 +10475,6 @@ fi
       CC_ASM_OBJS="alpha.o"
       ;;
 esac
-
-#############################################################################
-# ASM_MAGIC code.  Here we add certain 'magic' values. Things like
-#  -DUNDERSCORES -DBSD -DALIGN_LOG   (for macosx-x86-*)
-#  -DUNDERSCORES -DALIGN_LOG for (dos-djgpp-x86-*)
-#  -DUNDERSCORES for cygwin / MinGW / VC
-#############################################################################
-EXTRA_AS_FLAGS=
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for extra ASFLAGS" >&5
-$as_echo_n "checking for extra ASFLAGS... " >&6; }
-CC="$CC_BACKUP"
-CFLAGS_BACKUP=$CFLAGS
-CFLAGS="$CFLAGS -O0"
-if echo "int long_ident;" > conftest.c && ${CC} -c conftest.c && strings - conftest.${OBJEXT} | ${GREP} _long_ident > conftest.out; then :
-
-   for i in -DUNDERSCORES; do
-      jtr_list_add_dupe=0
-      for j in $EXTRA_AS_FLAGS; do
-         if test "x$i" = "x$j"; then
-            jtr_list_add_dupe=1
-            break
-         fi
-      done
-      if test $jtr_list_add_dupe = 0; then
-         EXTRA_AS_FLAGS="$EXTRA_AS_FLAGS $i"
-         jtr_list_add_result="$jtr_list_add_result $i"
-      fi
-   done
-
-fi
-
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-extern void exit(int);
-	int main() {
-	#if defined(__APPLE__) && defined(__MACH__)
-        exit(0);
-    #else
-        BORK!
-	#endif
-	}
-
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-
-   for i in -DBSD -DALIGN_LOG; do
-      jtr_list_add_dupe=0
-      for j in $EXTRA_AS_FLAGS; do
-         if test "x$i" = "x$j"; then
-            jtr_list_add_dupe=1
-            break
-         fi
-      done
-      if test $jtr_list_add_dupe = 0; then
-         EXTRA_AS_FLAGS="$EXTRA_AS_FLAGS $i"
-         jtr_list_add_result="$jtr_list_add_result $i"
-      fi
-   done
-
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-
-if test "x$EXTRA_AS_FLAGS" = x; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: None needed" >&5
-$as_echo "None needed" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${EXTRA_AS_FLAGS}" >&5
-$as_echo "${EXTRA_AS_FLAGS}" >&6; }
-fi
-
-#############################################################################
-# Extra code for X32 ABI test.  We need this for dynamic AES-NI support.
-#############################################################################
-if test "x$cpu_family" = xintel -a "x$ax_intel_x32" != xno; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for X32 ABI" >&5
-$as_echo_n "checking for X32 ABI... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-extern void exit(int);
-     int main() {
-     #if defined(__x86_64__) && defined(__ILP32__)
-         exit(0);}
-     #else
-         BORK!
-     #endif
-
-
-
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-   ax_intel_x32=yes
-
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-fi
 
 CC="$CC_BACKUP"
 CFLAGS="$CFLAGS_BACKUP"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -36,6 +36,7 @@ m4_include([m4/ax_pthread.m4])
 m4_include([m4/ax_prog_cc_mpi.m4])
 m4_include([m4/ax_lang_compiler_ms.m4])
 m4_include([m4/ax_check_gnu_make.m4])
+m4_include([m4/jtr_asm_magic.m4])
 m4_include([m4/jtr_x86_logic.m4])
 m4_include([m4/jtr_mic_logic.m4])
 m4_include([m4/jtr_ppc_logic.m4])
@@ -444,6 +445,7 @@ esac
 # macros for each environment.  We probably should fall back to calling
 # make -f Makefile.legacy clean generic or failing with an echo of that message,
 # for any environment we do not handle.
+JTR_ASM_MAGIC
 AS_IF([test "x$cpu_family" = xintel], [echo "checking special compiler flags... Intel X86*"] [JTR_X86_SPECIAL_LOGIC])
 AC_MSG_CHECKING([for arch.h alternative])
 AC_MSG_RESULT([${ARCH_LINK}])

--- a/src/m4/jtr_asm_magic.m4
+++ b/src/m4/jtr_asm_magic.m4
@@ -1,0 +1,61 @@
+# This file is Copyright (C) 2014-2017 magnum & JimF,
+# and is hereby released to the general public under the following terms:
+# Redistribution and use in source and binary forms, with or without
+# modifications, are permitted.
+#
+# All tests in this file are supposed to be cross compile compliant
+#
+AC_DEFUN([JTR_ASM_MAGIC], [
+CC_BACKUP=$CC
+CFLAGS_BACKUP=$CFLAGS
+
+#############################################################################
+# ASM_MAGIC code.  Here we add certain 'magic' values. Things like
+#  -DUNDERSCORES -DBSD -DALIGN_LOG   (for macosx-x86-*)
+#  -DUNDERSCORES -DALIGN_LOG for (dos-djgpp-x86-*)
+#  -DUNDERSCORES for cygwin / MinGW / VC
+#############################################################################
+EXTRA_AS_FLAGS=
+AC_MSG_CHECKING([for extra ASFLAGS])
+CC="$CC_BACKUP"
+CFLAGS="$CFLAGS -O0"
+AS_IF([echo "int long_ident;" > conftest.c && ${CC} -c conftest.c && strings - conftest.${OBJEXT} | ${GREP} _long_ident > conftest.out],
+      [JTR_LIST_ADD(EXTRA_AS_FLAGS, [-DUNDERSCORES])])
+
+AC_LINK_IFELSE([AC_LANG_SOURCE(
+	[[extern void exit(int);
+	int main() {
+	#if defined(__APPLE__) && defined(__MACH__)
+        exit(0);
+    #else
+        BORK!
+	#endif
+	}]])]
+  ,[JTR_LIST_ADD(EXTRA_AS_FLAGS, [-DBSD -DALIGN_LOG])])
+
+AS_IF([test "x$EXTRA_AS_FLAGS" = x],[AC_MSG_RESULT([None needed])],[AC_MSG_RESULT([${EXTRA_AS_FLAGS}])])
+
+#############################################################################
+# Extra code for X32 ABI test.  We need this for dynamic AES-NI support.
+#############################################################################
+AS_IF([test "x$cpu_family" = xintel -a "x$ax_intel_x32" != xno],
+AC_MSG_CHECKING([for X32 ABI])
+[AC_LINK_IFELSE(
+   [AC_LANG_SOURCE(
+      [[extern void exit(int);
+     int main() {
+     #if defined(__x86_64__) && defined(__ILP32__)
+         exit(0);}
+     #else
+         BORK!
+     #endif
+      ]]
+   )]
+   ,[AC_MSG_RESULT([yes])]
+   [ax_intel_x32=yes]
+   ,[AC_MSG_RESULT([no])]
+)])
+
+CC="$CC_BACKUP"
+CFLAGS="$CFLAGS_BACKUP"
+])

--- a/src/m4/jtr_generic_logic.m4
+++ b/src/m4/jtr_generic_logic.m4
@@ -92,54 +92,6 @@ case "${host_cpu}_${CFLAGS}" in
       ;;
 esac
 
-#############################################################################
-# ASM_MAGIC code.  Here we add certain 'magic' values. Things like
-#  -DUNDERSCORES -DBSD -DALIGN_LOG   (for macosx-x86-*)
-#  -DUNDERSCORES -DALIGN_LOG for (dos-djgpp-x86-*)
-#  -DUNDERSCORES for cygwin / MinGW / VC
-#############################################################################
-EXTRA_AS_FLAGS=
-AC_MSG_CHECKING([for extra ASFLAGS])
-CC="$CC_BACKUP"
-CFLAGS_BACKUP=$CFLAGS
-CFLAGS="$CFLAGS -O0"
-AS_IF([echo "int long_ident;" > conftest.c && ${CC} -c conftest.c && strings - conftest.${OBJEXT} | ${GREP} _long_ident > conftest.out],
-      [JTR_LIST_ADD(EXTRA_AS_FLAGS, [-DUNDERSCORES])])
-
-AC_LINK_IFELSE([AC_LANG_SOURCE(
-	[[extern void exit(int);
-	int main() {
-	#if defined(__APPLE__) && defined(__MACH__)
-        exit(0);
-    #else
-        BORK!
-	#endif
-	}]])]
-  ,[JTR_LIST_ADD(EXTRA_AS_FLAGS, [-DBSD -DALIGN_LOG])])
-
-AS_IF([test "x$EXTRA_AS_FLAGS" = x],[AC_MSG_RESULT([None needed])],[AC_MSG_RESULT([${EXTRA_AS_FLAGS}])])
-
-#############################################################################
-# Extra code for X32 ABI test.  We need this for dynamic AES-NI support.
-#############################################################################
-AS_IF([test "x$cpu_family" = xintel -a "x$ax_intel_x32" != xno],
-AC_MSG_CHECKING([for X32 ABI])
-[AC_LINK_IFELSE(
-   [AC_LANG_SOURCE(
-      [[extern void exit(int);
-     int main() {
-     #if defined(__x86_64__) && defined(__ILP32__)
-         exit(0);}
-     #else
-         BORK!
-     #endif
-      ]]
-   )]
-   ,[AC_MSG_RESULT([yes])]
-   [ax_intel_x32=yes]
-   ,[AC_MSG_RESULT([no])]
-)])
-
 CC="$CC_BACKUP"
 CFLAGS="$CFLAGS_BACKUP"
 ])

--- a/src/m4/jtr_x86_logic.m4
+++ b/src/m4/jtr_x86_logic.m4
@@ -173,7 +173,7 @@ if test "x$enable_native_tests" != xno; then
   if test ! -f arch.h; then
       cp $CPUID_FILE arch.h
   fi
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSSE3 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSSE3 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   AC_SUBST([SIMD_var],[$( ./test_SIMD; echo $? )])
   AS_IF([test "x$SIMD_var" = x1],
@@ -191,7 +191,7 @@ if test "x$enable_native_tests" != xno; then
   CC="$CC_BACKUP -msse4.1"
   AC_MSG_CHECKING([for SSE4.1])
 
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSE4_1 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_SSE4_1 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   AC_SUBST([SIMD_var],[$( ./test_SIMD; echo $? )])
   AS_IF([test "x$SIMD_var" = x1],
@@ -209,7 +209,7 @@ if test "x$enable_native_tests" != xno; then
   CC="$CC_BACKUP -mavx"
   AC_MSG_CHECKING([for AVX])
 
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   AC_SUBST([SIMD_var],[$( ./test_SIMD; echo $? )])
   AS_IF([test "x$SIMD_var" = x1],
@@ -227,7 +227,7 @@ if test "x$enable_native_tests" != xno; then
   CC="$CC_BACKUP -mxop"
   AC_MSG_CHECKING([for XOP])
 
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_XOP -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_XOP -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   AC_SUBST([SIMD_var],[$( ./test_SIMD; echo $? )])
   AS_IF([test "x$SIMD_var" = x1],
@@ -245,7 +245,7 @@ if test "x$enable_native_tests" != xno; then
   CC="$CC_BACKUP -mavx2"
   AC_MSG_CHECKING([for AVX2])
 
-  $CC -P $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX2 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
+  $CC -P $EXTRA_AS_FLAGS $CPPFLAGS $CPU_BEST_FLAGS $CFLAGS $CFLAGS_EXTRA -DCPU_REQ_AVX2 -DCPU_REQ test_SIMD.c $CPUID_ASM -o test_SIMD
 
   AC_SUBST([SIMD_var],[$( ./test_SIMD; echo $? )])
   AS_IF([test "x$SIMD_var" = x1],


### PR DESCRIPTION
See #2966, #2972.

I did all the right things in #2975 except I didn't source the M4 so the function was never called.

This works on OSX, let's see what it does to the build bots.