### PR TITLE
NT-old: Honor the --disable-simd configure option. Closes #3044.

### DIFF
--- a/src/x86-64.S
+++ b/src/x86-64.S
@@ -1741,6 +1741,8 @@ CPU_detect_fail:
 	ret
 #endif
 
+
+#ifndef JOHN_NO_SIMD
 /* The following was written by Alain Espinosa <alainesp at gmail.com> in 2007.
  * No copyright is claimed, and the software is hereby placed in the public domain.
  * In case this attempt to disclaim copyright and place the software in the
@@ -2098,6 +2100,8 @@ nt_crypt_all_8859_1_x86_64:
 	xchgq %r8,%rax
 	EPILOGUE
 	ret
+
+#endif /* !defined JOHN_NO_SIMD */
 
 #if defined(__ELF__) && defined(__linux__)
 .section .note.GNU-stack,"",@progbits

--- a/src/x86-64.h
+++ b/src/x86-64.h
@@ -372,7 +372,9 @@
 
 #define SHA_BUF_SIZ			16
 
+#ifndef JOHN_NO_SIMD
 #define NT_X86_64
+#endif
 
 #endif /* __SSE2__ */
 

--- a/src/x86-sse.h
+++ b/src/x86-sse.h
@@ -315,6 +315,8 @@
 
 #define SHA_BUF_SIZ			16
 
+#ifndef JOHN_NO_SIMD
 #define NT_SSE2
+#endif
 
 #endif


### PR DESCRIPTION
Not sure if something is needed for 32-bit builds