### PR TITLE
Rename "omp_t" to "threads"

### DIFF
--- a/src/7z_fmt_plug.c
+++ b/src/7z_fmt_plug.c
@@ -162,12 +162,12 @@ static void init(struct fmt_main *self)
 {
 	CRC32_t crc;
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	// allocate 1 more slot to handle the tail of vector buffer

--- a/src/AzureAD_fmt_plug.c
+++ b/src/AzureAD_fmt_plug.c
@@ -80,12 +80,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(self->params.max_keys_per_crypt,

--- a/src/BFEgg_fmt_plug.c
+++ b/src/BFEgg_fmt_plug.c
@@ -95,12 +95,12 @@ void init(struct fmt_main *self) {
 	const char *pos;
 
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/DMD5_fmt_plug.c
+++ b/src/DMD5_fmt_plug.c
@@ -119,12 +119,12 @@ static struct fmt_tests tests[] = {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/DOMINOSEC8_fmt_plug.c
+++ b/src/DOMINOSEC8_fmt_plug.c
@@ -176,12 +176,12 @@ static struct fmt_tests tests[] = {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));

--- a/src/DOMINOSEC_fmt_plug.c
+++ b/src/DOMINOSEC_fmt_plug.c
@@ -163,12 +163,12 @@ static struct fmt_tests tests[] = {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/EPI_fmt_plug.c
+++ b/src/EPI_fmt_plug.c
@@ -69,12 +69,12 @@ static struct fmt_tests global_tests[] =
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	key_len   = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/FGT_fmt_plug.c
+++ b/src/FGT_fmt_plug.c
@@ -88,12 +88,12 @@ static uint32_t (*crypt_key)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/HDAA_fmt_plug.c
+++ b/src/HDAA_fmt_plug.c
@@ -58,7 +58,7 @@ john_register_one(&fmt_HDAA);
 #define SALT_ALIGN			sizeof(size_t)
 
 #if defined(_OPENMP)
-static unsigned int omp_t = 1;
+static unsigned int threads = 1;
 #ifdef SIMD_COEF_32
 #ifndef OMP_SCALE
 #define OMP_SCALE			256
@@ -159,12 +159,12 @@ static void init(struct fmt_main *self)
 	int i;
 #endif
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
+	threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32
@@ -290,7 +290,7 @@ static int cmp_all(void *binary, int count)
 #ifdef SIMD_COEF_32
 	unsigned int x,y=0;
 #ifdef _OPENMP
-	for (; y < SIMD_PARA_MD5 * omp_t; y++)
+	for (; y < SIMD_PARA_MD5 * threads; y++)
 #else
 	for (; y < SIMD_PARA_MD5; y++)
 #endif

--- a/src/NETLM_fmt_plug.c
+++ b/src/NETLM_fmt_plug.c
@@ -107,12 +107,12 @@ static uchar *challenge;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/NETLMv2_fmt_plug.c
+++ b/src/NETLMv2_fmt_plug.c
@@ -114,12 +114,12 @@ static unsigned char *challenge;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/NETNTLMv2_fmt_plug.c
+++ b/src/NETNTLMv2_fmt_plug.c
@@ -120,12 +120,12 @@ static int keys_prepared;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/NETSPLITLM_fmt_plug.c
+++ b/src/NETSPLITLM_fmt_plug.c
@@ -87,12 +87,12 @@ static uchar *challenge;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/SybasePROP_fmt_plug.c
+++ b/src/SybasePROP_fmt_plug.c
@@ -77,12 +77,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -82,19 +82,19 @@ static uint32_t saved_salt;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_64
 #ifndef _OPENMP
-	int omp_t = 1;
+	int threads = 1;
 #endif
-	saved_key = mem_calloc_align(omp_t, sizeof(*saved_key), MEM_ALIGN_SIMD);
+	saved_key = mem_calloc_align(threads, sizeof(*saved_key), MEM_ALIGN_SIMD);
 	crypt_out = mem_calloc_align(self->params.max_keys_per_crypt,
 	                             8 * sizeof(uint64_t), MEM_ALIGN_SIMD);
 	max_keys = self->params.max_keys_per_crypt;

--- a/src/XSHA_fmt_plug.c
+++ b/src/XSHA_fmt_plug.c
@@ -19,7 +19,7 @@ john_register_one(&fmt_XSHA);
 #define NBKEYS				(SIMD_COEF_32 * SIMD_PARA_SHA1)
 
 #ifdef _OPENMP
-static unsigned int omp_t = 1;
+static unsigned int threads = 1;
 #include <omp.h>
 #ifndef OMP_SCALE
 #define OMP_SCALE			128
@@ -99,10 +99,10 @@ static void init(struct fmt_main *self)
 {
 #ifdef SIMD_COEF_32
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt = omp_t * NBKEYS;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt = omp_t * NBKEYS;
+	threads = omp_get_max_threads();
+	self->params.min_keys_per_crypt = threads * NBKEYS;
+	threads *= OMP_SCALE;
+	self->params.max_keys_per_crypt = threads * NBKEYS;
 #endif
 	saved_key = mem_calloc_align(self->params.max_keys_per_crypt,
 	                             SHA_BUF_SIZ * 4, MEM_ALIGN_SIMD);
@@ -205,7 +205,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int i = 0;
 #if defined(_OPENMP)
 	#pragma omp parallel for
-	for (i=0; i < omp_t; i++) {
+	for (i=0; i < threads; i++) {
 #endif
 		unsigned int *in = &saved_key[i*NBKEYS*SHA_BUF_SIZ];
 		unsigned int *out = &crypt_key[i*NBKEYS*BINARY_SIZE/4];
@@ -240,7 +240,7 @@ static int cmp_all(void *binary, int count)
 	unsigned int x,y=0;
 
 #ifdef _OPENMP
-	for (;y<SIMD_PARA_SHA1*omp_t;y++)
+	for (;y<SIMD_PARA_SHA1*threads;y++)
 #else
 	for (;y<SIMD_PARA_SHA1;y++)
 #endif

--- a/src/agilekeychain_fmt_plug.c
+++ b/src/agilekeychain_fmt_plug.c
@@ -93,12 +93,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/aix_smd5_fmt_plug.c
+++ b/src/aix_smd5_fmt_plug.c
@@ -74,12 +74,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/aix_ssha_fmt_plug.c
+++ b/src/aix_ssha_fmt_plug.c
@@ -125,12 +125,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/androidfde_fmt_plug.c
+++ b/src/androidfde_fmt_plug.c
@@ -101,12 +101,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	max_cracked = self->params.max_keys_per_crypt;

--- a/src/axcrypt_fmt_plug.c
+++ b/src/axcrypt_fmt_plug.c
@@ -91,12 +91,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/bestcrypt_fmt_plug.c
+++ b/src/bestcrypt_fmt_plug.c
@@ -131,12 +131,12 @@ static int *cracked, cracked_count;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -114,12 +114,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/bitlocker_fmt_plug.c
+++ b/src/bitlocker_fmt_plug.c
@@ -70,12 +70,12 @@ static bitlocker_custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/bks_fmt_plug.c
+++ b/src/bks_fmt_plug.c
@@ -89,12 +89,12 @@ static int *cracked, any_cracked;  // "cracked array" approach is required for U
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/blackberry_ES10_fmt_plug.c
+++ b/src/blackberry_ES10_fmt_plug.c
@@ -87,12 +87,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/blockchain_fmt_plug.c
+++ b/src/blockchain_fmt_plug.c
@@ -72,12 +72,12 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/chap_fmt_plug.c
+++ b/src/chap_fmt_plug.c
@@ -91,12 +91,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/citrix_ns_fmt_plug.c
+++ b/src/citrix_ns_fmt_plug.c
@@ -115,12 +115,12 @@ static uint32_t (*crypt_key)[BINARY_SIZE / 4];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32

--- a/src/clipperz_srp_fmt_plug.c
+++ b/src/clipperz_srp_fmt_plug.c
@@ -148,12 +148,12 @@ static void init(struct fmt_main *self)
 {
 	int i;
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/cloudkeychain_fmt_plug.c
+++ b/src/cloudkeychain_fmt_plug.c
@@ -105,12 +105,12 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/cq_fmt_plug.c
+++ b/src/cq_fmt_plug.c
@@ -335,12 +335,12 @@ unsigned int AdEncryptPassword(const char* username, const char* password) {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/crypt-sha1_fmt_plug.c
+++ b/src/crypt-sha1_fmt_plug.c
@@ -86,12 +86,12 @@ static struct saltstruct {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/cryptsha256_fmt_plug.c
+++ b/src/cryptsha256_fmt_plug.c
@@ -229,14 +229,14 @@ static struct saltstruct {
 
 static void init(struct fmt_main *self)
 {
-	int omp_t = 1;
+	int threads = 1;
 	int max_crypts;
 
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	omp_t *= OMP_SCALE;
+	threads = omp_get_max_threads();
+	threads *= OMP_SCALE;
 #endif
-	max_crypts = SIMD_COEF_SCALE * omp_t * MAX_KEYS_PER_CRYPT;
+	max_crypts = SIMD_COEF_SCALE * threads * MAX_KEYS_PER_CRYPT;
 	self->params.max_keys_per_crypt = max_crypts;
 	// we allocate 1 more than needed, and use that 'extra' value as a zero
 	// length PW to fill in the tail groups in MMX mode.

--- a/src/cryptsha512_fmt_plug.c
+++ b/src/cryptsha512_fmt_plug.c
@@ -217,14 +217,14 @@ static struct saltstruct {
 
 static void init(struct fmt_main *self)
 {
-	int omp_t = 1;
+	int threads = 1;
 	int max_crypts;
 
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	omp_t *= OMP_SCALE;
+	threads = omp_get_max_threads();
+	threads *= OMP_SCALE;
 #endif
-	max_crypts = SIMD_COEF_SCALE * omp_t * MAX_KEYS_PER_CRYPT;
+	max_crypts = SIMD_COEF_SCALE * threads * MAX_KEYS_PER_CRYPT;
 	self->params.max_keys_per_crypt = max_crypts;
 	// we allocate 1 more than needed, and use that 'extra' value as a zero
 	// length PW to fill in the tail groups in MMX mode.

--- a/src/dahua_fmt_plug.c
+++ b/src/dahua_fmt_plug.c
@@ -77,12 +77,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/dashlane_fmt_plug.c
+++ b/src/dashlane_fmt_plug.c
@@ -78,12 +78,12 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/django_fmt_plug.c
+++ b/src/django_fmt_plug.c
@@ -99,12 +99,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/django_scrypt_fmt_plug.c
+++ b/src/django_scrypt_fmt_plug.c
@@ -78,12 +78,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/dmg_fmt_plug.c
+++ b/src/dmg_fmt_plug.c
@@ -148,12 +148,12 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/dpapimk_fmt_plug.c
+++ b/src/dpapimk_fmt_plug.c
@@ -118,12 +118,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/dragonfly3_fmt_plug.c
+++ b/src/dragonfly3_fmt_plug.c
@@ -91,12 +91,12 @@ static int salt_len;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/dragonfly4_fmt_plug.c
+++ b/src/dragonfly4_fmt_plug.c
@@ -90,12 +90,12 @@ static int salt_len;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/drupal7_fmt_plug.c
+++ b/src/drupal7_fmt_plug.c
@@ -96,12 +96,12 @@ static char (*crypt_key)[DIGEST_SIZE];
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	EncKey    = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/ecryptfs_fmt_plug.c
+++ b/src/ecryptfs_fmt_plug.c
@@ -100,12 +100,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/eigrp_fmt_plug.c
+++ b/src/eigrp_fmt_plug.c
@@ -96,12 +96,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/electrum_fmt_plug.c
+++ b/src/electrum_fmt_plug.c
@@ -111,12 +111,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/encfs_fmt_plug.c
+++ b/src/encfs_fmt_plug.c
@@ -94,12 +94,12 @@ static void init(struct fmt_main *self)
 		self->params.flags &= ~FMT_OMP;
 	}
 	else {
-		int omp_t = omp_get_max_threads();
+		int threads = omp_get_max_threads();
 
-		if (omp_t > 1) {
-			self->params.min_keys_per_crypt *= omp_t;
-			omp_t *= OMP_SCALE;
-			self->params.max_keys_per_crypt *= omp_t;
+		if (threads > 1) {
+			self->params.min_keys_per_crypt *= threads;
+			threads *= OMP_SCALE;
+			self->params.max_keys_per_crypt *= threads;
 		}
 	}
 #endif

--- a/src/enpass_fmt_plug.c
+++ b/src/enpass_fmt_plug.c
@@ -76,12 +76,12 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/episerver_fmt_plug.c
+++ b/src/episerver_fmt_plug.c
@@ -134,7 +134,7 @@ static struct custom_salt {
 } *cur_salt;
 
 #if defined(_OPENMP) || defined(SIMD_COEF_32)
-static int omp_t = 1;
+static int threads = 1;
 #endif
 
 #ifdef SIMD_COEF_32
@@ -145,12 +145,12 @@ static void episerver_set_key_CP(char *_key, int index);
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
+	threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32
@@ -298,7 +298,7 @@ static void set_salt(void *salt)
 #ifdef SIMD_COEF_32
 	int index, j;
 	cur_salt = (struct custom_salt *)salt;
-	for (index = 0; index < MAX_KEYS_PER_CRYPT*omp_t; ++index)
+	for (index = 0; index < MAX_KEYS_PER_CRYPT*threads; ++index)
 		for (j = 0; j < EFFECTIVE_SALT_SIZE; ++j) // copy the salt to vector buffer
 			((unsigned char*)saved_key)[GETPOS(j, index)] = ((unsigned char*)cur_salt->esalt)[j];
 #else

--- a/src/ethereum_fmt_plug.c
+++ b/src/ethereum_fmt_plug.c
@@ -72,12 +72,12 @@ static union {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/fvde_fmt_plug.c
+++ b/src/fvde_fmt_plug.c
@@ -73,12 +73,12 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/geli_fmt_plug.c
+++ b/src/geli_fmt_plug.c
@@ -65,12 +65,12 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/gost_fmt_plug.c
+++ b/src/gost_fmt_plug.c
@@ -84,12 +84,12 @@ static int is_cryptopro; /* non 0 for CryptoPro hashes */
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	gost_init_table();

--- a/src/gpg_fmt_plug.c
+++ b/src/gpg_fmt_plug.c
@@ -69,12 +69,12 @@ static size_t cracked_size;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc_align(sizeof(*saved_key),

--- a/src/has160_fmt_plug.c
+++ b/src/has160_fmt_plug.c
@@ -72,12 +72,12 @@ static uint32_t (*crypt_out)[(BINARY_SIZE) / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));

--- a/src/haval_fmt_plug.c
+++ b/src/haval_fmt_plug.c
@@ -97,12 +97,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE256 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	if (!saved_key) {

--- a/src/hmacMD5_fmt_plug.c
+++ b/src/hmacMD5_fmt_plug.c
@@ -131,12 +131,12 @@ static void init(struct fmt_main *self)
 	unsigned int i;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32

--- a/src/hmacSHA1_fmt_plug.c
+++ b/src/hmacSHA1_fmt_plug.c
@@ -114,12 +114,12 @@ static void init(struct fmt_main *self)
 	unsigned int i;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32

--- a/src/hmacSHA256_fmt_plug.c
+++ b/src/hmacSHA256_fmt_plug.c
@@ -141,12 +141,12 @@ static void init(struct fmt_main *self, const int B_LEN)
 	int i;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32

--- a/src/hmacSHA512_fmt_plug.c
+++ b/src/hmacSHA512_fmt_plug.c
@@ -147,12 +147,12 @@ static void init(struct fmt_main *self, const int B_LEN)
 	int i;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_64

--- a/src/hsrp_fmt_plug.c
+++ b/src/hsrp_fmt_plug.c
@@ -90,12 +90,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/ike_fmt_plug.c
+++ b/src/ike_fmt_plug.c
@@ -100,12 +100,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/itunes_fmt_plug.c
+++ b/src/itunes_fmt_plug.c
@@ -81,12 +81,12 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/iwork_fmt_plug.c
+++ b/src/iwork_fmt_plug.c
@@ -70,12 +70,12 @@ static struct format_context *fctx;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -121,12 +121,12 @@ static void transform_key(char *masterkey, keepass_salt_t *csp,
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	keepass_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/keychain_fmt_plug.c
+++ b/src/keychain_fmt_plug.c
@@ -95,12 +95,12 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/keyring_fmt_plug.c
+++ b/src/keyring_fmt_plug.c
@@ -93,12 +93,12 @@ static size_t cracked_size;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/keystore_fmt_plug.c
+++ b/src/keystore_fmt_plug.c
@@ -146,12 +146,12 @@ inline static void getPreKeyedHash(int idx)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #elif SIMD_COEF_32
 	self->params.max_keys_per_crypt *= OMP_SCALE;

--- a/src/known_hosts_fmt_plug.c
+++ b/src/known_hosts_fmt_plug.c
@@ -73,12 +73,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/krb5_asrep_fmt_plug.c
+++ b/src/krb5_asrep_fmt_plug.c
@@ -152,12 +152,12 @@ static void init(struct fmt_main *self)
 {
 	unsigned char usage[5];
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_alloc_align(sizeof(*saved_key) *

--- a/src/krb5_db_fmt_plug.c
+++ b/src/krb5_db_fmt_plug.c
@@ -140,12 +140,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/krb5_tgs_fmt_plug.c
+++ b/src/krb5_tgs_fmt_plug.c
@@ -170,12 +170,12 @@ err:
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_alloc_align(sizeof(*saved_key) *

--- a/src/krb5pa-md5_fmt_plug.c
+++ b/src/krb5pa-md5_fmt_plug.c
@@ -130,12 +130,12 @@ static int keys_prepared;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/krb5pa-sha1_fmt_plug.c
+++ b/src/krb5pa-sha1_fmt_plug.c
@@ -121,12 +121,12 @@ static void init(struct fmt_main *self)
 {
 	unsigned char usage[5];
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/kwallet_fmt_plug.c
+++ b/src/kwallet_fmt_plug.c
@@ -91,12 +91,12 @@ static void init(struct fmt_main *self)
 {
 
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/lastpass_cli_fmt_plug.c
+++ b/src/lastpass_cli_fmt_plug.c
@@ -66,12 +66,12 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/lastpass_fmt_plug.c
+++ b/src/lastpass_fmt_plug.c
@@ -66,12 +66,12 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/lastpass_sniffed_fmt_plug.c
+++ b/src/lastpass_sniffed_fmt_plug.c
@@ -91,12 +91,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/leet_cc_fmt_plug.c
+++ b/src/leet_cc_fmt_plug.c
@@ -112,12 +112,12 @@ static void init(struct fmt_main *self)
 {
 	int keys;
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	keys = self->params.max_keys_per_crypt;

--- a/src/lotus85_fmt_plug.c
+++ b/src/lotus85_fmt_plug.c
@@ -293,12 +293,12 @@ static void get_user_id_secret_key(const char *password, uint8_t *secret_key)
 static void lotus85_init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	lotus85_saved_passwords = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/luks_fmt_plug.c
+++ b/src/luks_fmt_plug.c
@@ -286,12 +286,12 @@ static void init(struct fmt_main *self)
 	static int warned = 0;
 //	extern struct fmt_main fmt_luks;
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/md2_fmt_plug.c
+++ b/src/md2_fmt_plug.c
@@ -73,12 +73,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/mdc2_fmt_plug.c
+++ b/src/mdc2_fmt_plug.c
@@ -61,12 +61,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/money_fmt_plug.c
+++ b/src/money_fmt_plug.c
@@ -89,12 +89,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	orig_key = mem_calloc(sizeof(*orig_key), self->params.max_keys_per_crypt);

--- a/src/mongodb_fmt_plug.c
+++ b/src/mongodb_fmt_plug.c
@@ -85,12 +85,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/mongodb_scram_fmt_plug.c
+++ b/src/mongodb_scram_fmt_plug.c
@@ -80,12 +80,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/mozilla_ng_fmt_plug.c
+++ b/src/mozilla_ng_fmt_plug.c
@@ -79,12 +79,12 @@ static  struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/mscash1_fmt_plug.c
+++ b/src/mscash1_fmt_plug.c
@@ -96,10 +96,10 @@ inline static void swap(unsigned int *x, int count)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	fmt_mscash.params.max_keys_per_crypt *= omp_t;
+	int threads = omp_get_max_threads();
+	self->params.min_keys_per_crypt *= threads;
+	threads *= OMP_SCALE;
+	fmt_mscash.params.max_keys_per_crypt *= threads;
 #endif
 
 	ms_buffer1x = mem_calloc(sizeof(ms_buffer1x[0]), 16*fmt_mscash.params.max_keys_per_crypt);

--- a/src/mscash2_fmt_plug.c
+++ b/src/mscash2_fmt_plug.c
@@ -124,12 +124,12 @@ static unsigned int (*crypt_out);
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
-	if (omp_t < 1)
-		omp_t = 1;
-	self->params.min_keys_per_crypt *= omp_t;
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt *= omp_t;
+	int threads = omp_get_max_threads();
+	if (threads < 1)
+		threads = 1;
+	self->params.min_keys_per_crypt *= threads;
+	threads *= OMP_SCALE;
+	self->params.max_keys_per_crypt *= threads;
 #endif
 
 	key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/mssql12_fmt_plug.c
+++ b/src/mssql12_fmt_plug.c
@@ -170,12 +170,12 @@ static void set_key_enc(char *_key, int index);
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_64

--- a/src/multibit_fmt_plug.c
+++ b/src/multibit_fmt_plug.c
@@ -75,12 +75,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/mysql_fmt_plug.c
+++ b/src/mysql_fmt_plug.c
@@ -95,12 +95,12 @@ static uint32_t (*crypt_key)[BINARY_SIZE / 4];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/mysql_netauth_fmt_plug.c
+++ b/src/mysql_netauth_fmt_plug.c
@@ -66,12 +66,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/net_ah_fmt_plug.c
+++ b/src/net_ah_fmt_plug.c
@@ -65,12 +65,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/notes_fmt_plug.c
+++ b/src/notes_fmt_plug.c
@@ -68,12 +68,12 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/nt2_fmt_plug.c
+++ b/src/nt2_fmt_plug.c
@@ -176,12 +176,12 @@ static void init(struct fmt_main *self)
 	int i;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	if (options.target_enc == UTF_8) {

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -969,12 +969,12 @@ bailout:
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP) && !defined(SIMD_COEF_32)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	my = self;

--- a/src/nukedclan_fmt_plug.c
+++ b/src/nukedclan_fmt_plug.c
@@ -95,12 +95,12 @@ inline static void hex_encode(unsigned char *str, int len, unsigned char *out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/o10glogon_fmt_plug.c
+++ b/src/o10glogon_fmt_plug.c
@@ -95,12 +95,12 @@ static DES_key_schedule desschedule1;	// key 0x0123456789abcdef
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);

--- a/src/o3logon_fmt_plug.c
+++ b/src/o3logon_fmt_plug.c
@@ -92,12 +92,12 @@ static DES_key_schedule desschedule1;	// key 0x0123456789abcdef
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);

--- a/src/o5logon_fmt_plug.c
+++ b/src/o5logon_fmt_plug.c
@@ -94,12 +94,12 @@ static void init(struct fmt_main *self)
 	static char Buf[128];
 
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/odf_fmt_plug.c
+++ b/src/odf_fmt_plug.c
@@ -89,12 +89,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/office_fmt_plug.c
+++ b/src/office_fmt_plug.c
@@ -586,12 +586,12 @@ static void GenerateAgileEncryptionKey512(int idx, unsigned char hashBuf[SHA512_
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/oldoffice_fmt_plug.c
+++ b/src/oldoffice_fmt_plug.c
@@ -112,12 +112,12 @@ static custom_salt *cur_salt = &cs;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	if (options.target_enc == UTF_8)

--- a/src/openbsdsoftraid_fmt_plug.c
+++ b/src/openbsdsoftraid_fmt_plug.c
@@ -96,12 +96,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	key_buffer = mem_calloc(sizeof(*key_buffer), self->params.max_keys_per_crypt);

--- a/src/opencl_rar_fmt_plug.c
+++ b/src/opencl_rar_fmt_plug.c
@@ -277,13 +277,13 @@ static void init(struct fmt_main *_self)
 	}
 
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
+	threads = omp_get_max_threads();
 #endif /* _OPENMP */
 
 	if (options.target_enc == UTF_8)
 		self->params.plaintext_length = MIN(125, 3 * PLAINTEXT_LENGTH);
 
-	unpack_data = mem_calloc(omp_t, sizeof(unpack_data_t));
+	unpack_data = mem_calloc(threads, sizeof(unpack_data_t));
 
 	/* CRC-32 table init, do it before we start multithreading */
 	{

--- a/src/openssl_enc_fmt_plug.c
+++ b/src/openssl_enc_fmt_plug.c
@@ -107,12 +107,12 @@ static struct fmt_tests tests[] = {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/oracle12c_fmt_plug.c
+++ b/src/oracle12c_fmt_plug.c
@@ -84,12 +84,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/oracle_fmt_plug.c
+++ b/src/oracle_fmt_plug.c
@@ -213,12 +213,12 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule_static);

--- a/src/ospf_fmt_plug.c
+++ b/src/ospf_fmt_plug.c
@@ -76,12 +76,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/padlock_fmt_plug.c
+++ b/src/padlock_fmt_plug.c
@@ -95,12 +95,12 @@ static int *cracked, cracked_count;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/palshop_fmt_plug.c
+++ b/src/palshop_fmt_plug.c
@@ -64,12 +64,12 @@ static size_t *saved_len;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/panama_fmt_plug.c
+++ b/src/panama_fmt_plug.c
@@ -74,12 +74,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/pbkdf2-hmac-md4_fmt_plug.c
+++ b/src/pbkdf2-hmac-md4_fmt_plug.c
@@ -58,12 +58,12 @@ static uint32_t (*crypt_out)[PBKDF2_MDx_BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));

--- a/src/pbkdf2-hmac-md5_fmt_plug.c
+++ b/src/pbkdf2-hmac-md5_fmt_plug.c
@@ -59,12 +59,12 @@ static uint32_t (*crypt_out)[PBKDF2_MDx_BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));

--- a/src/pbkdf2-hmac-sha1_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha1_fmt_plug.c
@@ -68,12 +68,12 @@ static uint32_t (*crypt_out)[PBKDF2_SHA1_BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/pbkdf2-hmac-sha512_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha512_fmt_plug.c
@@ -80,12 +80,12 @@ static uint32_t (*crypt_out)[PBKDF2_SHA512_BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/pbkdf2_hmac_sha256_fmt_plug.c
@@ -84,12 +84,12 @@ static uint32_t (*crypt_out)[PBKDF2_SHA256_BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/pdf_fmt_plug.c
+++ b/src/pdf_fmt_plug.c
@@ -102,12 +102,12 @@ static struct fmt_tests pdf_tests[] = {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/pem_fmt_plug.c
+++ b/src/pem_fmt_plug.c
@@ -65,12 +65,12 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/pfx_fmt_plug.c
+++ b/src/pfx_fmt_plug.c
@@ -85,12 +85,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/pgpdisk_fmt_plug.c
+++ b/src/pgpdisk_fmt_plug.c
@@ -59,12 +59,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE * 2 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/pgpsda_fmt_plug.c
+++ b/src/pgpsda_fmt_plug.c
@@ -57,12 +57,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE * 2 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/pgpwde_fmt_plug.c
+++ b/src/pgpwde_fmt_plug.c
@@ -93,12 +93,12 @@ static void S2KPGPWDE(char *password, unsigned char *salt, unsigned char *key, i
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/phpassMD5_fmt_plug.c
+++ b/src/phpassMD5_fmt_plug.c
@@ -105,12 +105,12 @@ static unsigned loopCnt;
 
 static void init(struct fmt_main *self) {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32

--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -399,12 +399,12 @@ static void init(struct fmt_main *self)
 	unsigned short n=0;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/pomelo_fmt_plug.c
+++ b/src/pomelo_fmt_plug.c
@@ -75,12 +75,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	if (!saved_key) {

--- a/src/postgres_fmt_plug.c
+++ b/src/postgres_fmt_plug.c
@@ -91,12 +91,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/pst_fmt_plug.c
+++ b/src/pst_fmt_plug.c
@@ -76,12 +76,12 @@ static uint32_t (*crypt_out);
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/putty_fmt_plug.c
+++ b/src/putty_fmt_plug.c
@@ -89,12 +89,12 @@ static struct fmt_tests putty_tests[] = {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/pwsafe_fmt_plug.c
+++ b/src/pwsafe_fmt_plug.c
@@ -84,12 +84,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/qnx_fmt_plug.c
+++ b/src/qnx_fmt_plug.c
@@ -94,14 +94,14 @@ static struct qnx_saltstruct {
 
 static void init(struct fmt_main *self)
 {
-	int omp_t = 1;
+	int threads = 1;
 	int max_crypts;
 
 #ifdef _OPENMP
-	omp_t = omp_get_max_threads();
-	omp_t *= OMP_SCALE;
+	threads = omp_get_max_threads();
+	threads *= OMP_SCALE;
 #endif
-	max_crypts = SIMD_COEF_SCALE * omp_t * MAX_KEYS_PER_CRYPT;
+	max_crypts = SIMD_COEF_SCALE * threads * MAX_KEYS_PER_CRYPT;
 	self->params.max_keys_per_crypt = max_crypts;
 	// we allocate 1 more than needed, and use that 'extra' value as a zero
 	// length PW to fill in the tail groups in MMX mode.
@@ -109,8 +109,8 @@ static void init(struct fmt_main *self)
 	saved_key = mem_calloc(1 + max_crypts, sizeof(*saved_key));
 	crypt_out = mem_calloc(1 + max_crypts, sizeof(*crypt_out));
 #ifdef SIMD_COEF_32
-	for (omp_t = 1; omp_t <= PLAINTEXT_LENGTH; ++omp_t)
-		sk_by_len[omp_t] = mem_calloc(1+max_crypts, sizeof(int));
+	for (threads = 1; threads <= PLAINTEXT_LENGTH; ++threads)
+		sk_by_len[threads] = mem_calloc(1+max_crypts, sizeof(int));
 #endif
 }
 

--- a/src/racf_fmt_plug.c
+++ b/src/racf_fmt_plug.c
@@ -152,12 +152,12 @@ static int dirty;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/radmin_fmt_plug.c
+++ b/src/radmin_fmt_plug.c
@@ -75,12 +75,12 @@ static uint32_t (*crypt_out)[8];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rakp_fmt_plug.c
+++ b/src/rakp_fmt_plug.c
@@ -114,12 +114,12 @@ static void init(struct fmt_main *self)
 	int i;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32

--- a/src/rar5_fmt_plug.c
+++ b/src/rar5_fmt_plug.c
@@ -72,12 +72,12 @@ static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/rar_common.c
+++ b/src/rar_common.c
@@ -8,7 +8,7 @@
 
 #include "misc.h"	// error()
 
-static int omp_t = 1;
+static int threads = 1;
 static unsigned char *saved_salt;
 static unsigned char *saved_key;
 static int (*cracked);

--- a/src/rar_fmt_plug.c
+++ b/src/rar_fmt_plug.c
@@ -144,9 +144,9 @@ static uint32_t (*tmp_out)[NBKEYS*5];
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	self->params.max_keys_per_crypt *= omp_t;
+	threads = omp_get_max_threads();
+	self->params.min_keys_per_crypt *= threads;
+	self->params.max_keys_per_crypt *= threads;
 #endif /* _OPENMP */
 
 	// Length is a cost. We sort in buckets but we need them to be mostly full
@@ -155,7 +155,7 @@ static void init(struct fmt_main *self)
 	if (options.target_enc == UTF_8)
 		self->params.plaintext_length = MIN(125, 3 * PLAINTEXT_LENGTH);
 
-	unpack_data = mem_calloc(omp_t, sizeof(unpack_data_t));
+	unpack_data = mem_calloc(threads, sizeof(unpack_data_t));
 	cracked = mem_calloc(self->params.max_keys_per_crypt,
 	                     sizeof(*cracked));
 	// allocate 1 more slot to handle the tail of vector buffer

--- a/src/rawBLAKE2_512_fmt_plug.c
+++ b/src/rawBLAKE2_512_fmt_plug.c
@@ -81,12 +81,12 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rawKeccak_256_fmt_plug.c
+++ b/src/rawKeccak_256_fmt_plug.c
@@ -75,12 +75,12 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rawKeccak_512_fmt_plug.c
+++ b/src/rawKeccak_512_fmt_plug.c
@@ -70,12 +70,12 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -125,12 +125,12 @@ static uint32_t (*crypt_key)[4];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifndef SIMD_COEF_32

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -126,12 +126,12 @@ static uint32_t (*crypt_key)[4];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #else
 	self->params.max_keys_per_crypt *= 10;

--- a/src/rawMD5flat_fmt_plug.c
+++ b/src/rawMD5flat_fmt_plug.c
@@ -103,12 +103,12 @@ static uint32_t (*crypt_key)[DIGEST_SIZE/4];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	sz = self->params.max_keys_per_crypt * 64;

--- a/src/rawSHA1_fmt_plug.c
+++ b/src/rawSHA1_fmt_plug.c
@@ -100,14 +100,14 @@ static unsigned SSEi_flags;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t;
+	int threads;
 
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifdef SIMD_COEF_32

--- a/src/rawSHA1_ng_fmt_plug.c
+++ b/src/rawSHA1_ng_fmt_plug.c
@@ -211,12 +211,12 @@ inline static uint32_t __attribute__((const)) bswap32(uint32_t value)
 static void sha1_fmt_init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -113,12 +113,12 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifndef SIMD_COEF_32

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -101,12 +101,12 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifndef SIMD_COEF_32

--- a/src/rawSHA256_ng_fmt_plug.c
+++ b/src/rawSHA256_ng_fmt_plug.c
@@ -181,12 +181,12 @@ static void init(struct fmt_main *self)
 {
     int i;
 #ifdef _OPENMP
-    int omp_t = omp_get_max_threads();
+    int threads = omp_get_max_threads();
 
-    if (omp_t > 1) {
-            self->params.min_keys_per_crypt *= omp_t;
-            omp_t *= OMP_SCALE;
-            self->params.max_keys_per_crypt *= omp_t;
+    if (threads > 1) {
+            self->params.min_keys_per_crypt *= threads;
+            threads *= OMP_SCALE;
+            self->params.max_keys_per_crypt *= threads;
     }
 #endif
     saved_key = mem_calloc_align(self->params.max_keys_per_crypt,

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -123,12 +123,12 @@ static uint64_t (*crypt_out)[DIGEST_SIZE / sizeof(uint64_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifndef SIMD_COEF_64

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -97,12 +97,12 @@ static uint64_t (*crypt_out)[DIGEST_SIZE / sizeof(uint64_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifndef SIMD_COEF_64

--- a/src/rawSHA512_ng_fmt_plug.c
+++ b/src/rawSHA512_ng_fmt_plug.c
@@ -189,12 +189,12 @@ static void init(struct fmt_main *self)
 {
     int i;
 #ifdef _OPENMP
-    int omp_t = omp_get_max_threads();
+    int threads = omp_get_max_threads();
 
-    if (omp_t > 1) {
-        self->params.min_keys_per_crypt *= omp_t;
-        omp_t *= OMP_SCALE;
-        self->params.max_keys_per_crypt *= omp_t;
+    if (threads > 1) {
+        self->params.min_keys_per_crypt *= threads;
+        threads *= OMP_SCALE;
+        self->params.max_keys_per_crypt *= threads;
     }
 #endif
     saved_key = mem_calloc_align(self->params.max_keys_per_crypt,

--- a/src/ripemd_fmt_plug.c
+++ b/src/ripemd_fmt_plug.c
@@ -100,12 +100,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE160 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	if (!saved_key) {

--- a/src/rsvp_fmt_plug.c
+++ b/src/rsvp_fmt_plug.c
@@ -124,12 +124,12 @@ static  struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/salted_sha1_fmt_plug.c
+++ b/src/salted_sha1_fmt_plug.c
@@ -97,12 +97,12 @@ static unsigned int *saved_len;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifndef SIMD_COEF_32

--- a/src/sapB_fmt_plug.c
+++ b/src/sapB_fmt_plug.c
@@ -43,7 +43,7 @@ john_register_one(&fmt_sapB);
 
 #if defined(_OPENMP)
 #include <omp.h>
-static unsigned int omp_t = 1;
+static unsigned int threads = 1;
 #ifdef SIMD_COEF_32
 #ifndef OMP_SCALE
 #define OMP_SCALE			512	// tuned on K8-dual HT.
@@ -198,10 +198,10 @@ static void init(struct fmt_main *self)
 		fprintf(stderr, "Warning: SAP-B format should never be UTF-8.\nUse --target-encoding=iso-8859-1 or whatever is applicable.\n");
 
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt = (omp_t * MIN_KEYS_PER_CRYPT);
-	omp_t *= OMP_SCALE;
-	self->params.max_keys_per_crypt = (omp_t * MAX_KEYS_PER_CRYPT);
+	threads = omp_get_max_threads();
+	self->params.min_keys_per_crypt = (threads * MIN_KEYS_PER_CRYPT);
+	threads *= OMP_SCALE;
+	self->params.max_keys_per_crypt = (threads * MAX_KEYS_PER_CRYPT);
 #endif
 #ifdef SIMD_COEF_32
 	saved_key  = mem_calloc_align(self->params.max_keys_per_crypt,
@@ -313,7 +313,7 @@ static int cmp_all(void *binary, int count) {
 	unsigned int x,y=0;
 
 #ifdef _OPENMP
-	for (;y<SIMD_PARA_MD5*omp_t;y++)
+	for (;y<SIMD_PARA_MD5*threads;y++)
 #else
 	for (;y<SIMD_PARA_MD5;y++)
 #endif
@@ -515,7 +515,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #if defined(_OPENMP)
 	int t;
 #pragma omp parallel for
-	for (t = 0; t < omp_t; t++)
+	for (t = 0; t < threads; t++)
 #define ti (t*NBKEYS+index)
 #else
 #define t  0

--- a/src/sapG_fmt_plug.c
+++ b/src/sapG_fmt_plug.c
@@ -42,7 +42,7 @@ john_register_one(&fmt_sapG);
 
 #define ALGORITHM_NAME			"SHA1 " SHA1_ALGORITHM_NAME
 
-static unsigned int omp_t = 1;
+static unsigned int threads = 1;
 #if defined(_OPENMP)
 #include <omp.h>
 #ifndef OMP_SCALE
@@ -175,12 +175,12 @@ static void init(struct fmt_main *self)
 		self->params.plaintext_length = UTF8_PLAINTEXT_LENGTH;
 
 #if defined (_OPENMP)
-	omp_t = omp_get_max_threads();
+	threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 
@@ -294,7 +294,7 @@ static void *get_salt(char *ciphertext)
 
 static void clear_keys(void)
 {
-	memset(keyLen, 0, sizeof(*keyLen) * omp_t * MAX_KEYS_PER_CRYPT);
+	memset(keyLen, 0, sizeof(*keyLen) * threads * MAX_KEYS_PER_CRYPT);
 }
 
 static void set_key(char *key, int index)

--- a/src/sapH_fmt_plug.c
+++ b/src/sapH_fmt_plug.c
@@ -165,12 +165,12 @@ static struct sapH_salt {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_plain = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/securezip_fmt_plug.c
+++ b/src/securezip_fmt_plug.c
@@ -66,12 +66,12 @@ static struct custom_salt *cur_salt;
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key),  self->params.max_keys_per_crypt);

--- a/src/sha3_512_fmt_plug.c
+++ b/src/sha3_512_fmt_plug.c
@@ -68,12 +68,12 @@ static uint32_t (*crypt_out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));

--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -66,12 +66,12 @@ unsigned char *challenge;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/sip_fmt_plug.c
+++ b/src/sip_fmt_plug.c
@@ -83,12 +83,12 @@ static char bin2hex_table[256][2]; /* table for bin<->hex mapping */
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	/* Init bin 2 hex table for faster conversions later */

--- a/src/skein_fmt_plug.c
+++ b/src/skein_fmt_plug.c
@@ -92,12 +92,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE512 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/sl3_fmt_plug.c
+++ b/src/sl3_fmt_plug.c
@@ -81,12 +81,12 @@ static uint32_t (*crypt_key)[BINARY_SIZE / 4];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 #ifndef SIMD_COEF_32

--- a/src/snefru_fmt_plug.c
+++ b/src/snefru_fmt_plug.c
@@ -75,12 +75,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE256 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	if (!saved_key) {

--- a/src/snmp_fmt_plug.c
+++ b/src/snmp_fmt_plug.c
@@ -83,12 +83,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/ssh_ng_fmt_plug.c
+++ b/src/ssh_ng_fmt_plug.c
@@ -105,12 +105,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -94,12 +94,12 @@ static void init(struct fmt_main *self)
 	unsigned int i, j;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_len = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/sspr_fmt_plug.c
+++ b/src/sspr_fmt_plug.c
@@ -80,12 +80,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/stribog_fmt_plug.c
+++ b/src/stribog_fmt_plug.c
@@ -97,12 +97,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE_512 / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	if (!saved_key) {

--- a/src/strip_fmt_plug.c
+++ b/src/strip_fmt_plug.c
@@ -85,12 +85,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/sunmd5_fmt_plug.c
+++ b/src/sunmd5_fmt_plug.c
@@ -235,16 +235,16 @@ static void init(struct fmt_main *self)
 	int j, k, ngroups = 1;
 #endif
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 
 #ifdef SIMD_COEF_32
-	ngroups = omp_t;
+	ngroups = threads;
 #endif
 #endif
 

--- a/src/sxc_fmt_plug.c
+++ b/src/sxc_fmt_plug.c
@@ -89,12 +89,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/tacacs_plus_fmt_plug.c
+++ b/src/tacacs_plus_fmt_plug.c
@@ -84,12 +84,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/tcp_md5_fmt_plug.c
+++ b/src/tcp_md5_fmt_plug.c
@@ -75,12 +75,12 @@ static struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/tiger_fmt_plug.c
+++ b/src/tiger_fmt_plug.c
@@ -80,12 +80,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/truecrypt_fmt_plug.c
+++ b/src/truecrypt_fmt_plug.c
@@ -168,12 +168,12 @@ static struct fmt_tests tests_all[] = {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	key_buffer = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/vdi_fmt_plug.c
+++ b/src/vdi_fmt_plug.c
@@ -100,12 +100,12 @@ static struct vdi_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	key_buffer = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/vms_fmt_plug.c
+++ b/src/vms_fmt_plug.c
@@ -123,12 +123,12 @@ static int valid(char *ciphertext, struct fmt_main *self )
 static void fmt_vms_init ( struct fmt_main *self )
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	/* Init bin 2 hex table for faster conversions later */

--- a/src/vnc_fmt_plug.c
+++ b/src/vnc_fmt_plug.c
@@ -136,12 +136,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	des_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/vtp_fmt_plug.c
+++ b/src/vtp_fmt_plug.c
@@ -99,12 +99,12 @@ static  struct custom_salt {
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);

--- a/src/wbb3_fmt_plug.c
+++ b/src/wbb3_fmt_plug.c
@@ -92,12 +92,12 @@ inline static void hex_encode(unsigned char *str, int len, unsigned char *out)
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/whirlpool_fmt_plug.c
+++ b/src/whirlpool_fmt_plug.c
@@ -86,12 +86,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/wow_srp_fmt_plug.c
+++ b/src/wow_srp_fmt_plug.c
@@ -139,12 +139,12 @@ static void init(struct fmt_main *self)
 {
 	int i;
 #if defined (_OPENMP)
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/wpapmk_fmt_plug.c
+++ b/src/wpapmk_fmt_plug.c
@@ -51,9 +51,9 @@ extern mic_t *mic;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	self->params.max_keys_per_crypt *= omp_t;
+	int threads = omp_get_max_threads();
+	self->params.min_keys_per_crypt *= threads;
+	self->params.max_keys_per_crypt *= threads;
 #endif
 
 	assert(sizeof(hccap_t) == HCCAP_SIZE);

--- a/src/wpapsk_fmt_plug.c
+++ b/src/wpapsk_fmt_plug.c
@@ -77,9 +77,9 @@ extern mic_t *mic;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
-	self->params.min_keys_per_crypt *= omp_t;
-	self->params.max_keys_per_crypt *= omp_t;
+	int threads = omp_get_max_threads();
+	self->params.min_keys_per_crypt *= threads;
+	self->params.max_keys_per_crypt *= threads;
 #endif
 
 	assert(sizeof(hccap_t) == HCCAP_SIZE);

--- a/src/xmpp_scram_fmt_plug.c
+++ b/src/xmpp_scram_fmt_plug.c
@@ -91,12 +91,12 @@ static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/zip_fmt_plug.c
+++ b/src/zip_fmt_plug.c
@@ -125,12 +125,12 @@ static my_salt *saved_salt;
 static void init(struct fmt_main *self)
 {
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,

--- a/src/zipmonster_fmt_plug.c
+++ b/src/zipmonster_fmt_plug.c
@@ -76,12 +76,12 @@ static void init(struct fmt_main *self)
 	int i;
 	char buf[3];
 #ifdef _OPENMP
-	int omp_t = omp_get_max_threads();
+	int threads = omp_get_max_threads();
 
-	if (omp_t > 1) {
-		self->params.min_keys_per_crypt *= omp_t;
-		omp_t *= OMP_SCALE;
-		self->params.max_keys_per_crypt *= omp_t;
+	if (threads > 1) {
+		self->params.min_keys_per_crypt *= threads;
+		threads *= OMP_SCALE;
+		self->params.max_keys_per_crypt *= threads;
 	}
 #endif
 	saved_key = mem_calloc(self->params.max_keys_per_crypt,


### PR DESCRIPTION
From http://www.openwall.com/lists/john-dev/2017/12/17/1,

And I've just realized that we should also rename the "omp_t" variable,
since its current name is confusing (the _t suffix is commonly used on
typedef's), reserved by POSIX (all *_t are), and isn't comfortably
unlikely not to clash with whatever a future version of POSIX might
define.  In the core tree, I happen to have called a similar variable
simply "n".  That's in the *_init() functions in DES_bs.c and MD5_std.c.
If we'd like a more descriptive name (such as in one format where this
needs to be a global static variable), it can be e.g. "threads".