### PR TITLE
Assorted code cleanups

### DIFF
--- a/src/AzureAD_fmt_plug.c
+++ b/src/AzureAD_fmt_plug.c
@@ -80,12 +80,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc_align(self->params.max_keys_per_crypt,
 	                             sizeof(*saved_key), MEM_ALIGN_WORD);

--- a/src/BFEgg_fmt_plug.c
+++ b/src/BFEgg_fmt_plug.c
@@ -16,12 +16,7 @@ john_register_one(&fmt_BFEgg);
 
 #include <string.h>
 
-#include "misc.h"
-#include "formats.h"
-#include "common.h"
-#include "blowfish.c"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 // Tuning on AMD A8 4500M laptop, cygwin64 with OMP(4x) -test=5
 // 4   = 44330 (original)
@@ -39,26 +34,27 @@ static int omp_t = 1;
 #define OMP_SCALE               128
 #endif
 #endif
+
+#include "misc.h"
+#include "formats.h"
+#include "common.h"
+#include "blowfish.c"
 #include "memdbg.h"
 
-#define FORMAT_LABEL			"bfegg"
-#define FORMAT_NAME			"Eggdrop"
-#define ALGORITHM_NAME			"Blowfish 32/" ARCH_BITS_STR
-
-#define BENCHMARK_COMMENT		""
-#define BENCHMARK_LENGTH		-1
-
-#define PLAINTEXT_MIN_LENGTH		1
-#define PLAINTEXT_LENGTH		72
-#define CIPHERTEXT_LENGTH		13
-
-#define BINARY_SIZE			7
-#define BINARY_ALIGN			4
-#define SALT_SIZE			0
-#define SALT_ALIGN			1
-
-#define MIN_KEYS_PER_CRYPT		1
-#define MAX_KEYS_PER_CRYPT		1
+#define FORMAT_LABEL            "bfegg"
+#define FORMAT_NAME             "Eggdrop"
+#define ALGORITHM_NAME          "Blowfish 32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_MIN_LENGTH    1
+#define PLAINTEXT_LENGTH        72
+#define CIPHERTEXT_LENGTH       13
+#define BINARY_SIZE             7
+#define BINARY_ALIGN            4
+#define SALT_SIZE               0
+#define SALT_ALIGN              1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 
 static struct fmt_tests tests[] = {
     {"+9F93o1OxwgK1", "123456"},
@@ -99,10 +95,13 @@ void init(struct fmt_main *self) {
 	const char *pos;
 
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/DMD5_fmt_plug.c
+++ b/src/DMD5_fmt_plug.c
@@ -120,9 +120,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       PLAINTEXT_LENGTH + 1);

--- a/src/DOMINOSEC8_fmt_plug.c
+++ b/src/DOMINOSEC8_fmt_plug.c
@@ -49,7 +49,6 @@ john_register_one(&fmt_DOMINOSEC8);
 #undef SIMD_COEF_32
 #include "pbkdf2_hmac_sha1.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               128
@@ -177,10 +176,13 @@ static struct fmt_tests tests[] = {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));
 	crypt_out = mem_calloc(self->params.max_keys_per_crypt, sizeof(*crypt_out));

--- a/src/DOMINOSEC_fmt_plug.c
+++ b/src/DOMINOSEC_fmt_plug.c
@@ -38,7 +38,6 @@ john_register_one(&fmt_DOMINOSEC);
 #include "formats.h"
 #include "common.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               128
@@ -164,10 +163,13 @@ static struct fmt_tests tests[] = {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/EPI_fmt_plug.c
+++ b/src/EPI_fmt_plug.c
@@ -70,9 +70,12 @@ static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	key_len   = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*key_len));

--- a/src/FGT_fmt_plug.c
+++ b/src/FGT_fmt_plug.c
@@ -71,8 +71,6 @@ john_register_one(&fmt_FGT);
 #define MIN_KEYS_PER_CRYPT		1
 #define MAX_KEYS_PER_CRYPT		1
 
-
-
 static struct fmt_tests fgt_tests[] =
 {
 	{"AK1wTiFOMv7mZOTvQNmKQBAY98hZZjSRLxAY8vZp8NlDWU=", "fortigate"},
@@ -90,12 +88,13 @@ static uint32_t (*crypt_key)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = 1;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/HDAA_fmt_plug.c
+++ b/src/HDAA_fmt_plug.c
@@ -160,9 +160,12 @@ static void init(struct fmt_main *self)
 #endif
 #if defined (_OPENMP)
 	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_32
 	for (i = 0; i < LIMBS; i++)

--- a/src/KRB5_fmt_plug.c
+++ b/src/KRB5_fmt_plug.c
@@ -1,23 +1,18 @@
 /*
- * KRB5_fmt.c
- *
- *  Kerberos 5 module for John the Ripper, based on the
- *  KRB4 module by Dug Song.
+ * Kerberos 5 module for John the Ripper, based on the
+ * KRB4 module by Dug Song.
  *
  * Author: Nasko Oskov <nasko at netsekure.org>
  *
  * Licensing:
  *
- *  The module contains code derived or copied from the Heimdal project.
+ *  The module contains code derived or copied from the Heimdal project, which
+ *  is distribution of Kerberos based on M.I.T. implementation.
  *
- *  Copyright (c) 1997-2000 Kungliga Tekniska Högskolan
- *  (Royal Institute of Technology, Stockholm, Sweden).
- *  All rights reserved.
+ *  Copyright (c) 1997-2000 Kungliga Tekniska Högskolan (Royal Institute of
+ *  Technology, Stockholm, Sweden). All rights reserved.
  *
- *  Which is distribution of Kerberos based on M.I.T. implementation.
- *
- *  Copyright (C) 1990 by the Massachusetts Institute of Technology
- *
+ *  Copyright (C) 1990 by the Massachusetts Institute of Technology.
  */
 
 #if FMT_EXTERNS_H
@@ -26,33 +21,18 @@ extern struct fmt_main fmt_KRB5;
 john_register_one(&fmt_KRB5);
 #else
 
-#if AC_BUILT
-#include "autoconfig.h"
-#endif
-
+#include <ctype.h> // required
 #include <stdlib.h>
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#if !AC_BUILT || HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
-#include <errno.h>
-
 #include <string.h>
 #include <openssl/des.h>
 
-#include <ctype.h>
-
 #include "arch.h"
 #include "misc.h"
-#include "formats.h"    // needed for format structs
+#include "formats.h"
 #include "memory.h"
 #include "KRB5_std.h"
 #include "memdbg.h"
 
-
-// defines
 #define MAGIC_PREFIX        "$krb5$"
 #define MAGIC_PREFIX_LEN    (sizeof(MAGIC_PREFIX)-1)
 #define MAX_REALM_LEN       64

--- a/src/NETLM_fmt_plug.c
+++ b/src/NETLM_fmt_plug.c
@@ -108,9 +108,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/NETLMv2_fmt_plug.c
+++ b/src/NETLMv2_fmt_plug.c
@@ -115,9 +115,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,
 	                         sizeof(*saved_plain));

--- a/src/NETNTLMv2_fmt_plug.c
+++ b/src/NETNTLMv2_fmt_plug.c
@@ -121,9 +121,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,
 	                         sizeof(*saved_plain));

--- a/src/NETSPLITLM_fmt_plug.c
+++ b/src/NETSPLITLM_fmt_plug.c
@@ -89,9 +89,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,
 	                         sizeof(*saved_plain));

--- a/src/SybaseASE_fmt_plug.c
+++ b/src/SybaseASE_fmt_plug.c
@@ -118,9 +118,12 @@ static void init(struct fmt_main *self)
 #endif
 #ifdef _OPENMP
 	i = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= i;
-	i *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= i;
+
+	if (i > 1) {
+		self->params.min_keys_per_crypt *= i;
+		i *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= i;
+	}
 #endif
 	kpc = self->params.max_keys_per_crypt;
 

--- a/src/SybasePROP_fmt_plug.c
+++ b/src/SybasePROP_fmt_plug.c
@@ -35,7 +35,6 @@ john_register_one(&fmt_sybaseprop);
 #ifndef OMP_SCALE
 #define OMP_SCALE           16
 #endif
-static int omp_t = 1;
 #endif
 
 #include "memdbg.h"
@@ -78,7 +77,8 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
+	int omp_t = omp_get_max_threads();
+
 	if (omp_t > 1) {
 		self->params.min_keys_per_crypt *= omp_t;
 		omp_t *= OMP_SCALE;

--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -83,9 +83,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_64
 #ifndef _OPENMP

--- a/src/agilekeychain_fmt_plug.c
+++ b/src/agilekeychain_fmt_plug.c
@@ -1,4 +1,5 @@
-/* 1Password Agile Keychain cracker patch for JtR. Hacked together during
+/*
+ * 1Password Agile Keychain cracker patch for JtR. Hacked together during
  * July of 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
@@ -9,7 +10,7 @@
  * This software is based on "agilekeychain" project but no actual code is
  * borrowed from it.
  *
- * "agilekeychain" project is at https://bitbucket.org/gwik/agilekeychain
+ * "agilekeychain" project is at https://bitbucket.org/gwik/agilekeychain.
  */
 
 #if FMT_EXTERNS_H
@@ -19,7 +20,7 @@ john_register_one(&fmt_agile_keychain);
 #else
 
 #include <string.h>
-#include <errno.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
@@ -32,35 +33,35 @@ john_register_one(&fmt_agile_keychain);
 #include "common.h"
 #include "formats.h"
 #include "params.h"
-#include "johnswap.h"
 #include "options.h"
-#include "pbkdf2_hmac_sha1.h"
 #include "aes.h"
 #include "jumbo.h"
+#include "johnswap.h"
+#include "pbkdf2_hmac_sha1.h"
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"agilekeychain"
-#define FORMAT_NAME		"1Password Agile Keychain"
-#define FORMAT_TAG           "$agilekeychain$"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
+#define FORMAT_LABEL            "agilekeychain"
+#define FORMAT_NAME             "1Password Agile Keychain"
+#define FORMAT_TAG              "$agilekeychain$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
 #ifdef SIMD_COEF_32
-#define ALGORITHM_NAME		"PBKDF2-SHA1 AES " SHA1_ALGORITHM_NAME
+#define ALGORITHM_NAME          "PBKDF2-SHA1 AES " SHA1_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME		"PBKDF2-SHA1 AES 32/" ARCH_BITS_STR
+#define ALGORITHM_NAME          "PBKDF2-SHA1 AES 32/" ARCH_BITS_STR
 #endif
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define BINARY_SIZE		0
-#define BINARY_ALIGN		1
-#define SALT_ALIGN		sizeof(int)
-#define PLAINTEXT_LENGTH	125
-#define SALT_SIZE		sizeof(struct custom_salt)
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define BINARY_SIZE             0
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              sizeof(int)
+#define PLAINTEXT_LENGTH        125
+#define SALT_SIZE               sizeof(struct custom_salt)
 #ifdef SIMD_COEF_32
-#define MIN_KEYS_PER_CRYPT  SSE_GROUP_SZ_SHA1
-#define MAX_KEYS_PER_CRYPT  SSE_GROUP_SZ_SHA1
+#define MIN_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA1
+#define MAX_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA1
 #else
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 #endif
 
 #define SALTLEN 8
@@ -92,12 +93,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = 1;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),
 			self->params.max_keys_per_crypt, MEM_ALIGN_WORD);
@@ -285,7 +287,7 @@ static int cmp_one(void *binary, int index)
 
 static int cmp_exact(char *source, int index)
 {
-    return 1;
+	return 1;
 }
 
 static void agile_keychain_set_key(char *key, int index)

--- a/src/androidfde_fmt_plug.c
+++ b/src/androidfde_fmt_plug.c
@@ -1,10 +1,9 @@
-/* androidfde.c
+/*
+ * This code is based on androidfde.c file from hashkill (a hash cracking tool)
+ * project. Copyright (C) 2010 Milen Rangelov <gat3way@gat3way.eu>.
  *
- * hashkill - a hash cracking tool
- * Copyright (C) 2010 Milen Rangelov <gat3way@gat3way.eu>
- *
- * Modified for JtR and made stuff more generic
- * This software is Copyright (c) 2013 Dhiru Kholia <dhiru at openwall.com>
+ * Modified for JtR and made stuff more generic - Dhiru.
+ * This software is Copyright (c) 2013 Dhiru Kholia <dhiru at openwall.com>.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,15 +29,10 @@ john_register_one(&fmt_fde);
 
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
-#include "os.h"
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/types.h>
-#include <string.h>
+
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE           1
@@ -71,8 +65,8 @@ static int omp_t = 1;
 #define PLAINTEXT_LENGTH    64
 #define BENCHMARK_LENGTH    -1
 #define BINARY_SIZE         0
-#define BINARY_ALIGN		1
-#define SALT_ALIGN			8
+#define BINARY_ALIGN        1
+#define SALT_ALIGN          8
 #define SALT_SIZE           sizeof(struct custom_salt)
 #ifdef SIMD_COEF_32
 #define MIN_KEYS_PER_CRYPT  SSE_GROUP_SZ_SHA1
@@ -107,10 +101,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	max_cracked = self->params.max_keys_per_crypt;
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
@@ -233,7 +230,7 @@ static void AES_cbc_essiv(unsigned char *src, unsigned char *dst, unsigned char 
 	AES_cbc_encrypt(src, dst, size, &aeskey, essiv, AES_DECRYPT);
 }
 
-//		cracked[index] = hash_plugin_check_hash(saved_key[index]);
+// cracked[index] = hash_plugin_check_hash(saved_key[index]);
 void hash_plugin_check_hash(int index)
 {
 	unsigned char keycandidate2[255];

--- a/src/as400_des_fmt_plug.c
+++ b/src/as400_des_fmt_plug.c
@@ -1,15 +1,21 @@
-// AS/400 DES plugin for JtR
-// This software is Copyright (c) 2016 Rob Schoemaker (@5up3rUs3r) and Bart Kulach (@bartholozz)
-// and it is hereby released to the general public under the following terms:
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted.
-//
-// See http://www.hackthelegacy.org for details and tooling to retrieve hashes from AS/400 systems
-//
-// Based on RACF cracker patch for JtR by Dhiru Kholia <dhiru.kholia at gmail.com>,
-// Nigel Pentland <nigel at nigelpentland.net> and Main Framed <mainframed767 at gmail.com>.
-//
-// file format => userid:$as400des$*userid*hash
+/*
+ * AS/400 DES plugin for JtR.
+ *
+ * This software is Copyright (c) 2016 Rob Schoemaker (@5up3rUs3r) and Bart
+ * Kulach (@bartholozz) and it is hereby released to the general public under
+ * the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * See http://www.hackthelegacy.org for details and tooling to retrieve hashes
+ * from AS/400 systems.
+ *
+ * Based on RACF cracker patch for JtR by Dhiru Kholia <dhiru.kholia at gmail.com>, and
+ * Nigel Pentland <nigel at nigelpentland.net> and Main Framed <mainframed767 at gmail.com>.
+ *
+ * Hash format => userid:$as400des$*userid*hash
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_as400des;
@@ -17,10 +23,9 @@ extern struct fmt_main fmt_as400des;
 john_register_one(&fmt_as400des);
 #else
 
-#include <openssl/des.h>
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+#include <openssl/des.h>
+
 #include "arch.h"
 #include "crc32.h"
 #include "misc.h"
@@ -128,7 +133,6 @@ static void process_userid(unsigned char *str)
 		str[8] = 0; /* terminate string */
 	}
 }
-
 
 static struct fmt_tests as400_des_tests[] = {
 	{"$as400des$AAAAAAA*CA2E330B2FD1820E", "AAAAAAAA"},
@@ -305,6 +309,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 static int cmp_all(void *binary, int count)
 {
 	int index = 0;
+
 	for (; index < count; index++)
 		if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
 			return 1;

--- a/src/axcrypt_fmt_plug.c
+++ b/src/axcrypt_fmt_plug.c
@@ -1,10 +1,13 @@
-/* AxCrypt 1.x encrypted files cracker patch for JtR
- * 2016 by Fist0urs <eddy.maaalou at gmail.com>.
+/*
+ * AxCrypt 1.x encrypted files cracker patch for JtR.
+ * Written in 2016 by Fist0urs <eddy.maaalou at gmail.com>.
  *
  * This software is Copyright (c) 2016, Fist0urs <eddy.maaalou at gmail.com>,
  * and it is hereby released to the general public under the following terms:
+ *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
+ * are permitted.
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_axcrypt;
@@ -14,8 +17,14 @@ john_register_one(&fmt_axcrypt);
 
 #include <string.h>
 #include <stdint.h>
-#include <assert.h>
-#include <errno.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#ifndef OMP_SCALE
+#define OMP_SCALE               1
+#endif
+#endif
+
 #include "arch.h"
 #include "misc.h"
 #include "common.h"
@@ -25,30 +34,24 @@ john_register_one(&fmt_axcrypt);
 #include "dyna_salt.h"
 #include "sha.h"
 #include "aes.h"
-#ifdef _OPENMP
-#include <omp.h>
-#ifndef OMP_SCALE
-#define OMP_SCALE		1
-#endif
-#endif
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"axcrypt"
-#define FORMAT_NAME		"AxCrypt"
-#define FORMAT_TAG		"$axcrypt$*"
-#define FORMAT_TAG_LEN	(sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME		"SHA1 AES 32/" ARCH_BITS_STR
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	125 /* actual max is 250 */
-#define BINARY_SIZE		0
-#define SALT_SIZE		sizeof(struct custom_salt *)
-#define BINARY_ALIGN		MEM_ALIGN_NONE
-#define SALT_ALIGN		sizeof(struct custom_salt *)
+#define FORMAT_LABEL            "axcrypt"
+#define FORMAT_NAME             "AxCrypt"
+#define FORMAT_TAG              "$axcrypt$*"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "SHA1 AES 32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        125 /* actual max is 250 */
+#define BINARY_SIZE             0
+#define SALT_SIZE               sizeof(struct custom_salt *)
+#define BINARY_ALIGN            MEM_ALIGN_NONE
+#define SALT_ALIGN              sizeof(struct custom_salt *)
 /* constant value recommended by FIPS */
-#define AES_WRAPPING_IV		"\xA6\xA6\xA6\xA6\xA6\xA6\xA6\xA6"
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define AES_WRAPPING_IV         "\xA6\xA6\xA6\xA6\xA6\xA6\xA6\xA6"
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 
 #define PUT_64BITS_XOR_MSB(cp, value) ( \
 		(cp)[0] ^= (unsigned char)((value)), \
@@ -58,9 +61,9 @@ john_register_one(&fmt_axcrypt);
 
 static struct fmt_tests axcrypt_tests[] = {
 	/*
-		formats can be:
-		$axcrypt$*version*iterations*salt*wrappedkey
-		$axcrypt$*version*iterations*salt*wrappedkey*key-file
+	 * Formats can be,
+	 *   $axcrypt$*version*iterations*salt*wrappedkey
+	 *   $axcrypt$*version*iterations*salt*wrappedkey*key-file
 	*/
 	{"$axcrypt$*1*1337*0fd9e7e2f907f480f8af162564f8f94b*af10c88878ba4e2c89b12586f93b7802453121ee702bc362", "Bab00nmoNCo|\\|2$inge"},
 	{"$axcrypt$*1*60000*7522aa07694d441e47f8faad8a8cb984*95e02b7ccbdc27c227a80d1307505d8b769e87b32f312aa1", "nuNuche<3rewshauv"},
@@ -88,11 +91,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 				sizeof(*saved_key));
@@ -216,9 +221,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #endif
 	{
 		/*
-			NUMBER_AES_BLOCKS = 2
-			AES_BLOCK_SIZE = 16
-		*/
+		 * NUMBER_AES_BLOCKS = 2
+		 * AES_BLOCK_SIZE = 16
+		 */
 
 		unsigned char KEK[20], lsb[24], cipher[16];
 		AES_KEY akey;
@@ -273,6 +278,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			any_cracked |= 1;
 		}
 	}
+
 	return count;
 }
 

--- a/src/bestcrypt_fmt_plug.c
+++ b/src/bestcrypt_fmt_plug.c
@@ -131,11 +131,13 @@ static int *cracked, cracked_count;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -30,7 +30,6 @@ john_register_one(&fmt_bitcoin);
 #ifndef OMP_SCALE
 #define OMP_SCALE               1
 #endif
-static int omp_t = 1;
 #endif
 
 #include "arch.h"
@@ -115,10 +114,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),
 			self->params.max_keys_per_crypt, MEM_ALIGN_WORD);

--- a/src/bks_fmt_plug.c
+++ b/src/bks_fmt_plug.c
@@ -89,11 +89,13 @@ static int *cracked, any_cracked;  // "cracked array" approach is required for U
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*saved_key));

--- a/src/chap_fmt_plug.c
+++ b/src/chap_fmt_plug.c
@@ -29,7 +29,6 @@ john_register_one(&fmt_chap);
 #include <string.h>
 
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifdef __MIC__
 #ifndef OMP_SCALE
@@ -92,10 +91,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/citrix_ns_fmt_plug.c
+++ b/src/citrix_ns_fmt_plug.c
@@ -115,12 +115,13 @@ static uint32_t (*crypt_key)[BINARY_SIZE / 4];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_32
 	saved_key = mem_calloc_align(self->params.max_keys_per_crypt / NBKEYS,

--- a/src/clipperz_srp_fmt_plug.c
+++ b/src/clipperz_srp_fmt_plug.c
@@ -149,9 +149,12 @@ static void init(struct fmt_main *self)
 	int i;
 #if defined (_OPENMP)
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),
 			self->params.max_keys_per_crypt, MEM_ALIGN_WORD);

--- a/src/cq_fmt_plug.c
+++ b/src/cq_fmt_plug.c
@@ -337,9 +337,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),
 		self->params.max_keys_per_crypt, MEM_ALIGN_WORD);

--- a/src/crypt-sha1_fmt_plug.c
+++ b/src/crypt-sha1_fmt_plug.c
@@ -87,9 +87,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/dahua_fmt_plug.c
+++ b/src/dahua_fmt_plug.c
@@ -79,9 +79,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/dashlane_fmt_plug.c
+++ b/src/dashlane_fmt_plug.c
@@ -80,9 +80,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);

--- a/src/django_scrypt_fmt_plug.c
+++ b/src/django_scrypt_fmt_plug.c
@@ -24,7 +24,6 @@ john_register_one(&fmt_django_scrypt);
 #include "base64_convert.h"
 #include "escrypt/crypto_scrypt.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               1 // So slow a format, a multiplier is NOT needed
@@ -79,10 +78,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/dmg_fmt_plug.c
+++ b/src/dmg_fmt_plug.c
@@ -52,7 +52,7 @@ john_register_one(&fmt_dmg);
 #endif
 
 #include <string.h>
-#include <errno.h>
+#include <errno.h> // required
 #if !AC_BUILT || HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
@@ -121,9 +121,6 @@ extern volatile int bench_running;
 		((((unsigned long)(n) & 0xFF0000)) >> 8) | \
 		((((unsigned long)(n) & 0xFF000000)) >> 24))
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *cracked, cracked_count;
 
@@ -151,10 +148,13 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),
 			self->params.max_keys_per_crypt, MEM_ALIGN_WORD);

--- a/src/dragonfly3_fmt_plug.c
+++ b/src/dragonfly3_fmt_plug.c
@@ -91,12 +91,13 @@ static int salt_len;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_len));

--- a/src/dragonfly4_fmt_plug.c
+++ b/src/dragonfly4_fmt_plug.c
@@ -90,12 +90,13 @@ static int salt_len;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_len));

--- a/src/drupal7_fmt_plug.c
+++ b/src/drupal7_fmt_plug.c
@@ -96,12 +96,13 @@ static char (*crypt_key)[DIGEST_SIZE];
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	EncKey    = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*EncKey));

--- a/src/eigrp_fmt_plug.c
+++ b/src/eigrp_fmt_plug.c
@@ -98,9 +98,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/electrum_fmt_plug.c
+++ b/src/electrum_fmt_plug.c
@@ -113,9 +113,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);

--- a/src/encfs_fmt_plug.c
+++ b/src/encfs_fmt_plug.c
@@ -94,11 +94,13 @@ static void init(struct fmt_main *self)
 		self->params.flags &= ~FMT_OMP;
 	}
 	else {
-		int omp_t = 1;
-		omp_t = omp_get_max_threads();
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+		int omp_t = omp_get_max_threads();
+
+		if (omp_t > 1) {
+			self->params.min_keys_per_crypt *= omp_t;
+			omp_t *= OMP_SCALE;
+			self->params.max_keys_per_crypt *= omp_t;
+		}
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/ethereum_fmt_plug.c
+++ b/src/ethereum_fmt_plug.c
@@ -74,9 +74,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/fvde_fmt_plug.c
+++ b/src/fvde_fmt_plug.c
@@ -1,4 +1,5 @@
-/* JtR format to crack FileVault 2 hashes.
+/*
+ * JtR format to crack FileVault 2 hashes.
  *
  * This software is Copyright (c) 2017, Dhiru Kholia <kholia at kth.se> and it
  * is hereby released to the general public under the following terms:
@@ -17,8 +18,7 @@ john_register_one(&fmt_fvde);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
@@ -36,8 +36,8 @@ john_register_one(&fmt_fvde);
 #include "aes.h"
 #include "pbkdf2_hmac_sha256.h"
 #include "jumbo.h"
-#include "memdbg.h"
 #include "fvde_common.h"
+#include "memdbg.h"
 
 #define FORMAT_LABEL            "FVDE"
 #define FORMAT_NAME             "FileVault 2"
@@ -65,9 +65,6 @@ john_register_one(&fmt_fvde);
 #define MAX_KEYS_PER_CRYPT      1
 #endif
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *cracked, cracked_count;
 static fvde_custom_salt *cur_salt;
@@ -76,10 +73,13 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);

--- a/src/geli_fmt_plug.c
+++ b/src/geli_fmt_plug.c
@@ -57,9 +57,6 @@ john_register_one(&fmt_geli);
 #define MAX_KEYS_PER_CRYPT      1
 #endif
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *cracked, cracked_count;
 static custom_salt *cur_salt;
@@ -68,10 +65,13 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);

--- a/src/gpg_fmt_plug.c
+++ b/src/gpg_fmt_plug.c
@@ -30,7 +30,6 @@ john_register_one(&fmt_gpg);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <stdint.h>
 
 #ifdef _OPENMP
@@ -62,10 +61,6 @@ john_register_one(&fmt_gpg);
 #define MIN_KEYS_PER_CRYPT  1
 #define MAX_KEYS_PER_CRYPT  1
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
-
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *cracked;
 static int any_cracked;
@@ -74,10 +69,13 @@ static size_t cracked_size;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),
 			self->params.max_keys_per_crypt, MEM_ALIGN_WORD);

--- a/src/has160_fmt_plug.c
+++ b/src/has160_fmt_plug.c
@@ -1,4 +1,5 @@
-/* HAS160-512 cracker patch for JtR. Hacked together during May, 2015
+/*
+ * HAS160-512 cracker patch for JtR. Hacked together during May, 2015
  * by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * Thanks for RHash, http://www.randombit.net/has160.html and
@@ -27,9 +28,9 @@ john_register_one(&fmt__HAS160);
 #ifdef _OPENMP
 #ifndef OMP_SCALE
 #ifdef __MIC__
-#define OMP_SCALE           64
+#define OMP_SCALE                       64
 #else
-#define OMP_SCALE			2048
+#define OMP_SCALE                       2048
 #endif // __MIC__
 #endif // OMP_SCALE
 #include <omp.h>
@@ -37,21 +38,21 @@ john_register_one(&fmt__HAS160);
 
 #include "memdbg.h"
 
-#define FORMAT_LABEL			"has-160"
-#define FORMAT_NAME			""
-#define ALGORITHM_NAME			"HAS-160 32/" ARCH_BITS_STR
+#define FORMAT_LABEL                    "has-160"
+#define FORMAT_NAME                     ""
+#define ALGORITHM_NAME                  "HAS-160 32/" ARCH_BITS_STR
 
-#define BENCHMARK_COMMENT		""
-#define BENCHMARK_LENGTH		-1
+#define BENCHMARK_COMMENT               ""
+#define BENCHMARK_LENGTH                -1
 
-#define PLAINTEXT_LENGTH		125
-#define CIPHERTEXT_LENGTH		40
-#define BINARY_SIZE			20
-#define SALT_SIZE			0
-#define BINARY_ALIGN			4
-#define SALT_ALIGN			1
-#define MIN_KEYS_PER_CRYPT		1
-#define MAX_KEYS_PER_CRYPT		1
+#define PLAINTEXT_LENGTH                125
+#define CIPHERTEXT_LENGTH               40
+#define BINARY_SIZE                     20
+#define SALT_SIZE                       0
+#define BINARY_ALIGN                    4
+#define SALT_ALIGN                      1
+#define MIN_KEYS_PER_CRYPT              1
+#define MAX_KEYS_PER_CRYPT              1
 
 static struct fmt_tests tests[] = {
 	{"307964ef34151d37c8047adec7ab50f4ff89762d", ""},
@@ -71,12 +72,13 @@ static uint32_t (*crypt_out)[(BINARY_SIZE) / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));
 	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));
@@ -130,6 +132,7 @@ static void set_key(char *key, int index)
 static char *get_key(int index)
 {
 	saved_key[index][saved_len[index]] = 0;
+
 	return saved_key[index];
 }
 
@@ -154,6 +157,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 static int cmp_all(void *binary, int count)
 {
 	int index = 0;
+
 	for (; index < count; index++)
 		if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
 			return 1;

--- a/src/haval_fmt_plug.c
+++ b/src/haval_fmt_plug.c
@@ -30,7 +30,6 @@ john_register_one(&fmt_haval_128_4);
 #endif
 
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 // Tuned on core i7 quad HT
 //       256-3  128-4
@@ -98,10 +97,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE256 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	if (!saved_key) {
 		saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/hmacMD5_fmt_plug.c
+++ b/src/hmacMD5_fmt_plug.c
@@ -132,9 +132,12 @@ static void init(struct fmt_main *self)
 #endif
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_32
 	bufsize = sizeof(*opad) * self->params.max_keys_per_crypt * PAD_SIZE;

--- a/src/hmacSHA1_fmt_plug.c
+++ b/src/hmacSHA1_fmt_plug.c
@@ -116,9 +116,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_32
 	bufsize = sizeof(*opad) * self->params.max_keys_per_crypt * SHA_BUF_SIZ * 4;

--- a/src/hmacSHA256_fmt_plug.c
+++ b/src/hmacSHA256_fmt_plug.c
@@ -142,9 +142,12 @@ static void init(struct fmt_main *self, const int B_LEN)
 #endif
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_32
 	bufsize = sizeof(*opad) * self->params.max_keys_per_crypt * PAD_SIZE;

--- a/src/hmacSHA512_fmt_plug.c
+++ b/src/hmacSHA512_fmt_plug.c
@@ -148,9 +148,12 @@ static void init(struct fmt_main *self, const int B_LEN)
 #endif
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_64
 	bufsize = sizeof(*opad) * self->params.max_keys_per_crypt * PAD_SIZE;

--- a/src/hsrp_fmt_plug.c
+++ b/src/hsrp_fmt_plug.c
@@ -92,9 +92,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/ike_fmt_plug.c
+++ b/src/ike_fmt_plug.c
@@ -1,4 +1,5 @@
-/* PSK cracker patch for JtR. Hacked together during March of 2012 by
+/*
+ * PSK cracker patch for JtR. Hacked together during March of 2012 by
  * Dhiru Kholia <dhiru.kholia at gmail.com> .
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
@@ -53,8 +54,14 @@ john_register_one(&fmt_ike);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#ifndef OMP_SCALE
+#define OMP_SCALE               16
+#endif
+#endif
+
 #include "arch.h"
 #include "misc.h"
 #include "common.h"
@@ -62,30 +69,23 @@ john_register_one(&fmt_ike);
 #include "params.h"
 #include "options.h"
 #include "ike-crack.h"
-#ifdef _OPENMP
-#include <omp.h>
-#ifndef OMP_SCALE
-#define OMP_SCALE               16
-#endif
-static int omp_t = 1;
-#endif
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"IKE"
-#define FORMAT_NAME		"PSK"
-#define FORMAT_TAG           "$ike$*"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME		"HMAC MD5/SHA1 32/" ARCH_BITS_STR
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	32
-#define BINARY_SIZE		20 /* SHA1 */
-#define BINARY_SIZE_SMALLER	16 /* MD5 */
-#define SALT_SIZE		sizeof(psk_entry)
-#define BINARY_ALIGN		sizeof(uint32_t)
-#define SALT_ALIGN			sizeof(size_t)
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	16
+#define FORMAT_LABEL            "IKE"
+#define FORMAT_NAME             "PSK"
+#define FORMAT_TAG              "$ike$*"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "HMAC MD5/SHA1 32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        32
+#define BINARY_SIZE             20 /* SHA1 */
+#define BINARY_SIZE_SMALLER     16 /* MD5 */
+#define SALT_SIZE               sizeof(psk_entry)
+#define BINARY_ALIGN            sizeof(uint32_t)
+#define SALT_ALIGN              sizeof(size_t)
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      16
 
 static struct fmt_tests ike_tests[] = {
 	{"$ike$*0*5c7916ddf8db4d233b3b36005bb3ccc115a73807e11a897be943fd4a2d0f942624cb00588d8b3a0a26502b73e639df217ef6c4cb90f96b0a3c3ef2f62ed025b4a705df9de65e33e380c1ba5fa23bf1f9911bbf388d0844256fa0131fc5cf8acb396936ba3295b4637b039d93f58db90a3a1cf1ef5051103bacf6e1a3334f9f89*fde8c68c5f324c7dbcbadde1d757af6962c63496c009f77cad647f2997fd4295e50821453a6dc2f6279fd7fef68768584d9cee0da6e68a534a097ce206bf77ecc798310206f3f82d92d02c885794e0a430ceb2d6b43c2aff45a6e14c6558382df0692ff65c2724eef750764ee456f31424a5ebd9e115d826bbb9722111aa4e01*b2a3c7aa4be95e85*756e3fa11c1b102c*00000001000000010000002c01010001000000240101000080010001800200018003000180040002800b0001000c000400007080*01000000ac100202*251d7ace920b17cb34f9d561bca46d037b337d19*e045819a64edbf022620bff3efdb935216584cc4*b9c594fa3fca6bb30a85c4208a8df348", "abc123"},
@@ -100,10 +100,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);
@@ -198,8 +201,10 @@ error:
 static void *get_salt(char *ciphertext)
 {
 	static psk_entry cs;
+
 	cs.isnortel = atoi(&ciphertext[FORMAT_TAG_LEN]);
 	load_psk_params(&ciphertext[FORMAT_TAG_LEN+2], NULL, &cs);
+
 	return (void *)&cs;
 }
 
@@ -212,6 +217,7 @@ static void *get_binary(char *ciphertext)
 	unsigned char *out = buf.c;
 	char *p;
 	int i;
+
 	p = strrchr(ciphertext, '*') + 1;
 	for (i = 0; i < BINARY_SIZE_SMALLER; i++) {
 		out[i] =
@@ -219,6 +225,7 @@ static void *get_binary(char *ciphertext)
 			atoi16[ARCH_INDEX(p[1])];
 		p += 2;
 	}
+
 	return out;
 }
 
@@ -244,6 +251,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 static int cmp_all(void *binary, int count)
 {
 	int index = 0;
+
 	for (; index < count; index++)
 		if (*((uint32_t*)binary) == crypt_out[index][0])
 			return 1;
@@ -270,6 +278,7 @@ static char *get_key(int index)
 {
 	return saved_key[index];
 }
+
 /*
  * For ike, the hash algorithm used for hmac
  * is returned as the first "tunable cost":
@@ -285,9 +294,8 @@ static char *get_key(int index)
 #if IKE_REPORT_TUNABLE_COSTS
 static unsigned int tunable_cost_hmac_hash_type(void *salt)
 {
-	psk_entry *my_salt;
+	psk_entry *my_salt = salt;
 
-	my_salt = salt;
 	return (unsigned int) my_salt->hash_type;
 }
 #endif

--- a/src/itunes_fmt_plug.c
+++ b/src/itunes_fmt_plug.c
@@ -1,4 +1,5 @@
-/* JtR format to crack encrypted iTunes Backup passwords.
+/*
+ * JtR format to crack encrypted iTunes Backup passwords.
  *
  * This software is Copyright (c) 2017, Dhiru Kholia <dhiru at openwall.com>
  * and it is hereby released to the general public under the following terms:
@@ -17,9 +18,8 @@ john_register_one(&fmt_itunes);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
 #include <openssl/des.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
@@ -37,8 +37,8 @@ john_register_one(&fmt_itunes);
 #include "pbkdf2_hmac_sha1.h"
 #include "pbkdf2_hmac_sha256.h"
 #include "jumbo.h"
-#include "memdbg.h"
 #include "itunes_common.h"
+#include "memdbg.h"
 
 #define FORMAT_LABEL            "itunes-backup"
 #ifdef SIMD_COEF_32
@@ -73,9 +73,6 @@ static struct fmt_tests itunes_tests[] = {
 	{NULL}
 };
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *cracked, cracked_count;
 static struct custom_salt *cur_salt;
@@ -84,10 +81,13 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);

--- a/src/iwork_fmt_plug.c
+++ b/src/iwork_fmt_plug.c
@@ -19,9 +19,8 @@ john_register_one(&fmt_iwork);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
 #include <openssl/des.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
@@ -32,14 +31,14 @@ john_register_one(&fmt_iwork);
 #include "arch.h"
 #include "misc.h"
 #include "common.h"
+#include "jumbo.h"
 #include "formats.h"
 #include "params.h"
 #include "options.h"
 #include "johnswap.h"
-#include "pbkdf2_hmac_sha1.h"
-#include "jumbo.h"
-#include "memdbg.h"
 #include "iwork_common.h"
+#include "pbkdf2_hmac_sha1.h"
+#include "memdbg.h"
 
 #define FORMAT_LABEL            "iwork"
 #define FORMAT_NAME             "Apple iWork '09 / '13 / '14"
@@ -64,21 +63,20 @@ john_register_one(&fmt_iwork);
 #define MAX_KEYS_PER_CRYPT      1
 #endif
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *cracked, cracked_count;
 static struct format_context *fctx;
 
 static void init(struct fmt_main *self)
 {
-
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);

--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2012 Dhiru Kholia <dhiru.kholia at gmail.com>,
  * Copyright (c) 2014 m3g9tr0n (Spiros Fraganastasis),
  * Copyright (c) 2016 Fist0urs <eddy.maaalou at gmail.com>, and
- * Copyright (c) 2017 magnum
+ * Copyright (c) 2017 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -26,12 +26,11 @@ john_register_one(&fmt_KeePass);
 
 #include <string.h>
 #include <stdint.h>
-#include <assert.h>
-#include <errno.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
-#define OMP_SCALE		1
+#define OMP_SCALE               1
 #endif
 #endif
 
@@ -48,9 +47,9 @@ john_register_one(&fmt_KeePass);
 #include "chacha.h"
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"KeePass"
-#define FORMAT_NAME		""
-#define ALGORITHM_NAME		"SHA256 AES 32/" ARCH_BITS_STR " " SHA2_LIB
+#define FORMAT_LABEL            "KeePass"
+#define FORMAT_NAME             ""
+#define ALGORITHM_NAME          "SHA256 AES 32/" ARCH_BITS_STR " " SHA2_LIB
 
 static keepass_salt_t *cur_salt;
 static int any_cracked, *cracked;
@@ -122,11 +121,13 @@ static void transform_key(char *masterkey, keepass_salt_t *csp,
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	keepass_key = mem_calloc(self->params.max_keys_per_crypt,
 				sizeof(*keepass_key));

--- a/src/keyring_fmt_plug.c
+++ b/src/keyring_fmt_plug.c
@@ -1,10 +1,12 @@
-/* GNOME Keyring cracker patch for JtR. Hacked together during Monsoon of
+/*
+ * GNOME Keyring cracker patch for JtR. Hacked together during Monsoon of
  * 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
+ * are permitted.
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_keyring;
@@ -13,8 +15,7 @@ john_register_one(&fmt_keyring);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
@@ -27,10 +28,6 @@ john_register_one(&fmt_keyring);
 #endif // _OPENMP
 
 #include "arch.h"
-
-//#undef _OPENMP
-//#undef SIMD_COEF_32
-
 #include "misc.h"
 #include "common.h"
 #include "formats.h"
@@ -43,32 +40,33 @@ john_register_one(&fmt_keyring);
 #include "simd-intrinsics.h"
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"keyring"
-#define FORMAT_NAME		"GNOME Keyring"
-#define FORMAT_TAG			"$keyring$"
-#define FORMAT_TAG_LEN		(sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME		"SHA256 AES " SHA256_ALGORITHM_NAME
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	125
-#define BINARY_SIZE		0
-#define SALT_SIZE		sizeof(*cur_salt)
-#define BINARY_ALIGN		1
-#define SALT_ALIGN			sizeof(int)
+#define FORMAT_LABEL            "keyring"
+#define FORMAT_NAME             "GNOME Keyring"
+#define FORMAT_TAG              "$keyring$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "SHA256 AES " SHA256_ALGORITHM_NAME
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        125
+#define BINARY_SIZE             0
+#define SALT_SIZE               sizeof(*cur_salt)
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              sizeof(int)
 #ifdef SIMD_COEF_32
-#define MIN_KEYS_PER_CRYPT (SIMD_COEF_32*SIMD_PARA_SHA256)
-#define MAX_KEYS_PER_CRYPT (SIMD_COEF_32*SIMD_PARA_SHA256)
+#define MIN_KEYS_PER_CRYPT      (SIMD_COEF_32*SIMD_PARA_SHA256)
+#define MAX_KEYS_PER_CRYPT      (SIMD_COEF_32*SIMD_PARA_SHA256)
 #if ARCH_LITTLE_ENDIAN==1
 #define GETPOS(i, index)        ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
 #else
 #define GETPOS(i, index)        ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
 #endif
 #else
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 #endif
 
-#define SALTLEN 8
+#define SALTLEN                 8
+
 typedef unsigned char guchar;
 typedef unsigned int guint;
 typedef int gint;
@@ -94,13 +92,14 @@ static size_t cracked_size;
 
 static void init(struct fmt_main *self)
 {
+#ifdef _OPENMP
+	int omp_t = omp_get_max_threads();
 
-#if defined (_OPENMP)
-	int omp_t;
-
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	self->params.max_keys_per_crypt *= omp_t * OMP_SCALE;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/known_hosts_fmt_plug.c
+++ b/src/known_hosts_fmt_plug.c
@@ -74,9 +74,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/krb5_asrep_fmt_plug.c
+++ b/src/krb5_asrep_fmt_plug.c
@@ -154,9 +154,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_alloc_align(sizeof(*saved_key) *
 			self->params.max_keys_per_crypt,

--- a/src/krb5_db_fmt_plug.c
+++ b/src/krb5_db_fmt_plug.c
@@ -39,8 +39,7 @@ john_register_one(&fmt_krb5_3);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+
 #include "arch.h"
 #include "misc.h"
 #include "common.h"
@@ -52,6 +51,8 @@ john_register_one(&fmt_krb5_3);
 #include "pbkdf2_hmac_sha1.h"
 #include "aes.h"
 #include "krb5_common.h"
+
+// OpenMP configuration needs to be here.
 #ifdef _OPENMP
 #include <omp.h>
 #ifdef SIMD_COEF_32
@@ -64,6 +65,7 @@ john_register_one(&fmt_krb5_3);
 #endif
 #endif
 #endif
+
 #include "memdbg.h"
 
 #define FORMAT_LABEL            "krb5-18"
@@ -139,9 +141,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/krb5_tgs_fmt_plug.c
+++ b/src/krb5_tgs_fmt_plug.c
@@ -172,9 +172,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_alloc_align(sizeof(*saved_key) *
 			self->params.max_keys_per_crypt,

--- a/src/krb5pa-sha1_fmt_plug.c
+++ b/src/krb5pa-sha1_fmt_plug.c
@@ -29,7 +29,7 @@
  * and binary forms, with or without modification, are permitted.
  *
  * This software is Copyright (c) 2012 Dhiru Kholia (dhiru at openwall.com) and
- * released under same terms as above
+ * released under same terms as above.
  */
 
 #if FMT_EXTERNS_H
@@ -38,12 +38,9 @@ extern struct fmt_main fmt_krb5pa;
 john_register_one(&fmt_krb5pa);
 #else
 
-#include <errno.h>
 #include <string.h>
-#include <stdlib.h>
-#include <ctype.h>
+
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               64
@@ -54,12 +51,12 @@ static int omp_t = 1;
 #include "formats.h"
 #include "options.h"
 #include "common.h"
+#include "loader.h"
 #include "unicode.h"
 #include "johnswap.h"
 #include "aes.h"
 #include "hmac_sha.h"
 #include "pbkdf2_hmac_sha1.h"
-#include "loader.h"
 #include "krb5_common.h"
 #include "memdbg.h"
 
@@ -74,24 +71,24 @@ static int omp_t = 1;
 #endif
 #define BENCHMARK_COMMENT  ""
 #define BENCHMARK_LENGTH   -1
-#define BINARY_SIZE		12
-#define BINARY_ALIGN		4
-#define PLAINTEXT_LENGTH	125
-#define SALT_SIZE		sizeof(struct custom_salt)
-#define SALT_ALIGN		4
+#define BINARY_SIZE        12
+#define BINARY_ALIGN       4
+#define PLAINTEXT_LENGTH   125
+#define SALT_SIZE          sizeof(struct custom_salt)
+#define SALT_ALIGN         4
 #ifdef SIMD_COEF_32
-#define MIN_KEYS_PER_CRYPT  SSE_GROUP_SZ_SHA1
-#define MAX_KEYS_PER_CRYPT  SSE_GROUP_SZ_SHA1
+#define MIN_KEYS_PER_CRYPT SSE_GROUP_SZ_SHA1
+#define MAX_KEYS_PER_CRYPT SSE_GROUP_SZ_SHA1
 #else
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define MIN_KEYS_PER_CRYPT 1
+#define MAX_KEYS_PER_CRYPT 1
 #endif
-#define MAX_SALTLEN             128
-#define MAX_REALMLEN            64
-#define MAX_USERLEN             64
-#define TIMESTAMP_SIZE          44
-#define CHECKSUM_SIZE           BINARY_SIZE
-#define TOTAL_LENGTH            (14 + 2 * (CHECKSUM_SIZE + TIMESTAMP_SIZE) + MAX_REALMLEN + MAX_USERLEN + MAX_SALTLEN)
+#define MAX_SALTLEN        128
+#define MAX_REALMLEN       64
+#define MAX_USERLEN        64
+#define TIMESTAMP_SIZE     44
+#define CHECKSUM_SIZE      BINARY_SIZE
+#define TOTAL_LENGTH       (14 + 2 * (CHECKSUM_SIZE + TIMESTAMP_SIZE) + MAX_REALMLEN + MAX_USERLEN + MAX_SALTLEN)
 
 static struct fmt_tests tests[] = {
 	{"$krb5pa$18$user1$EXAMPLE.COM$$2a0e68168d1eac344da458599c3a2b33ff326a061449fcbc242b212504e484d45903c6a16e2d593912f56c93883bf697b325193d62a8be9c", "openwall"},
@@ -124,10 +121,13 @@ static void init(struct fmt_main *self)
 {
 	unsigned char usage[5];
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/lastpass_cli_fmt_plug.c
+++ b/src/lastpass_cli_fmt_plug.c
@@ -58,9 +58,6 @@ john_register_one(&fmt_lastpass_cli);
 #define MAX_KEYS_PER_CRYPT      1
 #endif
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static uint32_t (*crypt_out)[32 / sizeof(uint32_t)];
 
@@ -69,10 +66,13 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/lastpass_fmt_plug.c
+++ b/src/lastpass_fmt_plug.c
@@ -58,9 +58,6 @@ john_register_one(&fmt_lastpass);
 #define MAX_KEYS_PER_CRYPT      1
 #endif
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static uint32_t (*crypt_out)[32 / sizeof(uint32_t)];
 
@@ -69,10 +66,13 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/leet_cc_fmt_plug.c
+++ b/src/leet_cc_fmt_plug.c
@@ -113,9 +113,12 @@ static void init(struct fmt_main *self)
 	int keys;
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	keys = self->params.max_keys_per_crypt;
 	saved_key = mem_calloc(sizeof(*saved_key), keys);

--- a/src/lotus85_fmt_plug.c
+++ b/src/lotus85_fmt_plug.c
@@ -26,7 +26,6 @@ john_register_one(&fmt_lotus_85);
 #ifndef OMP_SCALE
 #define OMP_SCALE               64  // XXX tune me!
 #endif
-static int omp_t = 1;
 #endif
 
 #include "formats.h"
@@ -294,10 +293,13 @@ static void get_user_id_secret_key(const char *password, uint8_t *secret_key)
 static void lotus85_init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	lotus85_saved_passwords = mem_calloc(self->params.max_keys_per_crypt,
 	                                     PLAINTEXT_LENGTH + 1);

--- a/src/md2_fmt_plug.c
+++ b/src/md2_fmt_plug.c
@@ -23,7 +23,6 @@ john_register_one(&fmt_md2_);
 #include "params.h"
 #include "options.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 // OMP_SCALE tuned on core i7 quad core HT
 // 1   - 153k
@@ -74,10 +73,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/mdc2_fmt_plug.c
+++ b/src/mdc2_fmt_plug.c
@@ -63,9 +63,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/money_fmt_plug.c
+++ b/src/money_fmt_plug.c
@@ -91,9 +91,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	orig_key = mem_calloc(sizeof(*orig_key), self->params.max_keys_per_crypt);
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/mongodb_fmt_plug.c
+++ b/src/mongodb_fmt_plug.c
@@ -26,7 +26,6 @@ john_register_one(&fmt_mongodb);
 #include "params.h"
 #include "options.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #ifdef __MIC__
@@ -86,10 +85,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/mongodb_scram_fmt_plug.c
+++ b/src/mongodb_scram_fmt_plug.c
@@ -80,11 +80,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*saved_key));

--- a/src/mozilla_ng_fmt_plug.c
+++ b/src/mozilla_ng_fmt_plug.c
@@ -81,9 +81,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/mssql12_fmt_plug.c
+++ b/src/mssql12_fmt_plug.c
@@ -171,9 +171,12 @@ static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_64
 	saved_key = mem_calloc_align(self->params.max_keys_per_crypt,

--- a/src/mysql_fmt_plug.c
+++ b/src/mysql_fmt_plug.c
@@ -96,9 +96,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                      sizeof(*saved_key));

--- a/src/mysql_netauth_fmt_plug.c
+++ b/src/mysql_netauth_fmt_plug.c
@@ -1,10 +1,12 @@
-/* Cracker for MySQL network authentication hashes. Hacked together
+/*
+ * Cracker for MySQL network authentication hashes. Hacked together
  * during May of 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
+ * are permitted.
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_mysqlna;
@@ -12,41 +14,40 @@ extern struct fmt_main fmt_mysqlna;
 john_register_one(&fmt_mysqlna);
 #else
 
-#include "sha.h"
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#ifndef OMP_SCALE
+#define OMP_SCALE               1024 // tuned K8-dual HT
+#endif
+#endif
+
 #include "arch.h"
 #include "misc.h"
+#include "sha.h"
 #include "common.h"
 #include "formats.h"
 #include "params.h"
 #include "options.h"
-#ifdef _OPENMP
-static int omp_t = 1;
-#include <omp.h>
-#ifndef OMP_SCALE
-#define OMP_SCALE               1024// tuned K8-dual HT
-#endif
-#endif
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"mysqlna"
-#define FORMAT_NAME		"MySQL Network Authentication"
-#define FORMAT_TAG		"$mysqlna$"
-#define FORMAT_TAG_LEN	(sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME		"SHA1 32/" ARCH_BITS_STR
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	32
-#define HEX_LENGTH		40
-#define CIPHERTEXT_LENGTH	90
-#define BINARY_SIZE		20
-#define BINARY_ALIGN		MEM_ALIGN_WORD
-#define SALT_SIZE		sizeof(struct custom_salt)
-#define SALT_ALIGN		MEM_ALIGN_NONE
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define FORMAT_LABEL            "mysqlna"
+#define FORMAT_NAME             "MySQL Network Authentication"
+#define FORMAT_TAG              "$mysqlna$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "SHA1 32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        32
+#define HEX_LENGTH              40
+#define CIPHERTEXT_LENGTH       90
+#define BINARY_SIZE             20
+#define BINARY_ALIGN            MEM_ALIGN_WORD
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define SALT_ALIGN              MEM_ALIGN_NONE
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 
 static struct fmt_tests mysqlna_tests[] = {
 	{"$mysqlna$2D52396369653E4626293B2F75244D3871507A39*7D63098BEE381A51AA6DF11E307E46BD4F8B6E0C", "openwall"},
@@ -65,10 +66,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));
@@ -85,6 +89,7 @@ static void done(void)
 static int valid(char *ciphertext, struct fmt_main *self)
 {
 	char *p, *q;
+
 	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
 		return 0;
 	p = ciphertext + FORMAT_TAG_LEN;
@@ -130,6 +135,7 @@ static void *get_salt(char *ciphertext)
 		cs.scramble[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
 			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
 	MEM_FREE(keeptr);
+
 	return (void *)&cs;
 }
 
@@ -142,6 +148,7 @@ static void *get_binary(char *ciphertext)
 	unsigned char *out = buf.c;
 	char *p;
 	int i;
+
 	p = strrchr(ciphertext, '*') + 1;
 	for (i = 0; i < BINARY_SIZE; i++) {
 		out[i] =
@@ -177,6 +184,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		SHA_CTX ctx;
 		int i;
 		unsigned char *p = (unsigned char*)crypt_out[index];
+
 		SHA1_Init(&ctx);
 		SHA1_Update(&ctx, saved_key[index], strlen(saved_key[index]));
 		SHA1_Final(stage1_hash, &ctx);
@@ -191,12 +199,14 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			p[i] = token[i] ^ stage1_hash[i];
 		}
 	}
+
 	return count;
 }
 
 static int cmp_all(void *binary, int count)
 {
 	int index = 0;
+
 #ifdef _OPENMP
 	for (; index < count; index++)
 #endif

--- a/src/net_ah_fmt_plug.c
+++ b/src/net_ah_fmt_plug.c
@@ -67,9 +67,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/nt2_fmt_plug.c
+++ b/src/nt2_fmt_plug.c
@@ -177,9 +177,12 @@ static void init(struct fmt_main *self)
 #endif
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	if (options.target_enc == UTF_8) {
 		/* This avoids an if clause for every set_key */

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -970,9 +970,12 @@ static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP) && !defined(SIMD_COEF_32)
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	my = self;
 	if (options.target_enc == UTF_8) {

--- a/src/nukedclan_fmt_plug.c
+++ b/src/nukedclan_fmt_plug.c
@@ -95,11 +95,13 @@ inline static void hex_encode(unsigned char *str, int len, unsigned char *out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/o10glogon_fmt_plug.c
+++ b/src/o10glogon_fmt_plug.c
@@ -25,7 +25,6 @@ john_register_one(&fmt_o10glogon);
 #include <string.h>
 #include <openssl/des.h>
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               2048
@@ -95,14 +94,16 @@ static DES_key_schedule desschedule1;	// key 0x0123456789abcdef
 
 static void init(struct fmt_main *self)
 {
-	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);
-
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
+	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);
 	cur_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*cur_key));
 	plain_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/o3logon_fmt_plug.c
+++ b/src/o3logon_fmt_plug.c
@@ -29,7 +29,6 @@ john_register_one(&fmt_o3logon);
 #include "unicode.h"
 #include "base64_convert.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               512 // tuned on core i7
@@ -92,14 +91,16 @@ static DES_key_schedule desschedule1;	// key 0x0123456789abcdef
 
 static void init(struct fmt_main *self)
 {
-	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);
-
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
+	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);
 	cur_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*cur_key));
 	plain_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/o5logon_fmt_plug.c
+++ b/src/o5logon_fmt_plug.c
@@ -1,4 +1,5 @@
-/* Cracker for Oracle's O5LOGON protocol hashes. Hacked together during
+/*
+ * Cracker for Oracle's O5LOGON protocol hashes. Hacked together during
  * September of 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * O5LOGON is used since version 11g. CVE-2012-3137 applies to Oracle 11.1
@@ -7,9 +8,8 @@
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
-
-/*
+ * are permitted.
+ *
  * Modifications (c) 2014 Harrison Neal, released under the same terms
  * as the original.
  */
@@ -21,8 +21,14 @@ john_register_one(&fmt_o5logon);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+#include <stdint.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#ifndef OMP_SCALE
+#define OMP_SCALE               512 // tuned on core i7
+#endif
+#endif
 
 #include "arch.h"
 #include "sha.h"
@@ -33,32 +39,24 @@ john_register_one(&fmt_o5logon);
 #include "options.h"
 #include "aes.h"
 #include "md5.h"
-#ifdef _OPENMP
-static int omp_t = 1;
-#include <omp.h>
-#ifndef OMP_SCALE
-#define OMP_SCALE               512 // tuned on core i7
-//#define OMP_SCALE                8192 // tuned on K8-Dual HT
-#endif
-#endif
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"o5logon"
-#define FORMAT_NAME		"Oracle O5LOGON protocol"
-#define FORMAT_TAG           "$o5logon$"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME		"SHA1 AES 32/" ARCH_BITS_STR
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	32 /* Multiple of 16 */
-#define CIPHERTEXT_LENGTH	48
-#define SALT_LENGTH		10
-#define BINARY_SIZE		0
-#define BINARY_ALIGN	1
-#define SALT_ALIGN		sizeof(int)
-#define SALT_SIZE		sizeof(struct custom_salt)
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define FORMAT_LABEL            "o5logon"
+#define FORMAT_NAME             "Oracle O5LOGON protocol"
+#define FORMAT_TAG              "$o5logon$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "SHA1 AES 32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        32 /* Multiple of 16 */
+#define CIPHERTEXT_LENGTH       48
+#define SALT_LENGTH             10
+#define BINARY_SIZE             0
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              sizeof(int32_t)
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 
 static struct fmt_tests o5logon_tests[] = {
 	{"$o5logon$566499330E8896301A1D2711EFB59E756D41AF7A550488D82FE7C8A418E5BE08B4052C0DC404A805C1D7D43FE3350873*4F739806EBC1D7742BC6", "password"},
@@ -96,10 +94,13 @@ static void init(struct fmt_main *self)
 	static char Buf[128];
 
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));
@@ -314,7 +315,7 @@ static int cmp_one(void *binary, int index)
 
 static int cmp_exact(char *source, int index)
 {
-    return 1;
+	return 1;
 }
 
 static void o5logon_set_key(char *key, int index)

--- a/src/office_fmt_plug.c
+++ b/src/office_fmt_plug.c
@@ -1,5 +1,7 @@
-/* Office 2007 cracker patch for JtR. Hacked together during March of 2012 by
- * Dhiru Kholia <dhiru.kholia at gmail.com> */
+/*
+ * Office 2007 cracker patch for JtR. Hacked together during March of 2012 by
+ * Dhiru Kholia <dhiru.kholia at gmail.com>.
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_office;
@@ -10,12 +12,11 @@ john_register_one(&fmt_office);
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
-#define OMP_SCALE               4
+#define OMP_SCALE                4
 #endif
 #endif
 
@@ -34,40 +35,37 @@ john_register_one(&fmt_office);
 #include "simd-intrinsics.h"
 #include "memdbg.h"
 
-//#undef SIMD_COEF_32
-//#undef SIMD_COEF_64
-
-#define FORMAT_LABEL		"Office"
-#define FORMAT_NAME		"2007/2010/2013"
-#define ALGORITHM_NAME		"SHA1 " SHA1_ALGORITHM_NAME " / SHA512 " SHA512_ALGORITHM_NAME " AES"
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	125
-#define BINARY_SIZE		16
-#define SALT_SIZE		sizeof(*cur_salt)
-#define BINARY_ALIGN	4
-#define SALT_ALIGN	sizeof(int)
+#define FORMAT_LABEL             "Office"
+#define FORMAT_NAME              "2007/2010/2013"
+#define ALGORITHM_NAME           "SHA1 " SHA1_ALGORITHM_NAME " / SHA512 " SHA512_ALGORITHM_NAME " AES"
+#define BENCHMARK_COMMENT        ""
+#define BENCHMARK_LENGTH         -1
+#define PLAINTEXT_LENGTH         125
+#define BINARY_SIZE              16
+#define SALT_SIZE                sizeof(*cur_salt)
+#define BINARY_ALIGN             4
+#define SALT_ALIGN               sizeof(int)
 #ifdef SIMD_COEF_32
 #define GETPOS_512W(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i*8)&(0xffffffff-7))*SIMD_COEF_64 + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#define GETOUTPOS_512W(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i*8)&(0xffffffff-7))*SIMD_COEF_64 + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
+#define GETOUTPOS_512W(i, index) ( (index&(SIMD_COEF_64-1))*8 + ((i*8)&(0xffffffff-7))*SIMD_COEF_64 + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
 #if ARCH_LITTLE_ENDIAN==1
-#define GETPOS_1(i, index)  ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
-#define GETPOS_512(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#define GETOUTPOS_512(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
+#define GETPOS_1(i, index)       ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
+#define GETPOS_512(i, index)     ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
+#define GETOUTPOS_512(i, index)  ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
 #else
-#define GETPOS_1(i, index)  ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
-#define GETPOS_512(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#define GETOUTPOS_512(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
+#define GETPOS_1(i, index)       ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
+#define GETPOS_512(i, index)     ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
+#define GETOUTPOS_512(i, index)  ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
 #endif
-#define SHA1_LOOP_CNT       (SIMD_COEF_32*SIMD_PARA_SHA1)
-#define SHA512_LOOP_CNT     (SIMD_COEF_64 * SIMD_PARA_SHA512)
-#define MIN_KEYS_PER_CRYPT  (SIMD_COEF_32 * SIMD_PARA_SHA1 * SIMD_PARA_SHA512)
-#define MAX_KEYS_PER_CRYPT	(SIMD_COEF_32 * SIMD_PARA_SHA1 * SIMD_PARA_SHA512)
+#define SHA1_LOOP_CNT            (SIMD_COEF_32*SIMD_PARA_SHA1)
+#define SHA512_LOOP_CNT          (SIMD_COEF_64 * SIMD_PARA_SHA512)
+#define MIN_KEYS_PER_CRYPT       (SIMD_COEF_32 * SIMD_PARA_SHA1 * SIMD_PARA_SHA512)
+#define MAX_KEYS_PER_CRYPT       (SIMD_COEF_32 * SIMD_PARA_SHA1 * SIMD_PARA_SHA512)
 #else
-#define SHA1_LOOP_CNT		1
-#define SHA512_LOOP_CNT 1
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define SHA1_LOOP_CNT            1
+#define SHA512_LOOP_CNT          1
+#define MIN_KEYS_PER_CRYPT       1
+#define MAX_KEYS_PER_CRYPT       1
 #endif
 
 static struct fmt_tests office_tests[] = {
@@ -115,9 +113,6 @@ static ms_office_custom_salt *cur_salt;
 
 #define MS_OFFICE_2007_ITERATIONS	50000
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 /* Password encoded in UCS-2 */
 static UTF16 (*saved_key)[PLAINTEXT_LENGTH + 1];
 /* UCS-2 password length, in octets */
@@ -591,10 +586,13 @@ static void GenerateAgileEncryptionKey512(int idx, unsigned char hashBuf[SHA512_
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	saved_len = mem_calloc(sizeof(*saved_len), self->params.max_keys_per_crypt);

--- a/src/openbsdsoftraid_fmt_plug.c
+++ b/src/openbsdsoftraid_fmt_plug.c
@@ -35,7 +35,6 @@ john_register_one(&fmt_openbsd_softraid);
 #include "pbkdf2_hmac_sha1.h"
 #include "loader.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE                   1
@@ -97,10 +96,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	key_buffer = mem_calloc(sizeof(*key_buffer), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/opencl_blockchain_fmt_plug.c
+++ b/src/opencl_blockchain_fmt_plug.c
@@ -1,5 +1,6 @@
-/* blockchain "My Wallet" cracker patch for JtR. Hacked together during June of
- * 2013 by Dhiru Kholia <dhiru at openwall.com>.
+/*
+ * Format for cracking blockchain.info "My Wallet" format wallets. Hacked
+ * together during June of 2013 by Dhiru Kholia <dhiru at openwall.com>.
  *
  * See https://blockchain.info/wallet/wallet-format
 
@@ -23,6 +24,7 @@ john_register_one(&fmt_opencl_blockchain);
 
 #include <stdint.h>
 #include <string.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/src/opencl_cryptmd5_fmt_plug.c
+++ b/src/opencl_cryptmd5_fmt_plug.c
@@ -1,6 +1,6 @@
 /*
  * This software is Copyright (c) 2011-2012 Lukas Odzioba <ukasz at openwall dot net>
- * and Copyright (c) 2012 magnum
+ * and Copyright (c) 2012 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification, are permitted.
  */
@@ -13,11 +13,6 @@ john_register_one(&fmt_opencl_cryptMD5);
 #else
 
 #include <stdint.h>
-#include <string.h>
-#include <assert.h>
-#if (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER
-#include <unistd.h>
-#endif
 
 #include "arch.h"
 #include "formats.h"

--- a/src/opencl_keystore_fmt_plug.c
+++ b/src/opencl_keystore_fmt_plug.c
@@ -1,4 +1,5 @@
-/* Java KeyStore password cracker for JtR.
+/*
+ * Java KeyStore password cracker for JtR.
  * (will NOT address password(s) for alias(es) within keystore).
  *
  * OpenCL plugin by Terry West.
@@ -33,8 +34,6 @@ john_register_one(&fmt_opencl_keystore);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
 
 #include "arch.h"
 #include "sha.h"
@@ -44,22 +43,21 @@ john_register_one(&fmt_opencl_keystore);
 #include "params.h"
 #include "options.h"
 #include "keystore_common.h"
-
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"keystore-opencl"
-#define FORMAT_NAME			"Java KeyStore"
-#define ALGORITHM_NAME		"SHA1 OpenCL"
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	0
+#define FORMAT_LABEL            "keystore-opencl"
+#define FORMAT_NAME             "Java KeyStore"
+#define ALGORITHM_NAME          "SHA1 OpenCL"
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        0
 // reduced PLAIN_LEN from 125 bytes, and speed went from 12.2k to 16.4k
-#define PLAINTEXT_LENGTH	32
+#define PLAINTEXT_LENGTH        32
 // reduced BIN_SIZE from 20 bytes to 4 for the GPU, and speed went from
 // 16.4k to 17.8k.  cmp_exact does a CPU hash check on possible matches.
-#define SALT_SIZE			sizeof(struct custom_salt)
-#define SALT_ALIGN			4
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define SALT_ALIGN              4
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 
 // these to pass to kernel
 typedef struct {
@@ -190,7 +188,6 @@ static void reset(struct db_main *db)
 
 static void done(void)
 {
-
 	if (autotuned) {
 		release_clobj();
 
@@ -257,7 +254,6 @@ static void set_salt(void *salt)
 			                            CL_FALSE, 0, saltsize,
 										&saltbuffer, 0, NULL, NULL),
 										"Copy salt to gpu");
-
 }
 
 static void keystore_set_key(char *key, int index)
@@ -271,6 +267,7 @@ static void keystore_set_key(char *key, int index)
 static char *get_key(int index)
 {
 	static char key[PLAINTEXT_LENGTH + 1];
+
 	memcpy(key, inbuffer[index].pass, inbuffer[index].length);
 	key[inbuffer[index].length] = 0;
 
@@ -279,9 +276,7 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-
 	const int count = *pcount;
-
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
@@ -315,6 +310,7 @@ static int cmp_all(void *binary, int count)
 			return 1;
 		}
 	}
+
 	return 0;
 }
 
@@ -323,6 +319,7 @@ static int cmp_one(void *binary, int index)
 	if (((uint32_t*)binary)[0] != outbuffer[index].gpu_out) {
 		return 0;
 	}
+
 	return 1;
 }
 

--- a/src/opencl_krb5pa-sha1_fmt_plug.c
+++ b/src/opencl_krb5pa-sha1_fmt_plug.c
@@ -29,7 +29,7 @@
  * and binary forms, with or without modification, are permitted.
  *
  * This software is Copyright (c) 2012 Dhiru Kholia (dhiru at openwall.com) and
- * released under same terms as above
+ * released under same terms as above.
  */
 
 #ifdef HAVE_OPENCL
@@ -40,10 +40,7 @@ extern struct fmt_main fmt_opencl_krb5pa_sha1;
 john_register_one(&fmt_opencl_krb5pa_sha1);
 #else
 
-#include <errno.h>
 #include <string.h>
-#include <stdlib.h>
-#include <ctype.h>
 
 #include "arch.h"
 #include "misc.h"
@@ -60,17 +57,17 @@ john_register_one(&fmt_opencl_krb5pa_sha1);
 #include "hmac_sha.h"
 #include "loader.h"
 
-#define FORMAT_LABEL		"krb5pa-sha1-opencl"
-#define FORMAT_NAME		"Kerberos 5 AS-REQ Pre-Auth etype 17/18" /* aes-cts-hmac-sha1-96 */
-#define FORMAT_TAG           "$krb5pa$"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME		"PBKDF2-SHA1 OpenCL"
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1001
-#define BINARY_SIZE		12
-#define BINARY_ALIGN		4
-#define SALT_SIZE		sizeof(struct custom_salt)
-#define SALT_ALIGN		4
+#define FORMAT_LABEL            "krb5pa-sha1-opencl"
+#define FORMAT_NAME             "Kerberos 5 AS-REQ Pre-Auth etype 17/18" /* aes-cts-hmac-sha1-96 */
+#define FORMAT_TAG              "$krb5pa$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "PBKDF2-SHA1 OpenCL"
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1001
+#define BINARY_SIZE             12
+#define BINARY_ALIGN            4
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define SALT_ALIGN              4
 #define MAX_SALTLEN             52
 #define MAX_REALMLEN            MAX_SALTLEN
 #define MAX_USERLEN             MAX_SALTLEN
@@ -78,13 +75,13 @@ john_register_one(&fmt_opencl_krb5pa_sha1);
 #define CHECKSUM_SIZE           BINARY_SIZE
 #define TOTAL_LENGTH            (14 + 2 * (CHECKSUM_SIZE + TIMESTAMP_SIZE) + MAX_REALMLEN + MAX_USERLEN + MAX_SALTLEN)
 
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 
 /* This handles all sizes */
-#define GETPOS(i, index)	(((index) % ocl_v_width) * 4 + ((i) & ~3U) * ocl_v_width + (((i) & 3) ^ 3) + ((index) / ocl_v_width) * 64 * ocl_v_width)
+#define GETPOS(i, index)        (((index) % ocl_v_width) * 4 + ((i) & ~3U) * ocl_v_width + (((i) & 3) ^ 3) + ((index) / ocl_v_width) * 64 * ocl_v_width)
 /* This is faster but can't handle size 3 */
-//#define GETPOS(i, index)	(((index) & (ocl_v_width - 1)) * 4 + ((i) & ~3U) * ocl_v_width + (((i) & 3) ^ 3) + ((index) / ocl_v_width) * 64 * ocl_v_width)
+//#define GETPOS(i, index)      (((index) & (ocl_v_width - 1)) * 4 + ((i) & ~3U) * ocl_v_width + (((i) & 3) ^ 3) + ((index) / ocl_v_width) * 64 * ocl_v_width)
 
 static struct fmt_tests tests[] = {
 	{"$krb5pa$18$user1$EXAMPLE.COM$$2a0e68168d1eac344da458599c3a2b33ff326a061449fcbc242b212504e484d45903c6a16e2d593912f56c93883bf697b325193d62a8be9c", "openwall"},

--- a/src/opencl_o5logon_fmt_plug.c
+++ b/src/opencl_o5logon_fmt_plug.c
@@ -1,4 +1,5 @@
-/* Cracker for Oracle's O5LOGON protocol hashes. Hacked together during
+/*
+ * Cracker for Oracle's O5LOGON protocol hashes. Hacked together during
  * September of 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * O5LOGON is used since version 11g. CVE-2012-3137 applies to Oracle 11.1
@@ -7,7 +8,8 @@
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
+ * are permitted.
+ */
 
 /*
  * Modifications (c) 2014 Harrison Neal.
@@ -15,7 +17,7 @@
  * SHA-1 hashes are now computed with OpenCL.
  * Modifications are based on opencl_rawsha1_fmt.c and sha1_kernel.cl
  * and thus are licensed under the GPLv2.
- * Original files are (c) 2011 Samuele Giovanni Tonon and (c) 2012 magnum
+ * Original files are (c) 2011 Samuele Giovanni Tonon and (c) 2012 magnum.
  */
 
 #ifdef HAVE_OPENCL
@@ -27,8 +29,6 @@ john_register_one(&fmt_opencl_o5logon);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
 
 #include "arch.h"
 #include "sha.h"
@@ -39,23 +39,23 @@ john_register_one(&fmt_opencl_o5logon);
 #include "options.h"
 #include "common-opencl.h"
 
-#define FORMAT_LABEL		"o5logon-opencl"
-#define FORMAT_NAME		"Oracle O5LOGON protocol"
-#define FORMAT_TAG           "$o5logon$"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME		"SHA1 AES OpenCL"
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	32
-#define CIPHERTEXT_LENGTH	48
-#define SALT_LENGTH		10
-#define BINARY_SIZE		0
-#define SALT_SIZE		sizeof(struct custom_salt)
-#define BINARY_ALIGN		1
-#define SALT_ALIGN			MEM_ALIGN_WORD
+#define FORMAT_LABEL            "o5logon-opencl"
+#define FORMAT_NAME             "Oracle O5LOGON protocol"
+#define FORMAT_TAG              "$o5logon$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "SHA1 AES OpenCL"
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        32
+#define CIPHERTEXT_LENGTH       48
+#define SALT_LENGTH             10
+#define BINARY_SIZE             0
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              MEM_ALIGN_WORD
 
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 
 static struct fmt_tests o5logon_tests[] = {
 	{"$o5logon$566499330E8896301A1D2711EFB59E756D41AF7A550488D82FE7C8A418E5BE08B4052C0DC404A805C1D7D43FE3350873*4F739806EBC1D7742BC6", "password"},

--- a/src/opencl_office_fmt_plug.c
+++ b/src/opencl_office_fmt_plug.c
@@ -17,10 +17,7 @@ john_register_one(&fmt_opencl_office);
 #else
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
 
 #include "arch.h"
 #include "misc.h"

--- a/src/opencl_oldoffice_fmt_plug.c
+++ b/src/opencl_oldoffice_fmt_plug.c
@@ -19,7 +19,6 @@ john_register_one(&FORMAT_STRUCT);
 
 #include <stdint.h>
 #include <string.h>
-#include <errno.h>
 
 #include "common-opencl.h"
 #include "arch.h"

--- a/src/opencl_pwsafe_fmt_plug.c
+++ b/src/opencl_pwsafe_fmt_plug.c
@@ -1,13 +1,18 @@
-/* Password Safe cracker patch for JtR. Hacked together during May of
+/*
+ * Password Safe cracker patch for JtR. Hacked together during May of
  * 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
- * OpenCL port by Lukas Odzioba <ukasz at openwall.net>
- * Split kernel implemented and plaintext extension by Brian Wallace <brian.wallace9809 at gmail.com>
+ * OpenCL port by Lukas Odzioba <ukasz at openwall.net>.
  *
- * This software is Copyright (c) 2012-2013, Dhiru Kholia <dhiru.kholia at gmail.com> and Brian Wallace <brian.wallace9809 at gmail.com>,
- * and it is hereby released to the general public under the following terms:
+ * Split kernel implemented and plaintext extension by Brian Wallace <brian.wallace9809 at gmail.com>.
+ *
+ * This software is Copyright (c) 2012-2013, Dhiru Kholia <dhiru.kholia at
+ * gmail.com> and Brian Wallace <brian.wallace9809 at gmail.com>, and it is
+ * hereby released to the general public under the following terms:
+ *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
+ * are permitted.
+ */
 
 #ifdef HAVE_OPENCL
 
@@ -18,8 +23,6 @@ john_register_one(&fmt_opencl_pwsafe);
 #else
 
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
 #include <stdint.h>
 
 #include "arch.h"
@@ -33,18 +36,18 @@ john_register_one(&fmt_opencl_pwsafe);
 
 #define FORMAT_LABEL            "pwsafe-opencl"
 #define FORMAT_NAME             "Password Safe"
-#define FORMAT_TAG           "$pwsafe$*"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
+#define FORMAT_TAG              "$pwsafe$*"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
 #define ALGORITHM_NAME          "SHA256 OpenCL"
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        -1
 #define PLAINTEXT_LENGTH        87
 #define BINARY_SIZE             0
-#define BINARY_ALIGN		1
-#define SALT_ALIGN			MEM_ALIGN_WORD
-#define KERNEL_INIT_NAME	"pwsafe_init"
-#define KERNEL_RUN_NAME   	"pwsafe_iter"
-#define KERNEL_FINISH_NAME	"pwsafe_check"
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              MEM_ALIGN_WORD
+#define KERNEL_INIT_NAME        "pwsafe_init"
+#define KERNEL_RUN_NAME         "pwsafe_iter"
+#define KERNEL_FINISH_NAME      "pwsafe_check"
 #define MIN_KEYS_PER_CRYPT      1
 #define MAX_KEYS_PER_CRYPT      1
 

--- a/src/opencl_rar5_fmt_plug.c
+++ b/src/opencl_rar5_fmt_plug.c
@@ -17,9 +17,7 @@ extern struct fmt_main fmt_ocl_rar5;
 john_register_one(&fmt_ocl_rar5);
 #else
 
-#include <ctype.h>
 #include <string.h>
-#include <assert.h>
 #include <stdint.h>
 
 //#define DEBUG
@@ -32,32 +30,32 @@ john_register_one(&fmt_ocl_rar5);
 #include "common-opencl.h"
 #include "rar5_common.h"
 
-#define SIZE_SALT50 16
-#define SIZE_PSWCHECK 8
-#define SIZE_PSWCHECK_CSUM 4
-#define SIZE_INITV 16
+#define SIZE_SALT50             16
+#define SIZE_PSWCHECK           8
+#define SIZE_PSWCHECK_CSUM      4
+#define SIZE_INITV              16
 
-#define FORMAT_LABEL		"RAR5-opencl"
-#define FORMAT_NAME		""
-#define ALGORITHM_NAME		"PBKDF2-SHA256 OpenCL"
+#define FORMAT_LABEL            "RAR5-opencl"
+#define FORMAT_NAME             ""
+#define ALGORITHM_NAME          "PBKDF2-SHA256 OpenCL"
 
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define STEP			0
-#define SEED			1024
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define STEP                    0
+#define SEED                    1024
 
-#define BINARY_ALIGN		4
-#define SALT_ALIGN		sizeof(int)
+#define BINARY_ALIGN            4
+#define SALT_ALIGN              sizeof(int)
 
-#define PLAINTEXT_LENGTH	55
-#define BINARY_SIZE		SIZE_PSWCHECK
-#define SALT_SIZE		sizeof(struct custom_salt)
+#define PLAINTEXT_LENGTH        55
+#define BINARY_SIZE             SIZE_PSWCHECK
+#define SALT_SIZE               sizeof(struct custom_salt)
 
-#define KERNEL_NAME		"pbkdf2_sha256_kernel"
-#define SPLIT_KERNEL_NAME	"pbkdf2_sha256_loop"
+#define KERNEL_NAME             "pbkdf2_sha256_kernel"
+#define SPLIT_KERNEL_NAME       "pbkdf2_sha256_loop"
 
-#define HASH_LOOPS		(3*13*29) // factors 3, 13, 29, 29
-#define ITERATIONS		(32800 - 1)
+#define HASH_LOOPS              (3*13*29) // factors 3, 13, 29, 29
+#define ITERATIONS              (32800 - 1)
 
 typedef struct {
 	uint8_t length;

--- a/src/opencl_rar_fmt_plug.c
+++ b/src/opencl_rar_fmt_plug.c
@@ -49,7 +49,6 @@ john_register_one(&fmt_ocl_rar);
 #else
 
 #include <string.h>
-#include <errno.h>
 #if AC_BUILT
 #include "autoconfig.h"
 #endif

--- a/src/oracle12c_fmt_plug.c
+++ b/src/oracle12c_fmt_plug.c
@@ -84,11 +84,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*saved_key));

--- a/src/oracle_fmt_plug.c
+++ b/src/oracle_fmt_plug.c
@@ -24,7 +24,6 @@ john_register_one(&fmt_oracle);
 #include "formats.h"
 #include "unicode.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE              512
@@ -213,14 +212,16 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 static void init(struct fmt_main *self)
 {
-	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule_static);
-
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
+	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule_static);
 	cur_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*cur_key));
 	plain_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/ospf_fmt_plug.c
+++ b/src/ospf_fmt_plug.c
@@ -78,9 +78,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/padlock_fmt_plug.c
+++ b/src/padlock_fmt_plug.c
@@ -17,7 +17,6 @@ john_register_one(&fmt_padlock);
 #include <string.h>
 #ifdef _OPENMP
 #include <omp.h>
-static int omp_t = 1;
 #ifndef OMP_SCALE
 #define OMP_SCALE               4
 #endif
@@ -96,10 +95,13 @@ static int *cracked, cracked_count;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));

--- a/src/palshop_fmt_plug.c
+++ b/src/palshop_fmt_plug.c
@@ -64,11 +64,13 @@ static size_t *saved_len;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*saved_key));

--- a/src/panama_fmt_plug.c
+++ b/src/panama_fmt_plug.c
@@ -23,7 +23,6 @@ john_register_one(&fmt_panama_);
 #include "params.h"
 #include "options.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 // OMP_SCALE tuned on core i7 quad core HT
 // 1   -  217k
@@ -75,10 +74,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/pbkdf2-hmac-md4_fmt_plug.c
+++ b/src/pbkdf2-hmac-md4_fmt_plug.c
@@ -11,20 +11,16 @@ extern struct fmt_main fmt_pbkdf2_hmac_md4;
 john_register_one(&fmt_pbkdf2_hmac_md4);
 #else
 
-#include <ctype.h>
 #include <string.h>
-#include <assert.h>
 #include <stdint.h>
 
 #include "arch.h"
-
-//#undef SIMD_COEF_32
-
 #include "misc.h"
 #include "common.h"
 #include "formats.h"
 #include "pbkdf2_hmac_md4.h"
 #include "pbkdf2_hmac_common.h"
+
 #ifdef _OPENMP
 #include <omp.h>
 #ifndef OMP_SCALE
@@ -63,9 +59,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));
 	crypt_out = mem_calloc(self->params.max_keys_per_crypt, sizeof(*crypt_out));

--- a/src/pbkdf2-hmac-md5_fmt_plug.c
+++ b/src/pbkdf2-hmac-md5_fmt_plug.c
@@ -12,15 +12,10 @@ extern struct fmt_main fmt_pbkdf2_hmac_md5;
 john_register_one(&fmt_pbkdf2_hmac_md5);
 #else
 
-#include <ctype.h>
 #include <string.h>
-#include <assert.h>
 #include <stdint.h>
 
 #include "arch.h"
-
-//#undef SIMD_COEF_32
-
 #include "misc.h"
 #include "common.h"
 #include "formats.h"
@@ -65,9 +60,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));
 	crypt_out = mem_calloc(self->params.max_keys_per_crypt, sizeof(*crypt_out));

--- a/src/pbkdf2-hmac-sha1_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha1_fmt_plug.c
@@ -11,9 +11,7 @@ extern struct fmt_main fmt_pbkdf2_hmac_sha1;
 john_register_one(&fmt_pbkdf2_hmac_sha1);
 #else
 
-#include <ctype.h>
 #include <string.h>
-#include <assert.h>
 #include <stdint.h>
 
 #include "arch.h"
@@ -71,9 +69,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/pbkdf2-hmac-sha512_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha512_fmt_plug.c
@@ -57,7 +57,6 @@ john_register_one(&fmt_pbkdf2_hmac_sha512);
 #define MAX_KEYS_PER_CRYPT      1
 #endif
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               1
@@ -81,10 +80,13 @@ static uint32_t (*crypt_out)[PBKDF2_SHA512_BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/pbkdf2_hmac_sha256_fmt_plug.c
@@ -1,20 +1,21 @@
-/* This software is Copyright (c) 2012 Lukas Odzioba <ukasz@openwall.net>
+/*
+ * This software is Copyright (c) 2012 Lukas Odzioba <ukasz@openwall.net>
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  *
- * Based on hmac-sha512 by magnum
+ * Based on hmac-sha512 by magnum.
  *
  * Minor fixes, format unification and OMP support done by Dhiru Kholia
- * <dhiru@openwall.com>
+ * <dhiru@openwall.com>.
  *
  * Fixed for supporting $ml$ "dave" format as well as GRUB native format by
  * magnum 2013. Note: We support a binary size of >512 bits (64 bytes / 128
  * chars of hex) but we currently do not calculate it even in cmp_exact(). The
  * chance for a 512-bit hash collision should be pretty dang slim.
  *
- * the pbkdf2_sha256_hmac was so messed up, I simply copied sha512 over the top
- * of it, replacing the code in totality.  JimF.
+ * The pbkdf2_sha256_hmac was so messed up, I simply copied sha512 over the top
+ * of it, replacing the code in totality. JimF.
  */
 
 #if FMT_EXTERNS_H
@@ -23,9 +24,7 @@ extern struct fmt_main fmt_pbkdf2_hmac_sha256;
 john_register_one(&fmt_pbkdf2_hmac_sha256);
 #else
 
-#include <ctype.h>
 #include <string.h>
-#include <assert.h>
 #include <stdint.h>
 
 #include "misc.h"
@@ -62,7 +61,6 @@ john_register_one(&fmt_pbkdf2_hmac_sha256);
 #endif
 #define BENCHMARK_LENGTH        -1
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               4
@@ -86,10 +84,13 @@ static uint32_t (*crypt_out)[PBKDF2_SHA256_BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/pdf_fmt_plug.c
+++ b/src/pdf_fmt_plug.c
@@ -52,10 +52,6 @@ john_register_one(&fmt_pdf);
 #define MIN_KEYS_PER_CRYPT  1
 #define MAX_KEYS_PER_CRYPT  1
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
-
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *cracked;
 static int any_cracked;
@@ -106,10 +102,13 @@ static struct fmt_tests pdf_tests[] = {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	any_cracked = 0;

--- a/src/pfx_fmt_plug.c
+++ b/src/pfx_fmt_plug.c
@@ -85,11 +85,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*saved_key));

--- a/src/pgpdisk_fmt_plug.c
+++ b/src/pgpdisk_fmt_plug.c
@@ -59,11 +59,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE * 2 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/pgpsda_fmt_plug.c
+++ b/src/pgpsda_fmt_plug.c
@@ -57,11 +57,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE * 2 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/pgpwde_fmt_plug.c
+++ b/src/pgpwde_fmt_plug.c
@@ -93,11 +93,13 @@ static void S2KPGPWDE(char *password, unsigned char *salt, unsigned char *key, i
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);

--- a/src/phpassMD5_fmt_plug.c
+++ b/src/phpassMD5_fmt_plug.c
@@ -106,9 +106,12 @@ static unsigned loopCnt;
 static void init(struct fmt_main *self) {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_32
 	crypt_key = mem_calloc_align(self->params.max_keys_per_crypt/NBKEYS,

--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -399,12 +399,13 @@ static void init(struct fmt_main *self)
 	unsigned short n=0;
 #endif
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	K12 = mem_calloc(sizeof(*K12) * 3, self->params.max_keys_per_crypt);

--- a/src/pomelo_fmt_plug.c
+++ b/src/pomelo_fmt_plug.c
@@ -76,9 +76,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	if (!saved_key) {
 		saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));

--- a/src/postgres_fmt_plug.c
+++ b/src/postgres_fmt_plug.c
@@ -1,4 +1,5 @@
-/* PostgreSQL MD5 challenge-response cracker patch for JtR. Hacked together
+/*
+ * PostgreSQL MD5 challenge-response cracker patch for JtR. Hacked together
  * during October of 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * Use Ettercap to get PostgreSQL MD5 challenge-response pairs in JtR format.
@@ -8,10 +9,12 @@
  * $postgres$user*salt*hash
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
- * and Copyright magnum 2013,
- * and it is hereby released to the general public under the following terms:
+ * and Copyright magnum 2013, and it is hereby released to the general public
+ * under the following terms:
+ *
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
+ * are permitted.
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_postgres;
@@ -20,9 +23,8 @@ john_register_one(&fmt_postgres);
 #else
 
 #include <string.h>
-#include <errno.h>
+
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               2048 // scaled on K8-dual HT
@@ -89,10 +91,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/radmin_fmt_plug.c
+++ b/src/radmin_fmt_plug.c
@@ -1,4 +1,5 @@
-/* RAdmin v2.x cracker patch for JtR. Hacked together during
+/*
+ * RAdmin v2.x cracker patch for JtR. Hacked together during
  * May of 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
@@ -6,7 +7,8 @@
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted.
  *
- * Input Format => user:$radmin2$hash */
+ * Input Format => user:$radmin2$hash
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_radmin;
@@ -14,16 +16,8 @@ extern struct fmt_main fmt_radmin;
 john_register_one(&fmt_radmin);
 #else
 
-#include "md5.h"
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
-#include "arch.h"
-#include "misc.h"
-#include "common.h"
-#include "formats.h"
-#include "params.h"
-#include "options.h"
+
 #ifdef _OPENMP
 #include <omp.h>
 // Tuned on core i7 quad HT
@@ -36,24 +30,32 @@ john_register_one(&fmt_radmin);
 #define OMP_SCALE     32
 #endif
 #endif
+
+#include "md5.h"
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "options.h"
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"RAdmin"
-#define FORMAT_NAME		"v2.x"
-#define FORMAT_TAG           "$radmin2$"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME		"MD5 32/" ARCH_BITS_STR
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	99
-#define CIPHERTEXT_LENGTH	32
-#define BINARY_SIZE		16
-#define SALT_SIZE		0
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	64
+#define FORMAT_LABEL            "RAdmin"
+#define FORMAT_NAME             "v2.x"
+#define FORMAT_TAG              "$radmin2$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "MD5 32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        99
+#define CIPHERTEXT_LENGTH       32
+#define BINARY_SIZE             16
+#define SALT_SIZE               0
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      64
 
-#define BINARY_ALIGN		4
-#define SALT_ALIGN		1
+#define BINARY_ALIGN            4
+#define SALT_ALIGN              1
 
 static struct fmt_tests radmin_tests[] = {
 	{"$radmin2$B137F09CF92F465CABCA06AB1B283C1F", "lastwolf"},
@@ -74,9 +76,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));
@@ -92,7 +97,9 @@ static void done(void)
 
 static char *split(char *ciphertext, int index, struct fmt_main *self) {
 	static char buf[CIPHERTEXT_LENGTH + FORMAT_TAG_LEN + 1];   // $radmin2$ is 9 bytes
+
 	strnzcpylwr(buf, ciphertext, CIPHERTEXT_LENGTH + FORMAT_TAG_LEN + 1);
+
 	return buf;
 }
 
@@ -106,6 +113,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	p = ciphertext + FORMAT_TAG_LEN;
 	if (hexlen(p, &extra) != CIPHERTEXT_LENGTH || extra)
 		return 0;
+
 	return 1;
 }
 
@@ -118,6 +126,7 @@ static void *get_binary(char *ciphertext)
 	unsigned char *out = buf.c;
 	char *p;
 	int i;
+
 	p = strrchr(ciphertext, '$') + 1;
 	for (i = 0; i < BINARY_SIZE; i++) {
 		out[i] =
@@ -153,6 +162,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 static int cmp_all(void *binary, int count)
 {
 	int index;
+
 	for (index = 0; index < count; index++)
 		if (*(uint32_t *)binary == crypt_out[index][0])
 			return 1;
@@ -172,16 +182,17 @@ static int cmp_exact(char *source, int index)
 
 static void radmin_set_key(char *key, int index)
 {
-	// this code assures that both saved_key[index] gets null-terminated (without buffer overflow)
+	// This code assures that both saved_key[index] gets null-terminated (without buffer overflow)
 	char *cp = &saved_key[index][strnzcpyn(saved_key[index], key, PLAINTEXT_LENGTH + 1)+1];
-	// and is null padded up to 100 bytes.  We simply clean up prior buffer, up to element 99, but that element will never be written to
+	// and is null padded up to 100 bytes. We simply clean up prior buffer,
+	// up to element 99, but that element will never be written to.
 	if (cp < &saved_key[index][99])
 		while (*cp) *cp++ = 0;
 }
 
 static char *get_key(int index)
 {
-	// assured null teminated string.  Just return it.
+	// Assured NUL teminated string, just return it.
 	return saved_key[index];
 }
 

--- a/src/rakp_fmt_plug.c
+++ b/src/rakp_fmt_plug.c
@@ -116,9 +116,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_32
 	bufsize = sizeof(*opad) * self->params.max_keys_per_crypt * SHA_BUF_SIZ * 4;

--- a/src/rar5_fmt_plug.c
+++ b/src/rar5_fmt_plug.c
@@ -1,4 +1,5 @@
-/* RAR 5.0 cracker patch for JtR. Hacked together during May of 2013 by Dhiru
+/*
+ * RAR 5.0 cracker patch for JtR. Hacked together during May of 2013 by Dhiru
  * Kholia.
  *
  * http://www.rarlab.com/technote.htm
@@ -21,10 +22,8 @@ john_register_one(&fmt_rar5);
 
 #include <stdint.h>
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               1 // tuned on core i7
@@ -40,15 +39,13 @@ static int omp_t = 1;
 #include "params.h"
 #include "options.h"
 #include "rar5_common.h"
-//#define PBKDF2_HMAC_SHA256_ALSO_INCLUDE_CTX
 #include "pbkdf2_hmac_sha256.h"
-
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"RAR5"
-#define FORMAT_NAME		""
+#define FORMAT_LABEL            "RAR5"
+#define FORMAT_NAME             ""
 #ifdef SIMD_COEF_32
-#define ALGORITHM_NAME		"PBKDF2-SHA256 " SHA256_ALGORITHM_NAME
+#define ALGORITHM_NAME          "PBKDF2-SHA256 " SHA256_ALGORITHM_NAME
 #else
 #if ARCH_BITS >= 64
 #define ALGORITHM_NAME          "PBKDF2-SHA256 64/" ARCH_BITS_STR " " SHA2_LIB
@@ -56,18 +53,18 @@ static int omp_t = 1;
 #define ALGORITHM_NAME          "PBKDF2-SHA256 32/" ARCH_BITS_STR " " SHA2_LIB
 #endif
 #endif
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	32
-#define SALT_SIZE		sizeof(struct custom_salt)
-#define BINARY_ALIGN	sizeof(uint32_t)
-#define SALT_ALIGN		sizeof(int)
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        32
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define BINARY_ALIGN            sizeof(uint32_t)
+#define SALT_ALIGN              sizeof(int)
 #ifdef SIMD_COEF_32
-#define MIN_KEYS_PER_CRYPT	SSE_GROUP_SZ_SHA256
-#define MAX_KEYS_PER_CRYPT	SSE_GROUP_SZ_SHA256
+#define MIN_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA256
+#define MAX_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA256
 #else
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 #endif
 
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
@@ -75,10 +72,13 @@ static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/rar_fmt_plug.c
+++ b/src/rar_fmt_plug.c
@@ -52,7 +52,6 @@ john_register_one(&fmt_rar);
 #else
 
 #include <string.h>
-#include <errno.h>
 #if AC_BUILT
 #include "autoconfig.h"
 #endif

--- a/src/rawBLAKE2_512_fmt_plug.c
+++ b/src/rawBLAKE2_512_fmt_plug.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2012 by Solar Designer
  * based on rawMD4_fmt.c code, with trivial changes by groszek.
  *
- * Re-used for BLAKE2 by Dhiru Kholia (dhiru at openwall.com)
+ * Re-used for BLAKE2 by Dhiru Kholia (dhiru at openwall.com).
  */
 
 #if FMT_EXTERNS_H
@@ -12,12 +12,6 @@ extern struct fmt_main fmt_rawBLAKE2;
 john_register_one(&fmt_rawBLAKE2);
 #else
 
-#include "arch.h"
-
-#include "blake2.h"
-#include "params.h"
-#include "common.h"
-#include "formats.h"
 #include <string.h>
 
 #if !FAST_FORMATS_OMP
@@ -26,44 +20,45 @@ john_register_one(&fmt_rawBLAKE2);
 
 #ifdef _OPENMP
 #ifndef OMP_SCALE
-#define OMP_SCALE			2048
+#define OMP_SCALE               2048
 #endif
 #include <omp.h>
 #endif
+
+#include "arch.h"
+#include "blake2.h"
+#include "params.h"
+#include "common.h"
+#include "formats.h"
 #include "memdbg.h"
 
-#define FORMAT_LABEL			"Raw-Blake2"
-#define FORMAT_NAME			""
+#define FORMAT_LABEL            "Raw-Blake2"
+#define FORMAT_NAME             ""
 #if !defined(JOHN_NO_SIMD) && defined(__AVX__)
-#define ALGORITHM_NAME			"128/128 AVX"
+#define ALGORITHM_NAME          "128/128 AVX"
 #elif !defined(JOHN_NO_SIMD) && defined(__XOP__)
-#define ALGORITHM_NAME			"128/128 XOP"
+#define ALGORITHM_NAME          "128/128 XOP"
 #elif !defined(JOHN_NO_SIMD) && defined(__SSE4_1__)
-#define ALGORITHM_NAME			"128/128 SSE4.1"
+#define ALGORITHM_NAME          "128/128 SSE4.1"
 #elif !defined(JOHN_NO_SIMD) && defined(__SSSE3__)
-#define ALGORITHM_NAME			"128/128 SSSE3"
+#define ALGORITHM_NAME          "128/128 SSSE3"
 #elif !defined(JOHN_NO_SIMD) && defined(__SSE2__)
-#define ALGORITHM_NAME			"128/128 SSE2"
+#define ALGORITHM_NAME          "128/128 SSE2"
 #else
-#define ALGORITHM_NAME			"32/" ARCH_BITS_STR
+#define ALGORITHM_NAME          "32/" ARCH_BITS_STR
 #endif
-#define FORMAT_TAG           "$BLAKE2$"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
-
-#define BENCHMARK_COMMENT		""
-#define BENCHMARK_LENGTH		-1
-
-#define PLAINTEXT_LENGTH		125
-#define CIPHERTEXT_LENGTH		128
-
-#define BINARY_SIZE			64
-#define SALT_SIZE			0
-
-#define BINARY_ALIGN			4
-#define SALT_ALIGN			1
-
-#define MIN_KEYS_PER_CRYPT		1
-#define MAX_KEYS_PER_CRYPT		1
+#define FORMAT_TAG              "$BLAKE2$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        125
+#define CIPHERTEXT_LENGTH       128
+#define BINARY_SIZE             64
+#define SALT_SIZE               0
+#define BINARY_ALIGN            4
+#define SALT_ALIGN              1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
 
 static struct fmt_tests tests[] = {
 	{"4245af08b46fbb290222ab8a68613621d92ce78577152d712467742417ebc1153668f1c9e1ec1e152a32a9c242dc686d175e087906377f0c483c5be2cb68953e", "blake2"},
@@ -86,12 +81,13 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_len));

--- a/src/rawKeccak_256_fmt_plug.c
+++ b/src/rawKeccak_256_fmt_plug.c
@@ -75,12 +75,13 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*saved_len));

--- a/src/rawKeccak_512_fmt_plug.c
+++ b/src/rawKeccak_512_fmt_plug.c
@@ -70,12 +70,13 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*saved_len));

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -126,9 +126,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifndef SIMD_COEF_32
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -127,9 +127,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #else
 	self->params.max_keys_per_crypt *= 10;
 #endif

--- a/src/rawMD5flat_fmt_plug.c
+++ b/src/rawMD5flat_fmt_plug.c
@@ -104,9 +104,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	sz = self->params.max_keys_per_crypt * 64;
 #ifndef SIMD_COEF_32

--- a/src/rawSHA1_fmt_plug.c
+++ b/src/rawSHA1_fmt_plug.c
@@ -102,10 +102,13 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t;
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifdef SIMD_COEF_32
 	saved_key = mem_calloc_align(self->params.max_keys_per_crypt/NBKEYS,

--- a/src/rawSHA1_ng_fmt_plug.c
+++ b/src/rawSHA1_ng_fmt_plug.c
@@ -213,9 +213,11 @@ static void sha1_fmt_init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 
 	M   = mem_calloc_align(self->params.max_keys_per_crypt, sizeof(*M),

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -114,9 +114,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifndef SIMD_COEF_32
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -102,9 +102,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifndef SIMD_COEF_32
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rawSHA256_ng_fmt_plug.c
+++ b/src/rawSHA256_ng_fmt_plug.c
@@ -181,12 +181,13 @@ static void init(struct fmt_main *self)
 {
     int i;
 #ifdef _OPENMP
-    int omp_t;
+    int omp_t = omp_get_max_threads();
 
-    omp_t = omp_get_max_threads();
-    self->params.min_keys_per_crypt *= omp_t;
-    omp_t *= OMP_SCALE;
-    self->params.max_keys_per_crypt *= omp_t;
+    if (omp_t > 1) {
+            self->params.min_keys_per_crypt *= omp_t;
+            omp_t *= OMP_SCALE;
+            self->params.max_keys_per_crypt *= omp_t;
+    }
 #endif
     saved_key = mem_calloc_align(self->params.max_keys_per_crypt,
                                  sizeof(*saved_key), VWIDTH * 4);

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -123,12 +123,13 @@ static uint64_t (*crypt_out)[DIGEST_SIZE / sizeof(uint64_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifndef SIMD_COEF_64
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -97,12 +97,13 @@ static uint64_t (*crypt_out)[DIGEST_SIZE / sizeof(uint64_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifndef SIMD_COEF_64
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rawSHA512_ng_fmt_plug.c
+++ b/src/rawSHA512_ng_fmt_plug.c
@@ -189,12 +189,13 @@ static void init(struct fmt_main *self)
 {
     int i;
 #ifdef _OPENMP
-    int omp_t;
+    int omp_t = omp_get_max_threads();
 
-    omp_t = omp_get_max_threads();
-    self->params.min_keys_per_crypt *= omp_t;
-    omp_t *= OMP_SCALE;
-    self->params.max_keys_per_crypt *= omp_t;
+    if (omp_t > 1) {
+        self->params.min_keys_per_crypt *= omp_t;
+        omp_t *= OMP_SCALE;
+        self->params.max_keys_per_crypt *= omp_t;
+    }
 #endif
     saved_key = mem_calloc_align(self->params.max_keys_per_crypt,
                            sizeof(*saved_key), MEM_ALIGN_SIMD);

--- a/src/ripemd_fmt_plug.c
+++ b/src/ripemd_fmt_plug.c
@@ -30,7 +30,6 @@ john_register_one(&fmt_ripemd_128);
 #endif
 
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 // OMP_SCALE tuned on core i7 quad core HT
 //         128     160
@@ -101,10 +100,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE160 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	if (!saved_key) {
 		saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rsvp_fmt_plug.c
+++ b/src/rsvp_fmt_plug.c
@@ -126,9 +126,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/salted_sha1_fmt_plug.c
+++ b/src/salted_sha1_fmt_plug.c
@@ -97,12 +97,13 @@ static unsigned int *saved_len;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifndef SIMD_COEF_32
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/sapG_fmt_plug.c
+++ b/src/sapG_fmt_plug.c
@@ -176,9 +176,12 @@ static void init(struct fmt_main *self)
 
 #if defined (_OPENMP)
 	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 
 	max_keys = self->params.max_keys_per_crypt;

--- a/src/sapH_fmt_plug.c
+++ b/src/sapH_fmt_plug.c
@@ -166,9 +166,12 @@ static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,
 	                         sizeof(*saved_plain));

--- a/src/securezip_fmt_plug.c
+++ b/src/securezip_fmt_plug.c
@@ -58,9 +58,6 @@ john_register_one(&fmt_securezip);
 #define SHA1_SIZE               20
 #endif
 
-#if defined (_OPENMP)
-static int omp_t = 1;
-#endif
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int any_cracked, *cracked;
 static size_t cracked_size;
@@ -69,10 +66,13 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);
 	any_cracked = 0;

--- a/src/sha3_512_fmt_plug.c
+++ b/src/sha3_512_fmt_plug.c
@@ -68,12 +68,13 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));
 	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));

--- a/src/skein_fmt_plug.c
+++ b/src/skein_fmt_plug.c
@@ -25,7 +25,6 @@ john_register_one(&fmt_skein_512);
 #include "params.h"
 #include "options.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 // OMP_SCALE tuned on core i7 quad core HT
 //        256bt  512bt
@@ -93,10 +92,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE512 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/sl3_fmt_plug.c
+++ b/src/sl3_fmt_plug.c
@@ -81,12 +81,13 @@ static uint32_t (*crypt_key)[BINARY_SIZE / 4];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int omp_t = omp_get_max_threads();
 
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 #ifndef SIMD_COEF_32
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/snefru_fmt_plug.c
+++ b/src/snefru_fmt_plug.c
@@ -25,7 +25,6 @@ john_register_one(&fmt_snefru_128);
 #include "params.h"
 #include "options.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 // OMP_SCALE tuned on core i7 quad core HT
 //        128kb   256kb
@@ -76,10 +75,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE256 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	if (!saved_key) {
 		saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/snmp_fmt_plug.c
+++ b/src/snmp_fmt_plug.c
@@ -85,9 +85,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);

--- a/src/ssh_ng_fmt_plug.c
+++ b/src/ssh_ng_fmt_plug.c
@@ -1,4 +1,5 @@
-/* Fast cracker for SSH RSA / DSA key files. Hacked together during October
+/*
+ * Fast cracker for SSH RSA / DSA key files. Hacked together during October
  * of 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * Support for cracking new openssh key format (bcrypt pbkdf) was added by
@@ -11,7 +12,8 @@
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
+ * are permitted.
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_sshng;
@@ -22,14 +24,11 @@ john_register_one(&fmt_sshng);
 #include <string.h>
 #include <stdint.h>
 #include <openssl/des.h>
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
+
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
-#define OMP_SCALE               16 // adjust this dynamically based on the hash type?
+#define OMP_SCALE           16 // adjust this dynamically based on the hash type?
 #endif
 #endif
 
@@ -42,8 +41,8 @@ static int omp_t = 1;
 #include "options.h"
 #include "md5.h"
 #include "bcrypt_pbkdf.h"
-#include "memdbg.h"
 #include "asn1.h"
+#include "memdbg.h"
 
 #define FORMAT_LABEL        "SSH-ng"
 #define FORMAT_NAME         ""
@@ -106,10 +105,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -95,9 +95,12 @@ static void init(struct fmt_main *self)
 #endif
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_len));

--- a/src/sspr_fmt_plug.c
+++ b/src/sspr_fmt_plug.c
@@ -82,9 +82,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);

--- a/src/strip_fmt_plug.c
+++ b/src/strip_fmt_plug.c
@@ -1,10 +1,12 @@
-/* STRIP cracker patch for JtR. Hacked together during September of
+/*
+ * STRIP cracker patch for JtR. Hacked together during September of
  * 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
- * are permitted. */
+ * are permitted.
+ */
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_strip;
@@ -14,8 +16,13 @@ john_register_one(&fmt_strip);
 
 #include <string.h>
 #include <stdint.h>
-#include <assert.h>
-#include <errno.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#ifndef OMP_SCALE
+#define OMP_SCALE               4 // tuned on core i7
+#endif
+#endif
 
 #include "arch.h"
 #include "aes.h"
@@ -26,33 +33,27 @@ john_register_one(&fmt_strip);
 #include "options.h"
 #include "johnswap.h"
 #include "pbkdf2_hmac_sha1.h"
-#ifdef _OPENMP
-#include <omp.h>
-#ifndef OMP_SCALE
-#define OMP_SCALE               4 // tuned on core i7
-#endif
-#endif
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"STRIP"
-#define FORMAT_NAME		"Password Manager"
-#define FORMAT_TAG          "$strip$*"
-#define FORMAT_TAG_LEN      (sizeof(FORMAT_TAG)-1)
+#define FORMAT_LABEL            "STRIP"
+#define FORMAT_NAME             "Password Manager"
+#define FORMAT_TAG              "$strip$*"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
 #ifdef SIMD_COEF_32
-#define ALGORITHM_NAME		"PBKDF2-SHA1 " SHA1_ALGORITHM_NAME
+#define ALGORITHM_NAME          "PBKDF2-SHA1 " SHA1_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME		"PBKDF2-SHA1 32/" ARCH_BITS_STR
+#define ALGORITHM_NAME          "PBKDF2-SHA1 32/" ARCH_BITS_STR
 #endif
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define BINARY_SIZE		0
-#define PLAINTEXT_LENGTH	125
-#define SALT_SIZE		sizeof(struct custom_salt)
-#define BINARY_ALIGN	1
-#define SALT_ALIGN		1
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define BINARY_SIZE             0
+#define PLAINTEXT_LENGTH        125
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              1
 #ifdef SIMD_COEF_32
-#define MIN_KEYS_PER_CRYPT  SSE_GROUP_SZ_SHA1
-#define MAX_KEYS_PER_CRYPT  SSE_GROUP_SZ_SHA1
+#define MIN_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA1
+#define MAX_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA1
 #else
 #define MIN_KEYS_PER_CRYPT	1
 #define MAX_KEYS_PER_CRYPT	1
@@ -84,11 +85,13 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);
@@ -150,7 +153,7 @@ static void set_salt(void *salt)
 	cur_salt = (struct custom_salt *)salt;
 }
 
-/* verify validity of page */
+/* Verify validity of a page */
 static int verify_page(unsigned char *page1)
 {
 	uint32_t pageSize;
@@ -216,14 +219,14 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		       16, ITERATIONS, master[0], 32, 0);
 #endif
 		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i) {
-			//memcpy(output, SQLITE_FILE_HEADER, FILE_HEADER_SZ);
+			// memcpy(output, SQLITE_FILE_HEADER, FILE_HEADER_SZ);
 			size = page_sz - reserve_sz;
 			iv_in = cur_salt->data + size + 16;
 			memcpy(iv_out, iv_in, 16);
 
 			AES_set_decrypt_key(master[i], 256, &akey);
 			/*
-			 * decrypting 8 bytes from offset 16 is enough since the
+			 * Decrypting 8 bytes from offset 16 is enough since the
 			 * verify_page function looks at output[16..23] only.
 			 */
 			AES_cbc_encrypt(cur_salt->data + 16, output + 16, 8, &akey, iv_out, AES_DECRYPT);
@@ -240,6 +243,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 static int cmp_all(void *binary, int count)
 {
 	int index;
+
 	for (index = 0; index < count; index++)
 		if (cracked[index])
 			return 1;
@@ -253,7 +257,7 @@ static int cmp_one(void *binary, int index)
 
 static int cmp_exact(char *source, int index)
 {
-    return 1;
+	return 1;
 }
 
 static void strip_set_key(char *key, int index)

--- a/src/sunmd5_fmt_plug.c
+++ b/src/sunmd5_fmt_plug.c
@@ -236,9 +236,12 @@ static void init(struct fmt_main *self)
 #endif
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 
 #ifdef SIMD_COEF_32
 	ngroups = omp_t;

--- a/src/tcp_md5_fmt_plug.c
+++ b/src/tcp_md5_fmt_plug.c
@@ -77,9 +77,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/tiger_fmt_plug.c
+++ b/src/tiger_fmt_plug.c
@@ -28,7 +28,6 @@ john_register_one(&fmt_tiger);
 #endif
 
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 // OMP_SCALE tuned on core i7 quad core HT
 // 1   -   235k
@@ -81,10 +80,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/truecrypt_fmt_plug.c
+++ b/src/truecrypt_fmt_plug.c
@@ -169,9 +169,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	key_buffer = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*key_buffer));

--- a/src/vdi_fmt_plug.c
+++ b/src/vdi_fmt_plug.c
@@ -101,9 +101,12 @@ static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	key_buffer = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*key_buffer));

--- a/src/vms_fmt_plug.c
+++ b/src/vms_fmt_plug.c
@@ -35,7 +35,6 @@ john_register_one(&fmt_VMS);
 #include "common.h"
 #include "formats.h"
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               1024 // Tuned on K8-Dual HT
@@ -124,10 +123,13 @@ static int valid(char *ciphertext, struct fmt_main *self )
 static void fmt_vms_init ( struct fmt_main *self )
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	/* Init bin 2 hex table for faster conversions later */
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/vtp_fmt_plug.c
+++ b/src/vtp_fmt_plug.c
@@ -101,9 +101,11 @@ static void init(struct fmt_main *self)
 #ifdef _OPENMP
 	int omp_t = omp_get_max_threads();
 
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
 	saved_len = mem_calloc(sizeof(*saved_len), self->params.max_keys_per_crypt);

--- a/src/whirlpool_fmt_plug.c
+++ b/src/whirlpool_fmt_plug.c
@@ -1,5 +1,6 @@
-/* whirlpool cracker patch for JtR. Hacked together during April of 2013 by Dhiru
- * Kholia <dhiru at openwall.com>.
+/*
+ * Whirlpool cracker patch for JtR. Hacked together during April of 2013 by
+ * Dhiru Kholia <dhiru at openwall.com>.
  *
  * This software is Copyright (c) 2013 Dhiru Kholia <dhiru at openwall.com> and
  * it is hereby released to the general public under the following terms:
@@ -19,43 +20,44 @@ john_register_one(&fmt_whirlpool);
 #else
 
 #include <string.h>
-#include "arch.h"
-#include "openssl_local_overrides.h"
-#include "sph_whirlpool.h"
-#include "misc.h"
-#include "common.h"
-#include "formats.h"
-#include "params.h"
-#include "options.h"
-#include <openssl/opensslv.h>
-#if (AC_BUILT && HAVE_WHIRLPOOL) ||	\
-   (!AC_BUILT && OPENSSL_VERSION_NUMBER >= 0x10000000 && !HAVE_NO_SSL_WHIRLPOOL)
-#include <openssl/whrlpool.h>
-#endif
+
 #ifdef _OPENMP
-static int omp_t = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE               256
 #endif
 #endif
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "options.h"
+#include "sph_whirlpool.h"
+#include "openssl_local_overrides.h"
+#include <openssl/opensslv.h>
+#if (AC_BUILT && HAVE_WHIRLPOOL) ||	\
+   (!AC_BUILT && OPENSSL_VERSION_NUMBER >= 0x10000000 && !HAVE_NO_SSL_WHIRLPOOL)
+#include <openssl/whrlpool.h>
+#endif
 #include "memdbg.h"
 
-#define FORMAT_LABEL		"Whirpool"
-#define FORMAT_NAME		""
-#define FORMAT_TAG		"$whirlpool$"
-#define TAG_LENGTH		11
-#define ALGORITHM_NAME		"32/" ARCH_BITS_STR
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	-1
-#define PLAINTEXT_LENGTH	125
-#define CIPHERTEXT_LENGTH	128
-#define BINARY_SIZE		64
-#define SALT_SIZE		0
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
-#define BINARY_ALIGN		4
-#define SALT_ALIGN		1
+#define FORMAT_LABEL            "Whirpool"
+#define FORMAT_NAME             ""
+#define FORMAT_TAG              "$whirlpool$"
+#define TAG_LENGTH              11
+#define ALGORITHM_NAME          "32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define PLAINTEXT_LENGTH        125
+#define CIPHERTEXT_LENGTH       128
+#define BINARY_SIZE             64
+#define SALT_SIZE               0
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+#define BINARY_ALIGN            4
+#define SALT_ALIGN              1
 
 static struct fmt_tests whirlpool_0_tests[] = {
 	{"B3E1AB6EAF640A34F784593F2074416ACCD3B8E62C620175FCA0997B1BA2347339AA0D79E754C308209EA36811DFA40C1C32F1A2B9004725D987D3635165D3C8", ""},
@@ -84,10 +86,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/wow_srp_fmt_plug.c
+++ b/src/wow_srp_fmt_plug.c
@@ -140,9 +140,12 @@ static void init(struct fmt_main *self)
 	int i;
 #if defined (_OPENMP)
 	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*saved_key));

--- a/src/xmpp_scram_fmt_plug.c
+++ b/src/xmpp_scram_fmt_plug.c
@@ -91,11 +91,13 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	static int omp_t = 1;
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int omp_t = omp_get_max_threads();
+
+	if (omp_t > 1) {
+		self->params.min_keys_per_crypt *= omp_t;
+		omp_t *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= omp_t;
+	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*saved_key));


### PR DESCRIPTION
This is related to https://github.com/magnumripper/JohnTheRipper/issues/3001.

I would like to get some feedback before I start changing other files.

Changes,

1. Use the new OpenMP guidelines. Actual OpenMP tuning is left for a new PR.

2. I am using the `newline after variable declarations` rule from the Linux kernel world.

3. In our "format defines block", I am using spaces instead of tabs as spaces work well with every editor.

4. System headers on top, OpenMP a line below, and then rest of the headers.

5. Improved comment style, and formatting a bit.

Update: Not all formats have the same level of cleanups. Doing so would probably take days! This did not occur to me when I started this task.