### PR TITLE
Add OpenCL support for OpenBSD-SoftRAID stuff

### DIFF
--- a/src/opencl_openbsdsoftraid_fmt_plug.c
+++ b/src/opencl_openbsdsoftraid_fmt_plug.c
@@ -1,0 +1,386 @@
+/*
+ * JtR OpenCL format to crack OpenBSD-SoftRAID hashes.
+ *
+ * This software is Copyright (c) 2017, Dhiru Kholia <dhiru at openwall.com>,
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * The OpenCL boilerplate code is borrowed from other OpenCL formats.
+ */
+
+#ifdef HAVE_OPENCL
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_opencl_openbsd_softraid;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_opencl_openbsd_softraid);
+#else
+
+#include <string.h>
+#include <stdint.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "arch.h"
+#include "formats.h"
+#include "common.h"
+#include "options.h"
+#include "jumbo.h"
+#include "common-opencl.h"
+#include "misc.h"
+#include "aes.h"
+#include "sha.h"
+#include "hmac_sha.h"
+#define OUTLEN (32)
+#include "opencl_pbkdf2_hmac_sha1.h"
+#include "openbsdsoftraid_common.h"
+#include "openbsdsoftraid_variable_code.h"
+
+#define FORMAT_LABEL            "OpenBSD-SoftRAID-opencl"
+#define OCL_ALGORITHM_NAME      "PBKDF2-SHA1 OpenCL"
+#define CPU_ALGORITHM_NAME      " AES"
+#define ALGORITHM_NAME          OCL_ALGORITHM_NAME CPU_ALGORITHM_NAME
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1000
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+#define PLAINTEXT_LENGTH        64
+#define SALT_SIZE               sizeof(*cur_salt)
+#define SALT_ALIGN              MEM_ALIGN_WORD
+
+/* This handles all widths */
+#define GETPOS(i, index)        (((index) % ocl_v_width) * 4 + ((i) & ~3U) * ocl_v_width + (((i) & 3) ^ 3) + ((index) / ocl_v_width) * 64 * ocl_v_width)
+
+static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+static struct custom_salt *cur_salt;
+static size_t key_buf_size;
+static unsigned int *inbuffer;
+static pbkdf2_out *output;
+static pbkdf2_salt currentsalt;
+static cl_mem mem_in, mem_out, mem_salt, mem_state;
+static size_t key_buf_size;
+static int new_keys;
+static struct fmt_main *self;
+
+static cl_kernel pbkdf2_init, pbkdf2_loop, pbkdf2_final;
+
+#define cracked_size (sizeof(*cracked) * global_work_size * ocl_v_width)
+
+/*
+ * HASH_LOOPS is ideally made by factors of (iteration count - 1) and should
+ * be chosen for a kernel duration of not more than 200 ms
+ */
+#define HASH_LOOPS              (3 * 271) // XXX
+#define ITERATIONS              100000 /* Just for auto tune */
+#define LOOP_COUNT              (((currentsalt.iterations - 1 + HASH_LOOPS - 1)) / HASH_LOOPS)
+#define STEP                    0
+#define SEED                    128
+
+static const char * warn[] = {
+	"P xfer: "  ,  ", init: "   , ", loop: " , ", final: ", ", res xfer: "
+};
+
+static int split_events[] = { 2, -1, -1 };
+
+//This file contains auto-tuning routine(s). Has to be included after formats definitions.
+#include "opencl_autotune.h"
+#include "memdbg.h"
+
+/* ------- Helper functions ------- */
+static size_t get_task_max_work_group_size()
+{
+	size_t s;
+
+	s = autotune_get_task_max_work_group_size(FALSE, 0, pbkdf2_init);
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, pbkdf2_loop));
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, pbkdf2_final));
+	return s;
+}
+
+static void create_clobj(size_t gws, struct fmt_main *self)
+{
+	gws *= ocl_v_width;
+	key_buf_size = 64 * gws;
+
+	// Allocate memory
+	inbuffer = mem_calloc(1, key_buf_size);
+	output = mem_alloc(sizeof(pbkdf2_out) * gws);
+	crypt_out = mem_calloc(gws, sizeof(*crypt_out));
+
+	mem_in = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, key_buf_size, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem in");
+	mem_salt = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, sizeof(pbkdf2_salt), NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem setting");
+	mem_out = clCreateBuffer(context[gpu_id], CL_MEM_WRITE_ONLY, sizeof(pbkdf2_out) * gws, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem out");
+
+	mem_state = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE, sizeof(pbkdf2_state) * gws, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem_state");
+
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_init, 0, sizeof(mem_in), &mem_in), "Error while setting mem_in kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_init, 1, sizeof(mem_salt), &mem_salt), "Error while setting mem_salt kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_init, 2, sizeof(mem_state), &mem_state), "Error while setting mem_state kernel argument");
+
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_loop, 0, sizeof(mem_state), &mem_state), "Error while setting mem_state kernel argument");
+
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_final, 0, sizeof(mem_salt), &mem_salt), "Error while setting mem_salt kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_final, 1, sizeof(mem_out), &mem_out), "Error while setting mem_out kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_final, 2, sizeof(mem_state), &mem_state), "Error while setting mem_state kernel argument");
+}
+
+static void release_clobj(void)
+{
+	if (crypt_out) {
+		HANDLE_CLERROR(clReleaseMemObject(mem_in), "Release mem in");
+		HANDLE_CLERROR(clReleaseMemObject(mem_salt), "Release mem setting");
+		HANDLE_CLERROR(clReleaseMemObject(mem_state), "Release mem state");
+		HANDLE_CLERROR(clReleaseMemObject(mem_out), "Release mem out");
+
+		MEM_FREE(inbuffer);
+		MEM_FREE(output);
+	}
+}
+
+static void done(void)
+{
+	if (autotuned) {
+		release_clobj();
+
+		HANDLE_CLERROR(clReleaseKernel(pbkdf2_init), "Release kernel");
+		HANDLE_CLERROR(clReleaseKernel(pbkdf2_loop), "Release kernel");
+		HANDLE_CLERROR(clReleaseKernel(pbkdf2_final), "Release kernel");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program");
+
+		autotuned--;
+	}
+}
+
+static void init(struct fmt_main *_self)
+{
+	static char valgo[sizeof(ALGORITHM_NAME) + 8] = "";
+
+	self = _self;
+
+	opencl_prepare_dev(gpu_id);
+	/* VLIW5 does better with just 2x vectors due to GPR pressure */
+	if (!options.v_width && amd_vliw5(device_info[gpu_id]))
+		ocl_v_width = 2;
+	else
+		ocl_v_width = opencl_get_vector_width(gpu_id, sizeof(cl_int));
+
+	if (ocl_v_width > 1) {
+		/* Run vectorized kernel */
+		snprintf(valgo, sizeof(valgo),
+		         OCL_ALGORITHM_NAME " %ux" CPU_ALGORITHM_NAME, ocl_v_width);
+		self->params.algorithm_name = valgo;
+	}
+}
+
+static void reset(struct db_main *db)
+{
+	if (!autotuned) {
+		char build_opts[64];
+
+		snprintf(build_opts, sizeof(build_opts),
+		         "-DHASH_LOOPS=%u -DOUTLEN=%u "
+		         "-DPLAINTEXT_LENGTH=%u -DV_WIDTH=%u",
+		         HASH_LOOPS, OUTLEN, PLAINTEXT_LENGTH, ocl_v_width);
+		opencl_init("$JOHN/kernels/pbkdf2_hmac_sha1_kernel.cl", gpu_id, build_opts);
+
+		pbkdf2_init = clCreateKernel(program[gpu_id], "pbkdf2_init", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+		crypt_kernel = pbkdf2_loop = clCreateKernel(program[gpu_id], "pbkdf2_loop", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+		pbkdf2_final = clCreateKernel(program[gpu_id], "pbkdf2_final", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+
+		// Initialize openCL tuning (library) for this format.
+		opencl_init_auto_setup(SEED, 2 * HASH_LOOPS, split_events,
+		                       warn, 2, self, create_clobj,
+		                       release_clobj,
+		                       ocl_v_width * sizeof(pbkdf2_state), 0, db);
+
+		// Auto tune execution from shared/included code.
+		autotune_run(self, 2 * (ITERATIONS - 1) + 4, 0,
+		             (cpu(device_info[gpu_id]) ?
+		              1000000000 : 10000000000ULL));
+	}
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (struct custom_salt*)salt;
+	memcpy((char*)currentsalt.salt, cur_salt->salt, OPENBSD_SOFTRAID_SALTLENGTH);
+	currentsalt.length = OPENBSD_SOFTRAID_SALTLENGTH;
+	currentsalt.iterations = cur_salt->num_iterations;
+	currentsalt.outlen = 32;
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_salt, CL_FALSE, 0, sizeof(pbkdf2_salt), &currentsalt, 0, NULL, NULL), "Copy salt to gpu");
+}
+
+static void clear_keys(void)
+{
+	memset(inbuffer, 0, key_buf_size);
+}
+
+static int valid(char *ciphertext, struct fmt_main *self)
+{
+        return openbsdsoftraid_valid(ciphertext, self, 0);
+}
+
+static void set_key(char *key, int index)
+{
+	int i;
+	int length = strlen(key);
+
+	for (i = 0; i < length; i++)
+		((char*)inbuffer)[GETPOS(i, index)] = key[i];
+
+	new_keys = 1;
+}
+
+static char *get_key(int index)
+{
+	static char ret[PLAINTEXT_LENGTH + 1];
+	int i = 0;
+
+	while (i < PLAINTEXT_LENGTH &&
+	       (ret[i] = ((char*)inbuffer)[GETPOS(i, index)]))
+		i++;
+	ret[i] = 0;
+
+	return ret;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int i, j, index;
+	size_t scalar_gws;
+	size_t *lws = local_work_size ? &local_work_size : NULL;
+
+	global_work_size = GET_MULTIPLE_OR_BIGGER_VW(count, local_work_size);
+	scalar_gws = global_work_size * ocl_v_width;
+
+	// Copy data to gpu
+	if (ocl_autotune_running || new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
+		new_keys = 0;
+	}
+
+	// Run kernels
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], pbkdf2_init, 1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]), "Run initial kernel");
+
+	for (j = 0; j < (ocl_autotune_running ? 1 : (currentsalt.outlen + 19) / 20); j++) {
+		for (i = 0; i < (ocl_autotune_running ? 1 : LOOP_COUNT); i++) {
+			BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], pbkdf2_loop, 1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[2]), "Run loop kernel");
+			BENCH_CLERROR(clFinish(queue[gpu_id]), "Error running loop kernel");
+			opencl_process_event();
+		}
+
+		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], pbkdf2_final, 1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[3]), "Run intermediate kernel");
+	}
+
+	// Read the result back
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0, sizeof(pbkdf2_out) * scalar_gws, output, 0, NULL, multi_profilingEvent[4]), "Copy result back");
+
+	if (!ocl_autotune_running) {
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+		for (index = 0; index < count; index++) {
+			unsigned char unmasked_keys[OPENBSD_SOFTRAID_KEYLENGTH * OPENBSD_SOFTRAID_KEYS];
+			unsigned char hashed_mask_key[20];
+			AES_KEY akey;
+			int k;
+
+			AES_set_decrypt_key((unsigned char*)output[index].dk, 256, &akey);
+			for (k = 0; k < (OPENBSD_SOFTRAID_KEYLENGTH * OPENBSD_SOFTRAID_KEYS) / 16;  k++) {
+				AES_decrypt(&cur_salt->masked_keys[16*k], &unmasked_keys[16*k], &akey);
+			}
+
+			/* get SHA1 of mask_key */
+			SHA1((unsigned char*)output[index].dk, 32, hashed_mask_key);
+			hmac_sha1(hashed_mask_key, OPENBSD_SOFTRAID_MACLENGTH,
+					unmasked_keys, OPENBSD_SOFTRAID_KEYLENGTH * OPENBSD_SOFTRAID_KEYS,
+					(unsigned char*)crypt_out[index], 20);
+		}
+	}
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main fmt_opencl_openbsd_softraid = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
+		{ NULL },
+		{ FORMAT_TAG },
+		tests_openbsdsoftraid
+	}, {
+		init,
+		done,
+		reset,
+		fmt_default_prepare,
+		valid,
+		fmt_default_split,
+		openbsdsoftraid_get_binary,
+		openbsdsoftraid_get_salt,
+		{ NULL },
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */
+
+#endif /* HAVE_OPENCL */


### PR DESCRIPTION
This fixes https://github.com/magnumripper/JohnTheRipper/issues/3021 (Add OpenCL support for OpenBSD-SoftRAID stuff)

Also see PR https://github.com/magnumripper/JohnTheRipper/pull/3052.

A pure GPU format can be done later by improving upon this code.

Current performance,

```
$ ../run/john --test --format=OpenBSD-SoftRAID --cost=1,8192  # i7-6600U CPU
Will run 4 OpenMP threads
Benchmarking: OpenBSD-SoftRAID (8192 iterations) [PBKDF2-SHA1 256/256 AVX2 8x]... (4xOMP) DONE
Speed for cost 1 (kdf) of 1, cost 2 (iteration count) of 8192
Raw:	2407 c/s real, 706 c/s virtual
```

```
$ ../run/john --test --format=OpenBSD-SoftRAID-OpenCL
Will run 32 OpenMP threads
Device 6: GeForce GTX TITAN X
Benchmarking: OpenBSD-SoftRAID-opencl [PBKDF2-SHA1 OpenCL AES]... (32xOMP) DONE
Raw:	103260 c/s real, 13327 c/s virtual
```