### PR TITLE
Fix for non SIMD builds

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -730,6 +730,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -840,6 +841,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1092,6 +1094,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1229,7 +1240,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -17414,6 +17425,8 @@ fi
 
 if test -n "$SIMD_NAME"; then
    CPU_NAME="$host_cpu $SIMD_NAME"
+else
+   CPU_NAME=$host_cpu
 fi
 
 # Ensure reports of tests does not show up blank:

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1173,6 +1173,8 @@ fi
 
 if test -n "$SIMD_NAME"; then
    CPU_NAME="$host_cpu $SIMD_NAME"
+else
+   CPU_NAME=$host_cpu
 fi
 
 # Ensure reports of tests does not show up blank:


### PR DESCRIPTION
In non SIMD builds, it is printing nothing where the CPU name is expected.

```
Target CPU ................................. , 64-bit LE
```

****
Well, to make things clear, maybe:
```
if test -n "$SIMD_NAME"; then
   CPU_NAME="$host_cpu $SIMD_NAME"
else
   CPU_NAME="$host_cpu no-SIMD"
fi
```