### PR TITLE
maint: remove the usage of 2017q3 worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
 
   - os: linux
     env: ASAN="--enable-asan" TEST="fresh test"
-    group: deprecated-2017Q3
 
   - os: linux
     compiler: gcc


### PR DESCRIPTION
It is no longer needed (the bug in the previous worker was fixed).
* The new image available for Travis fixed whatever was wrong.