### PR TITLE
Fix for uninitialized variables

### DIFF
--- a/src/NETLM_fmt_plug.c
+++ b/src/NETLM_fmt_plug.c
@@ -253,7 +253,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 static int cmp_all(void *binary, int count)
 {
-	int index;
+	int index = 0;
 #if defined(_OPENMP) || MAX_KEYS_PER_CRYPT > 1
 	for (index = 0; index < count; index++)
 #endif

--- a/src/hmacMD5_fmt_plug.c
+++ b/src/hmacMD5_fmt_plug.c
@@ -409,7 +409,7 @@ static int cmp_all(void *binary, int count)
 
 	return 0;
 #else
-	int index;
+	int index = 0;
 
 #if defined(_OPENMP) || (MAX_KEYS_PER_CRYPT > 1)
 	for (index = 0; index < count; index++)

--- a/src/hmacSHA1_fmt_plug.c
+++ b/src/hmacSHA1_fmt_plug.c
@@ -333,7 +333,7 @@ static int cmp_all(void *binary, int count)
 
 	return 0;
 #else
-	int index;
+	int index = 0;
 
 #if defined(_OPENMP) || (MAX_KEYS_PER_CRYPT > 1)
 	for (index = 0; index < count; index++)

--- a/src/hmacSHA256_fmt_plug.c
+++ b/src/hmacSHA256_fmt_plug.c
@@ -422,7 +422,7 @@ static int cmp_all(void *binary, int count)
 	}
 	return 0;
 #else
-	int index;
+	int index = 0;
 
 #if defined(_OPENMP) || (MAX_KEYS_PER_CRYPT > 1)
 	for (index = 0; index < count; index++)

--- a/src/hmacSHA512_fmt_plug.c
+++ b/src/hmacSHA512_fmt_plug.c
@@ -476,7 +476,7 @@ static int cmp_all(void *binary, int count)
 	}
 	return 0;
 #else
-	int index;
+	int index = 0;
 #if defined(_OPENMP) || (MAX_KEYS_PER_CRYPT > 1)
 	for (index = 0; index < count; index++)
 #endif


### PR DESCRIPTION
Variable 'index' is used uninitialized in non-SIMD non-OpenMP builds.

* The style can be improved later (two initializations happening). I'm just fixing a bug.