### PR TITLE
Remove .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test"]
-	path = test
-	url = https://github.com/magnumripper/jtrTestSuite.git


### PR DESCRIPTION
### Summary

Why does it exist in the first place? It is useless without a `git submodule add <url> <path>` run. If anyone wants sub-modules, just run the `git submodule add` and commit the "result".

### Other Information

It is making my life harder and I failed to see any reason for it.
