### PR TITLE
Unify version strings and ignore some files for git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Substitions for git archive
+src/Makefile.in export-subst
+
 # Files/directories to be ignored for git archive
 .circle export-ignore
 .gitattributes export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Files/directories to be ignored for git archive
+.circle export-ignore
+.gitattributes export-ignore
+.github export-ignore
+.gitignore export-ignore
+.gitmodules export-ignore
+.mailmap export-ignore
+.pre-commit.sh export-ignore
+.travis export-ignore
+.travis.yml export-ignore
+circle.yml export-ignore

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -43,9 +43,14 @@ top_srcdir = @top_srcdir@
 srcdir = @srcdir@
 prefix = @prefix@
 
-JTR_GIT_VERSION = \"$(shell git describe --tags --dirty=+ --always 2>/dev/null)\"
-ifeq ($(JTR_GIT_VERSION), \"\")
-JTR_GIT_VERSION = JOHN_VERSION
+JTR_GIT_COMMIT = \"-$(shell git describe --dirty=+ --always 2>/dev/null)\"
+ifeq ($(JTR_GIT_COMMIT), \"-\")
+# this format string will be replaced by git archive:
+JTR_ARCHIVE_VERSION_STRING = "$Format:-%h %ci$"
+JTR_GIT_VERSION = JOHN_VERSION "\"$(JTR_ARCHIVE_VERSION_STRING)\""
+else
+JTR_GIT_HEAD_TS = \" $(shell git show -s --format=%ci HEAD 2>/dev/null)\"
+JTR_GIT_VERSION = JOHN_VERSION "$(JTR_GIT_COMMIT) $(JTR_GIT_HEAD_TS)"
 endif
 
 CPPFLAGS = @CPPFLAGS@

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -46,7 +46,7 @@ prefix = @prefix@
 JTR_GIT_COMMIT = \"-$(shell git describe --dirty=+ --always 2>/dev/null)\"
 ifeq ($(JTR_GIT_COMMIT), \"-\")
 # this format string will be replaced by git archive:
-JTR_ARCHIVE_VERSION_STRING = "$Format:-%h %ci$"
+JTR_ARCHIVE_VERSION_STRING = $Format:-%h %ci$
 JTR_GIT_VERSION = JOHN_VERSION "\"$(JTR_ARCHIVE_VERSION_STRING)\""
 else
 JTR_GIT_HEAD_TS = \" $(shell git show -s --format=%ci HEAD 2>/dev/null)\"


### PR DESCRIPTION
When downloading an archive from github, there are some files which the user doesn't need and which should be ignored.

There has been confusion regarding version strings for quite some time:
-versions of downloaded git archives appeared to be newer than versions for local git repositories
-version strings for local git repos differed based on not annotated tags in local repositories, compared to the github repository or recently cloned github repositories.


This pull request should address the issues discussed in https://github.com/magnumripper/JohnTheRipper/issues/2481 and https://github.com/magnumripper/JohnTheRipper/issues/3014