### PR TITLE
Handle a build outside git and archive

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -42,12 +42,13 @@ subdirs = aes secp256k1 escrypt @ZTEX_SUBDIRS@
 top_srcdir = @top_srcdir@
 srcdir = @srcdir@
 prefix = @prefix@
+F = ""
 
 JTR_GIT_COMMIT = \"-$(shell git describe --dirty=+ --always 2>/dev/null)\"
 ifeq ($(JTR_GIT_COMMIT), \"-\")
 # this format string will be replaced by git archive:
 JTR_ARCHIVE_VERSION_STRING = $Format:-%h %ci$
-JTR_GIT_VERSION = JOHN_VERSION "\"$(JTR_ARCHIVE_VERSION_STRING)\""
+JTR_GIT_VERSION = JOHN_VERSION "\"$(shell echo "$(JTR_ARCHIVE_VERSION_STRING)" | "$(SED)" 's/ormat:-%h %ci/-/g')\""
 else
 JTR_GIT_HEAD_TS = \" $(shell git show -s --format=%ci HEAD 2>/dev/null)\"
 JTR_GIT_VERSION = JOHN_VERSION "$(JTR_GIT_COMMIT) $(JTR_GIT_HEAD_TS)"


### PR DESCRIPTION
I agree that seems unusual, but it can happen. The build will fail if there is any '%'.

The error is:
```
options.c:359:9: error: invalid conversion specifier ' ' [-Werror,-Wformat-invalid-specifier]

        printf(JOHN_USAGE, name);

               ^

options.c:301:20: note: expanded from macro 'JOHN_USAGE'

"John the Ripper " JTR_GIT_VERSION _MP_VERSION DEBUG_STRING MEMDBG_STRING ASAN_STRING UBSAN_STRING " [" JOHN_BLD "]\n" \

                   ^

./version.h:1:48: note: expanded from macro 'JTR_GIT_VERSION'

#define JTR_GIT_VERSION JOHN_VERSION "ormat:-%h %ci"

                                             ~~^

options.c:359:21: error: format specifies type 'int' but the argument has type 'char *' [-Werror,-Wformat]

        printf(JOHN_USAGE, name);

                           ^~~~

options.c:359:9: error: more '%' conversions than data arguments [-Werror,-Wformat]

        printf(JOHN_USAGE, name);

               ^

options.c:305:10: note: expanded from macro 'JOHN_USAGE'

"Usage: %s [OPTIONS] [PASSWORD-FILES]\n" \

        ~^

3 errors generated.

Makefile:1419: recipe for target 'options.o' failed

make[1]: *** [options.o] Error 1

make[1]: *** Waiting for unfinished jobs....

Makefile:186: recipe for target 'default' failed

make: *** [default] Error 2
```