### PR TITLE
fmt_split_case issue dyna_compiler and --test-full=1

### DIFF
--- a/src/dynamic_compiler.c
+++ b/src/dynamic_compiler.c
@@ -2398,17 +2398,28 @@ char *dynamic_compile_prepare(char *fld0, char *fld1) {
 }
 char *dynamic_compile_split(char *ct) {
 	extern int ldr_in_pot;
+	static char Buf[1024], Buf2[1024];
 	if (strncmp(ct, "dynamic_", 8)) {
-		return dynamic_compile_prepare("", ct);
+		char *cp;
+		ct = dynamic_compile_prepare("", ct);
+		cp = strrchr(ct, '@');
+		while (*cp) {
+			if (*cp >= 'A' && *cp <= 'Z') {
+				snprintf(Buf, sizeof(Buf), "%s", ct);
+				cp = strrchr(Buf, '@');
+				strlwr(cp);
+				return Buf;
+			}
+			++cp;
+		}
+		return ct;
 	} else if (strncmp(ct, "@dynamic=", 9) && strncmp(ct, dyna_signature, dyna_sig_len)) {
 		// convert back into dynamic= format
 		// Note we should probably ONLY do this on 'raw' hashes!
-		static char Buf[512];
 		snprintf(Buf, sizeof(Buf), "%s%s", dyna_signature, ct);
 		ct = Buf;
 	} else {
 		if (ldr_in_pot == 1 && !strncmp(ct, "@dynamic=", 9)) {
-			static char Buf[512], Buf2[512];
 			char *cp = strchr(&ct[1], '@');
 			if (cp) {
 				strnzcpy(Buf, &cp[1], sizeof(Buf));

--- a/src/dynamic_compiler.c
+++ b/src/dynamic_compiler.c
@@ -2398,28 +2398,17 @@ char *dynamic_compile_prepare(char *fld0, char *fld1) {
 }
 char *dynamic_compile_split(char *ct) {
 	extern int ldr_in_pot;
-	static char Buf[1024], Buf2[1024];
 	if (strncmp(ct, "dynamic_", 8)) {
-		char *cp;
-		ct = dynamic_compile_prepare("", ct);
-		cp = strrchr(ct, '@');
-		while (*cp) {
-			if (*cp >= 'A' && *cp <= 'Z') {
-				snprintf(Buf, sizeof(Buf), "%s", ct);
-				cp = strrchr(Buf, '@');
-				strlwr(cp);
-				return Buf;
-			}
-			++cp;
-		}
-		return ct;
+		return dynamic_compile_prepare("", ct);
 	} else if (strncmp(ct, "@dynamic=", 9) && strncmp(ct, dyna_signature, dyna_sig_len)) {
 		// convert back into dynamic= format
 		// Note we should probably ONLY do this on 'raw' hashes!
+		static char Buf[512];
 		snprintf(Buf, sizeof(Buf), "%s%s", dyna_signature, ct);
 		ct = Buf;
 	} else {
 		if (ldr_in_pot == 1 && !strncmp(ct, "@dynamic=", 9)) {
+			static char Buf[512], Buf2[512];
 			char *cp = strchr(&ct[1], '@');
 			if (cp) {
 				strnzcpy(Buf, &cp[1], sizeof(Buf));

--- a/src/dynamic_compiler_fmt_plug.c
+++ b/src/dynamic_compiler_fmt_plug.c
@@ -174,7 +174,7 @@ struct fmt_main fmt_CompiledDynamic =
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
 			/* for now, turn off FMT_SPLIT_UNIFIES_CASE until we get the code right */
-		0, 0, 16, BINARY_ALIGN, DYNA_SALT_SIZE, SALT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT | FMT_DYNAMIC /*| FMT_SPLIT_UNIFIES_CASE */ ,
+		0, 0, 16, BINARY_ALIGN, DYNA_SALT_SIZE, SALT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT | FMT_DYNAMIC | FMT_SPLIT_UNIFIES_CASE,
 		{ NULL },
 		{ NULL },
 		tests

--- a/src/dynamic_compiler_fmt_plug.c
+++ b/src/dynamic_compiler_fmt_plug.c
@@ -84,6 +84,7 @@ static int dyna_hash_type_len;
 static struct fmt_main *pDynamic;
 static void our_init(struct fmt_main *self);
 static void get_ptr();
+static char* (*dyna_split)(char *ciphertext, int index, struct fmt_main *self);
 
 /* this function converts a 'native' @dynamic= signature string into a $dynamic_6xxx$ syntax string */
 static char *Convert(char *Buf, char *ciphertext, int in_load)
@@ -115,7 +116,7 @@ static char *Convert(char *Buf, char *ciphertext, int in_load)
 static char *our_split(char *ciphertext, int index, struct fmt_main *self)
 {
 	ciphertext = dynamic_compile_split(ciphertext);
-	return ciphertext;
+	return dyna_split(ciphertext, index, self);
 }
 extern char *load_regen_lost_salt_Prepare(char *split_fields1);
 static char *our_prepare(char **fields, struct fmt_main *self)
@@ -212,6 +213,7 @@ static void link_funcs() {
 	}
 	fmt_CompiledDynamic.methods.salt   = our_salt;
 	fmt_CompiledDynamic.methods.binary = our_binary;
+	dyna_split = fmt_CompiledDynamic.methods.split;
 	fmt_CompiledDynamic.methods.split = our_split;
 	fmt_CompiledDynamic.methods.prepare = our_prepare;
 	fmt_CompiledDynamic.methods.done = our_done;

--- a/src/dynamic_compiler_fmt_plug.c
+++ b/src/dynamic_compiler_fmt_plug.c
@@ -174,7 +174,7 @@ struct fmt_main fmt_CompiledDynamic =
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
 			/* for now, turn off FMT_SPLIT_UNIFIES_CASE until we get the code right */
-		0, 0, 16, BINARY_ALIGN, DYNA_SALT_SIZE, SALT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT | FMT_DYNAMIC | FMT_SPLIT_UNIFIES_CASE,
+		0, 0, 16, BINARY_ALIGN, DYNA_SALT_SIZE, SALT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT | FMT_DYNAMIC /*| FMT_SPLIT_UNIFIES_CASE */ ,
 		{ NULL },
 		{ NULL },
 		tests

--- a/src/formats.c
+++ b/src/formats.c
@@ -1469,6 +1469,8 @@ static void test_fmt_split_unifies_case_3(struct fmt_main *format,
 
 		*has_change_case = 1;
 		split_ret = format->methods.split(cipher_copy, 0, format);
+		if (strcmp(cipher_copy, ciphertext))
+			*is_need_unify_case = 0;
 		binary = format->methods.binary(split_ret);
 
 		if (binary != NULL)
@@ -1487,6 +1489,8 @@ static void test_fmt_split_unifies_case_3(struct fmt_main *format,
 
 		*has_change_case = 1;
 		split_ret = format->methods.split(cipher_copy, 0, format);
+		if (strcmp(cipher_copy, ciphertext))
+			*is_need_unify_case = 0;
 		binary = format->methods.binary(split_ret);
 
 		if (binary != NULL)

--- a/src/formats.c
+++ b/src/formats.c
@@ -1082,7 +1082,8 @@ static char *fmt_self_test_body(struct fmt_main *format,
 		// @loverszhaokai needs to look at a re-do of the function.  The 'blind' casing fails
 		// when there are constant strings, or things like user names embedded in the hash,
 		// or other non-hex strings.
-		if (full_lvl > 0)
+		// Fixed the function,  Dec 13, 2017.  Jfoug.  Changed to function with --test-full=0
+		if (full_lvl >= 0)
 		if (!fmt_split_case && format->params.binary_size != 0 && is_change_case && is_need_unify_case) {
 			snprintf(s_size, sizeof(s_size),
 				"should unify cases in split() and set FMT_SPLIT_UNIFIES_CASE (#3)");
@@ -1464,42 +1465,46 @@ static void test_fmt_split_unifies_case_3(struct fmt_main *format,
 	// Lower case
 	strlwr(cipher_copy + index);
 
-	if (strcmp(cipher_copy, ciphertext))
-	if (format->methods.valid(cipher_copy, format)) {
+	if (strcmp(cipher_copy, ciphertext)) {
+		if (format->methods.valid(cipher_copy, format)) {
 
-		*has_change_case = 1;
-		split_ret = format->methods.split(cipher_copy, 0, format);
-		if (strcmp(cipher_copy, ciphertext))
-			*is_need_unify_case = 0;
-		binary = format->methods.binary(split_ret);
+			*has_change_case = 1;
+			split_ret = format->methods.split(cipher_copy, 0, format);
+			if (!strcmp(split_ret, ciphertext))
+				*is_need_unify_case = 0;
+			binary = format->methods.binary(split_ret);
 
-		if (binary != NULL)
-		if (memcmp(orig_binary, binary, format->params.binary_size) != 0) {
-			// Do not need to unify cases in split() and add
-			// FMT_SPLIT_UNIFIES_CASE
+			if (binary != NULL)
+			if (memcmp(orig_binary, binary, format->params.binary_size) != 0) {
+				// Do not need to unify cases in split() and add
+				// FMT_SPLIT_UNIFIES_CASE
+				*is_need_unify_case = 0;
+			}
+		} else
 			*is_need_unify_case = 0;
-		}
 	}
 
 	// Upper case
 	strupr(cipher_copy + index);
 
-	if (strcmp(cipher_copy, ciphertext))
-	if (format->methods.valid(cipher_copy, format)) {
+	if (strcmp(cipher_copy, ciphertext)) {
+		if (format->methods.valid(cipher_copy, format)) {
 
-		*has_change_case = 1;
-		split_ret = format->methods.split(cipher_copy, 0, format);
-		if (strcmp(cipher_copy, ciphertext))
-			*is_need_unify_case = 0;
-		binary = format->methods.binary(split_ret);
+			*has_change_case = 1;
+			split_ret = format->methods.split(cipher_copy, 0, format);
+			if (!strcmp(split_ret, ciphertext))
+				*is_need_unify_case = 0;
+			binary = format->methods.binary(split_ret);
 
-		if (binary != NULL)
-		if (memcmp(orig_binary, binary, format->params.binary_size) != 0) {
-			// Do not need to unify cases in split() and add
-			// FMT_SPLIT_UNIFIES_CASE
+			if (binary != NULL)
+			if (memcmp(orig_binary, binary, format->params.binary_size) != 0) {
+				// Do not need to unify cases in split() and add
+				// FMT_SPLIT_UNIFIES_CASE
+				*is_need_unify_case = 0;
+			}
+		} else
 			*is_need_unify_case = 0;
-		}
-	}
+	} 
 
 	MEM_FREE(orig_salt);
 	MEM_FREE(orig_binary);

--- a/src/formats.c
+++ b/src/formats.c
@@ -1083,7 +1083,9 @@ static char *fmt_self_test_body(struct fmt_main *format,
 		// when there are constant strings, or things like user names embedded in the hash,
 		// or other non-hex strings.
 		// Fixed the function,  Dec 13, 2017.  Jfoug.  Changed to function with --test-full=0
-		if (full_lvl >= 0)
+		// However, there is one format which has not been fixed. That is the dynamic
+		// compiler.  So the --test-full=1 level has been kept for this functionality.
+		if (full_lvl > 0)
 		if (!fmt_split_case && format->params.binary_size != 0 && is_change_case && is_need_unify_case) {
 			snprintf(s_size, sizeof(s_size),
 				"should unify cases in split() and set FMT_SPLIT_UNIFIES_CASE (#3)");
@@ -1504,7 +1506,7 @@ static void test_fmt_split_unifies_case_3(struct fmt_main *format,
 			}
 		} else
 			*is_need_unify_case = 0;
-	} 
+	}
 
 	MEM_FREE(orig_salt);
 	MEM_FREE(orig_binary);

--- a/src/formats.c
+++ b/src/formats.c
@@ -1083,9 +1083,7 @@ static char *fmt_self_test_body(struct fmt_main *format,
 		// when there are constant strings, or things like user names embedded in the hash,
 		// or other non-hex strings.
 		// Fixed the function,  Dec 13, 2017.  Jfoug.  Changed to function with --test-full=0
-		// However, there is one format which has not been fixed. That is the dynamic
-		// compiler.  So the --test-full=1 level has been kept for this functionality.
-		if (full_lvl > 0)
+		if (full_lvl >= 0)
 		if (!fmt_split_case && format->params.binary_size != 0 && is_change_case && is_need_unify_case) {
 			snprintf(s_size, sizeof(s_size),
 				"should unify cases in split() and set FMT_SPLIT_UNIFIES_CASE (#3)");

--- a/src/palshop_fmt_plug.c
+++ b/src/palshop_fmt_plug.c
@@ -93,7 +93,9 @@ static int valid(char *ciphertext, struct fmt_main *self)
 
 	if (!p)
 		return 0;
-	if (!ishex_oddOK(p))
+	if (!ishexlc(p+1))
+		return 0;
+	if ( !((*p >= '0' && *p<= '9') || (*p >= 'a' && *p<= 'f') ) ) // first byte (was skipped in the hexlc call.
 		return 0;
 
 	if (strlen(p) != CIPHERTEXT_LENGTH)


### PR DESCRIPTION
This has been a LONG standing issue (in the test_fmt_split_unifies_case_3() function) which gave this error:

```
FAILED (should unify cases in split() and set FMT_SPLIT_UNIFIES_CASE (#3))
```

Due to the false positives, we have moved that logic from --test-full=0 and placed it into --test-full=1 so that the build bots would work.  Well with this fix, all of the false pos are gone. The one REAL problem (dyna_compiler) has been fixed, by making split deal with case.

The first patch does NOT move it back into --test-full=0.  I want to run on build bots first.  Once they are all happy, I will put a 2nd fix out that will move this logic from --test-full=1 and place it into --test-full=0 and make sure the build bots are happy still.  Once that happens we can merge.