### PR TITLE
Remove any tag from the JtR version

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -44,7 +44,7 @@ srcdir = @srcdir@
 prefix = @prefix@
 F = ""
 
-JTR_GIT_COMMIT = \"-$(shell git describe --dirty=+ --always 2>/dev/null)\"
+JTR_GIT_COMMIT = \"-$(shell git rev-parse --short HEAD 2>/dev/null)\"
 ifeq ($(JTR_GIT_COMMIT), \"-\")
 # this format string will be replaced by git archive:
 JTR_ARCHIVE_VERSION_STRING = $Format:-%h %ci$


### PR DESCRIPTION
* 'git describe' is no longer suitable to use while versioning. The versioning information was added to `param.h` recently.

### Summary

See #3047 