### PR TITLE
Make some compilation warnings just a message

### DIFF
--- a/src/compiler_message.h
+++ b/src/compiler_message.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of John the Ripper password cracker.
+ *
+ * Developed by Claudio André <claudioandre.br at gmail.com> in 2017
+ *
+ * Copyright (c) 2017 Claudio André <claudioandre.br at gmail.com>
+ * This program comes with ABSOLUTELY NO WARRANTY; express or implied.
+ *
+ * This is free software, and you are welcome to redistribute it
+ * under certain conditions; as expressed here
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+#ifndef _JTR_CC_MESSAGE_H
+#define _JTR_CC_MESSAGE_H
+
+#if __GNUC__ && GCC_VERSION >= 40201	// 4.2.1
+#pragma message JTR_CC_MESSAGE
+#elif _MSC_VER
+#pragma message(JTR_CC_MESSAGE)
+#else
+#warning JTR_CC_MESSAGE
+#endif
+
+#endif /* _JTR_CC_MESSAGE_H */

--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -1779,11 +1779,8 @@ struct fmt_main fmt_pkzip = {
 #else
 
 #if !defined(FMT_EXTERNS_H) && !defined(FMT_REGISTERS_H)
-#ifdef __GNUC__
-#warning pkzip format requires zlib to function. The format has been disabled
-#elif _MSC_VER
-#pragma message(": warning pkzip format requires zlib to function. The format has been disabled :")
-#endif
+#define JTR_CC_MESSAGE "Notice: pkzip format requires zlib to function; format disabled."
+#include "compiler_message.h"
 #endif
 
 #endif /* HAVE_LIBZ */

--- a/src/rar_fmt_plug.c
+++ b/src/rar_fmt_plug.c
@@ -438,11 +438,8 @@ struct fmt_main fmt_rar = {
 
 #else
 #if !defined(FMT_EXTERNS_H) && !defined(FMT_REGISTERS_H)
-#ifdef __GNUC__
-#warning ": target system requires aligned memory access, rar format disabled:"
-#elif _MSC_VER
-#pragma message(": target system requires aligned memory access, rar format disabled:")
-#endif
+#define JTR_CC_MESSAGE "Notice: target system requires aligned memory access; rar format disabled."
+#include "compiler_message.h"
 #endif
 
 #endif	/* ARCH_ALLOWS_UNALIGNED */

--- a/src/stribog_fmt_plug.c
+++ b/src/stribog_fmt_plug.c
@@ -472,10 +472,7 @@ struct fmt_main fmt_stribog_512 = {
 
 #else
 #if !defined(FMT_EXTERNS_H) && !defined(FMT_REGISTERS_H)
-#ifdef __GNUC__
-#warning Stribog-256 and Stribog-512 formats require SSE 4.1, formats disabled
-#elif _MSC_VER
-#pragma message(": warning Stribog-256 and Stribog-512 formats require SSE 4.1, formats disabled:")
-#endif
+#define JTR_CC_MESSAGE "Notice: Stribog-256 and Stribog-512 formats require SSE 4.1, formats disabled."
+#include "compiler_message.h"
 #endif
 #endif /* __SSE4_1__ */

--- a/src/wpapmk_fmt_plug.c
+++ b/src/wpapmk_fmt_plug.c
@@ -28,11 +28,9 @@ john_register_one(&fmt_wpapsk_pmk);
 
 #define FORMAT_LABEL		"wpapsk-pmk"
 #if !HAVE_OPENSSL_CMAC_H
-#ifdef _MSC_VER
-#pragma message ("Notice: WPAPMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.")
-#else
-#warning Notice: WPAPMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.
-#endif
+#define JTR_CC_MESSAGE "Notice: WPAPMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL."
+#include "compiler_message.h"
+
 #define FORMAT_NAME		"WPA/WPA2 master key"
 #else
 #define FORMAT_NAME		"WPA/WPA2/PMF master key"

--- a/src/wpapsk_fmt_plug.c
+++ b/src/wpapsk_fmt_plug.c
@@ -50,11 +50,9 @@ john_register_one(&fmt_wpapsk);
 
 #define FORMAT_LABEL		"wpapsk"
 #if !HAVE_OPENSSL_CMAC_H
-#ifdef _MSC_VER
-#pragma message("Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.")
-#else
-#warning Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.
-#endif
+#define JTR_CC_MESSAGE "Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL."
+#include "compiler_message.h"
+
 #define FORMAT_NAME		"WPA/WPA2 PSK"
 #else
 #define FORMAT_NAME		"WPA/WPA2/PMF PSK"


### PR DESCRIPTION
The message is informational. It is neither a compilation warning nor an error.

### Summary

- Will allow to use -werror everywhere.
- Works on Linux and CygWin. Lets see how other OS will behave.
- gcc and clang.