### PR TITLE
Legacy build fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Substitions for git archive
 src/Makefile.in export-subst
+src/Makefile.legacy export-subst
 
 # Files/directories to be ignored for git archive
 .circle export-ignore

--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -30,9 +30,15 @@ SORT = sort
 STRIP = strip
 MAKE_ORIG = +$(MAKE) -f Makefile.legacy
 
-JTR_GIT_VERSION = \"$(shell git describe --tags --dirty=+ 2>/dev/null)\"
-ifeq ($(JTR_GIT_VERSION), \"\")
-JTR_GIT_VERSION = JUMBO_VERSION
+JTR_GIT_COMMIT = \"-$(shell git rev-parse --short HEAD 2>/dev/null)\"
+ifeq ($(JTR_GIT_COMMIT), \"-\")
+F = "" # for tarballs or zip files not created using git archive
+# this format string will be replaced by git archive:
+JTR_ARCHIVE_VERSION_STRING = $Format:-%h %ci$
+JTR_GIT_VERSION = JUMBO_VERSION "\"$(shell echo "$(JTR_ARCHIVE_VERSION_STRING)" | "$(SED)" 's/ormat:-%h %ci/-/g')\""
+else
+JTR_GIT_HEAD_TS = \" $(shell git show -s --format=%ci HEAD 2>/dev/null)\"
+JTR_GIT_VERSION = JUMBO_VERSION "$(JTR_GIT_COMMIT) $(JTR_GIT_HEAD_TS)"
 endif
 
 ## Uncomment the line below for MPI (can be used together with OMP as well)

--- a/src/jumbo.h
+++ b/src/jumbo.h
@@ -40,7 +40,7 @@
 
 #include <stdint.h>
 #define __STDC_FORMAT_MACROS
-#if (AC_BUILT && HAVE_INTTYPES_H) && ! defined(_MSC_VER)
+#if (!AC_BUILT || HAVE_INTTYPES_H) && ! defined(_MSC_VER)
 #include <inttypes.h>
 #else
 #ifndef PRIx64

--- a/src/rar_common.c
+++ b/src/rar_common.c
@@ -118,8 +118,8 @@ typedef struct {
 		unsigned int w;
 		unsigned char c[4];
 	} crc;
-	unsigned long long pack_size;
-	unsigned long long unp_size;
+	uint64_t pack_size;
+	uint64_t unp_size;
 	int method;
 	unsigned char blob_hash[20]; // holds an sha1, but could be 'any' hash.
 	// raw_data should be word aligned, and 'ok'
@@ -181,8 +181,8 @@ static void *get_salt(char *ciphertext)
 	} else {
 		char *p = strtokm(NULL, "*");
 		char crc_c[4];
-		unsigned long long pack_size;
-		unsigned long long unp_size;
+		uint64_t pack_size;
+		uint64_t unp_size;
 
 		for (i = 0; i < 4; i++)
 			crc_c[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16 + atoi16[ARCH_INDEX(p[i * 2 + 1])];
@@ -548,7 +548,7 @@ inline static void check_rar(int count)
 				CRC32_t crc;
 				unsigned char crc_out[4];
 				unsigned char plain[0x8000];
-				unsigned long long size = cur_file->unp_size;
+				uint64_t size = cur_file->unp_size;
 				unsigned char *cipher = cur_file->blob;
 
 				/* Use full decryption with CRC check.

--- a/src/wpapmk.h
+++ b/src/wpapmk.h
@@ -13,7 +13,7 @@
 
 #include <stdint.h>
 #include <assert.h>
-#if HAVE_OPENSSL_CMAC_H
+#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
 #include <openssl/cmac.h>
 #endif
 
@@ -65,7 +65,7 @@ typedef struct {
 static struct fmt_tests tests[] = {
 	{"$WPAPSK$test#..qHuv0A..ZPYJBRzZwAKpEXUJwpza/b69itFaq4.OWoGHfonpc13zCAUsRIfQN2Zar6EXp2BYcRuSkWEJIWjEJJvb4DWZCspbZ51.21.3zy.EY.6........../zZwAKpEXUJwpza/b69itFaq4.OWoGHfonpc13zCAUsQ..................................................................BoK.31m.E2..31m.U2..31m.U2..31m.U................................................................................................................................................................................/X.....E...AkkDQmDg9837LBHG.dGlKA", "cdd79a5acfb070c7e9d1023b870285d639e430b32f31aa37ac825a55b55524ee"},
 	{"$WPAPSK$Coherer#..l/Uf7J..qHUXMunTE3nfbMWSwxv27Ua0XutIOrfRSuv9gOCIugIVGlosMyXdNxfBZUAYmgKqeb6GBPxLiIZr56NtWTGR/Cp5ldAk61.5I0.Ec.2...........nTE3nfbMWSwxv27Ua0XutIOrfRSuv9gOCIugIVGlosM.................................................................3X.I.E..1uk0.E..1uk2.E..1uk0....................................................................................................................................................................................../t.....U...8FWdk8OpPckhewBwt4MXYI", "a288fcf0caaacda9a9f58633ff35e8992a01d9c10ba5e02efdf8cb5d730ce7bc"},
-#if HAVE_OPENSSL_CMAC_H || defined(JOHN_OCL_WPAPMK)
+#if (!AC_BUILT || HAVE_OPENSSL_CMAC_H) || defined(JOHN_OCL_WPAPMK)
 	{"$WPAPSK$Neheb#g9a8Jcre9D0WrPnEN4QXDbA5NwAy5TVpkuoChMdFfL/8Dus4i/X.lTnfwuw04ASqHgvo12wJYJywulb6pWM6C5uqiMPNKNe9pkr6LE61.5I0.Eg.2..........1N4QXDbA5NwAy5TVpkuoChMdFfL/8Dus4i/X.lTnfwuw.................................................................3X.I.E..1uk2.E..1uk2.E..1uk4X...................................................................................................................................................................................../t.....k...0sHl.mVkiHW.ryNchcMd4g", "fb57668cd338374412c26208d79aa5c30ce40a110224f3cfb592a8f2e8bf53e8"},
 #endif
 	{NULL}
@@ -182,7 +182,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		return 0;
 	if (hccap->keyver < 1)
 		return 0;
-#if HAVE_OPENSSL_CMAC_H || defined(JOHN_OCL_WPAPMK)
+#if (!AC_BUILT || HAVE_OPENSSL_CMAC_H) || defined(JOHN_OCL_WPAPMK)
 	if (hccap->keyver > 3)
 		return 0;
 #else
@@ -256,7 +256,7 @@ static void set_salt(void *salt)
 
 #ifndef JOHN_OCL_WPAPMK
 
-#if HAVE_OPENSSL_CMAC_H
+#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
 
 /* Code borrowed from https://w1.fi/wpa_supplicant/ starts */
 
@@ -411,7 +411,7 @@ static void wpapsk_postprocess(int keys)
 			hmac_sha1((unsigned char*)prf, 16, hccap.eapol,
 			          hccap.eapol_size, mic[i].keymic, 16);
 		}
-#if HAVE_OPENSSL_CMAC_H
+#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
 	} else if (hccap.keyver == 3) { // 802.11w, WPA-PSK-SHA256
 #ifdef _OPENMP
 #pragma omp parallel for default(none) private(i) shared(keys, outbuffer, data, hccap, mic)

--- a/src/wpapmk_fmt_plug.c
+++ b/src/wpapmk_fmt_plug.c
@@ -27,7 +27,7 @@ john_register_one(&fmt_wpapsk_pmk);
 #include "memdbg.h"
 
 #define FORMAT_LABEL		"wpapsk-pmk"
-#if !HAVE_OPENSSL_CMAC_H
+#if AC_BUILT && !HAVE_OPENSSL_CMAC_H
 #ifdef _MSC_VER
 #pragma message ("Notice: WPAPMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.")
 #else
@@ -120,7 +120,7 @@ struct fmt_main fmt_wpapsk_pmk = {
 		MAX_KEYS_PER_CRYPT,
 		FMT_OMP,
 		{
-#if HAVE_OPENSSL_CMAC_H
+#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
 			"key version [1:WPA 2:WPA2 3:802.11w]"
 #else
 			"key version [1:WPA 2:WPA2]"

--- a/src/wpapsk.h
+++ b/src/wpapsk.h
@@ -13,7 +13,7 @@
 
 #include <stdint.h>
 #include <assert.h>
-#if HAVE_OPENSSL_CMAC_H
+#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
 #include <openssl/cmac.h>
 #endif
 
@@ -69,7 +69,7 @@ static struct fmt_tests tests[] = {
 	/* Maximum length, 63 characters */
 	{"$WPAPSK$Greased Lighting#kA5.CDNB.07cofsOMXEEUwFTkO/RX2sQUaW9eteI8ynpFMwRgFZC6kk7bGqgvfcXnuF1f7L5fgn4fQMLmDrKjdBNjb6LClRmfLiTYk21.5I0.Ec............7MXEEUwFTkO/RX2sQUaW9eteI8ynpFMwRgFZC6kk7bGo.................................................................3X.I.E..1uk2.E..1uk2.E..1uk00...................................................................................................................................................................................../t.....U...D06LUdWVfGPaP1Oa3AV9Hg", "W*A5z&1?op2_L&Hla-OA$#5i_Lu@F+6d?je?u5!6+6766eluu7-l+jOEkIwLe90"},
 	{"$WPAPSK$hello#JUjQmBbOHUY4RTqMpGc9EjqGdCxMZPWNXBNd1ejNDoFuemrLl27juYlDDUDMgZfery1qJTHYVn2Faso/kUDDjr3y8gspK7viz8BCJE21.5I0.Ec............/pGc9EjqGdCxMZPWNXBNd1ejNDoFuemrLl27juYlDDUA.................................................................3X.I.E..1uk2.E..1uk2.E..1uk0....................................................................................................................................................................................../t.....U...9Py59nqygwiar49oOKA3RY", "12345678"},
-#if HAVE_OPENSSL_CMAC_H || defined(JOHN_OCL_WPAPSK)
+#if (!AC_BUILT || HAVE_OPENSSL_CMAC_H) || defined(JOHN_OCL_WPAPSK)
 	/* 802.11w with WPA-PSK-SHA256 */
 	{"$WPAPSK$hello#HY6.hTXZv.v27BkPGuhkCnLAKxYHlTWYs.4yuqVSNAip3SeixhErtNMV30LZAA3uaEfy2U2tJQi.VICk4hqn3V5m7W3lNHSJYW5vLE21.5I0.Eg............/GuhkCnLAKxYHlTWYs.4yuqVSNAip3SeixhErtNMV30I.................................................................3X.I.E..1uk2.E..1uk2.E..1uk4....................................................................................................................................................................................../t.....k.../Ms4UxzvlNw5hOM1igIeo6", "password"},
 	/* 802.11w with WPA-PSK-SHA256, https://github.com/neheb */
@@ -193,7 +193,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		return 0;
 	if (hccap->keyver < 1)
 		return 0;
-#if HAVE_OPENSSL_CMAC_H || defined(JOHN_OCL_WPAPSK)
+#if (!AC_BUILT || HAVE_OPENSSL_CMAC_H) || defined(JOHN_OCL_WPAPSK)
 	if (hccap->keyver > 3)
 		return 0;
 #else
@@ -337,7 +337,7 @@ static char *get_key(int index)
 	return ret;
 }
 
-#if HAVE_OPENSSL_CMAC_H
+#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
 
 /* Code borrowed from https://w1.fi/wpa_supplicant/ starts */
 
@@ -492,7 +492,7 @@ static void wpapsk_postprocess(int keys)
 			hmac_sha1((unsigned char*)prf, 16, hccap.eapol,
 			          hccap.eapol_size, mic[i].keymic, 16);
 		}
-#if HAVE_OPENSSL_CMAC_H
+#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
 	} else if (hccap.keyver == 3) { // 802.11w, WPA-PSK-SHA256
 #ifdef _OPENMP
 #pragma omp parallel for default(none) private(i) shared(keys, outbuffer, data, hccap, mic)

--- a/src/wpapsk_fmt_plug.c
+++ b/src/wpapsk_fmt_plug.c
@@ -49,7 +49,7 @@ john_register_one(&fmt_wpapsk);
 #include "memdbg.h"
 
 #define FORMAT_LABEL		"wpapsk"
-#if !HAVE_OPENSSL_CMAC_H
+#if AC_BUILT && !HAVE_OPENSSL_CMAC_H
 #ifdef _MSC_VER
 #pragma message("Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.")
 #else
@@ -192,7 +192,7 @@ struct fmt_main fmt_wpapsk = {
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_OMP,
 		{
-#if HAVE_OPENSSL_CMAC_H
+#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
 			"key version [1:WPA 2:WPA2 3:802.11w]"
 #else
 			"key version [1:WPA 2:WPA2]"


### PR DESCRIPTION
### Summary

Several fixes for legacy builds.

Legacy build warnings (linux-x86-64-native on an AVX system) introduced with commit 136a3e8:
```
rar2john.c: In function 'process_file':
rar2john.c:353:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'long unsigned int' [-Wformat=]
            "! HEAD_SIZE: %d, PACK_SIZE: %"PRIu64", UNP_SIZE: %"PRIu64"\n",
            ^
rar2john.c:353:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 5 has type 'long unsigned int' [-Wformat=]
rar2john.c:556:40: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
   best_len += sprintf(&best[best_len], "*%"PRIu64"*%"PRIu64"*",
                                        ^
rar2john.c:556:40: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'long unsigned int' [-Wformat=]
zip2john.c: In function 'process_file':
zip2john.c:292:24: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
      cp += sprintf(cp, "*%"PRIx64"*", real_cmpr_len);
                        ^
zip2john.c: In function 'LoadZipBlob':
zip2john.c:662:11: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 8 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
           "%s->%s PKZIP%s Encr:%s%s cmplen=%"PRIu64", decmplen=%"PRIu64", crc=%X\n",
           ^
zip2john.c:662:11: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 9 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
zip2john.c: In function 'process_old_zip':
zip2john.c:818:11: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 4 has type 'long unsigned int' [-Wformat=]
    printf("1*%x*%x*%"PRIx64"*%s*%s*", hashes[i].magic_type, hashes[i].cmptype, (uint64_t)len, hashes[i].chksum, hashes[i].chksum2);
           ^
zip2john.c:823:11: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
    printf("%x*%x*%"PRIx64"*%"PRIx64"*%x*%"PRIx64"*%"PRIx64"*%x*", 2, hashes[0].magic_type, hashes[0].cmp_len, hashes[0].decomp_len, hashes[0].crc, hashes[0].offset, hashes[0].offex, hashes[0].cmptype);
           ^
zip2john.c:823:11: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 5 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
zip2john.c:823:11: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 7 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
zip2john.c:823:11: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 8 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
zip2john.c:824:11: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
    printf("%"PRIx64"*%s*%s*", hashes[0].cmp_len, hashes[0].chksum, hashes[0].chksum2);
           ^
pkzip.c: In function 'winzip_common_valid':
pkzip.c:112:26: warning: format '%llx' expects argument of type 'long long unsigned int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
  sscanf((const char*)cp, "%"PRIx64, &val);
                          ^
pkzip_fmt_plug.c: In function 'valid':
pkzip_fmt_plug.c:251:15: warning: format '%llx' expects argument of type 'long long unsigned int *', but argument 3 has type 'u64 * {aka long unsigned int *}' [-Wformat=]
    sscanf(cp, "%"PRIx64, &complen);
               ^
pkzip_fmt_plug.c:280:14: warning: format '%llx' expects argument of type 'long long unsigned int *', but argument 3 has type 'u64 * {aka long unsigned int *}' [-Wformat=]
   sscanf(cp, "%"PRIx64, &data_len);
              ^
pkzip_fmt_plug.c: In function 'get_salt':
pkzip_fmt_plug.c:596:15: warning: format '%llx' expects argument of type 'long long unsigned int *', but argument 3 has type 'u64 * {aka long unsigned int *}' [-Wformat=]
    sscanf(cp, "%"PRIx64, &(salt->compLen));
               ^
pkzip_fmt_plug.c:598:15: warning: format '%llx' expects argument of type 'long long unsigned int *', but argument 3 has type 'u64 * {aka long unsigned int *}' [-Wformat=]
    sscanf(cp, "%"PRIx64, &(salt->deCompLen));
               ^
pkzip_fmt_plug.c:609:14: warning: format '%llx' expects argument of type 'long long unsigned int *', but argument 3 has type 'u64 * {aka long unsigned int *}' [-Wformat=]
   sscanf(cp, "%"PRIx64, &(salt->H[i].datlen));
              ^
zip_fmt_plug.c: In function 'get_salt':
zip_fmt_plug.c:173:27: warning: format '%llx' expects argument of type 'long long unsigned int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
  sscanf((const char *)cp, "%"PRIx64, &salt.comp_len);
                           ^
logger.c: In function 'log_guess':
logger.c:498:28: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
                            " as candidate #%"PRIu64,
                            ^
mask.c: In function 'mask_save_state':
mask.c:1821:16: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
  fprintf(file, "%"PRIu64"\n", rec_cand + 1);
                ^
mask.c:1826:17: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   fprintf(file, "%"PRIu64"\n", cand_length + 1);
                 ^
mask.c: In function 'mask_restore_state':
mask.c:1839:19: warning: format '%llu' expects argument of type 'long long unsigned int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
  if (fscanf(file, "%"PRIu64"\n", &ull) == 1)
                   ^
mask.c:1859:20: warning: format '%llu' expects argument of type 'long long unsigned int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
   if (fscanf(file, "%"PRIu64"\n", &ull) == 1)
                    ^
status.c: In function 'status_print_cracking':
status.c:302:15: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   sprintf(sc, " %"PRIu64"p", status.cands);
               ^
wordlist.c: In function 'save_state':
wordlist.c:123:16: warning: format '%lld' expects argument of type 'long long int', but argument 4 has type 'long int' [-Wformat=]
  fprintf(file, "%d\n%" PRId64 "\n%" PRId64 "\n",
                ^
wordlist.c:123:16: warning: format '%lld' expects argument of type 'long long int', but argument 5 has type 'long int' [-Wformat=]
wordlist.c: In function 'restore_state':
wordlist.c:288:19: warning: format '%lld' expects argument of type 'long long int *', but argument 3 has type 'int64_t * {aka long int *}' [-Wformat=]
  if (fscanf(file, "%"PRId64"\n%"PRId64"\n", &rule, &pos) != 2)
                   ^
wordlist.c:288:19: warning: format '%lld' expects argument of type 'long long int *', but argument 4 has type 'int64_t * {aka long int *}' [-Wformat=]
wordlist.c:294:20: warning: format '%lld' expects argument of type 'long long int *', but argument 3 has type 'int64_t * {aka long int *}' [-Wformat=]
   if (fscanf(file, "%"PRId64"\n", &line) != 1)
                    ^
wordlist.c: In function 'do_wordlist_crack':
wordlist.c:802:15: warning: format '%lld' expects argument of type 'long long int', but argument 4 has type 'long int' [-Wformat=]
     log_event("- loaded this node's share of "
               ^
wordlist.c:819:15: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'long int' [-Wformat=]
     log_event("- loading wordfile %s into memory "
               ^
wordlist.c:860:14: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'long int' [-Wformat=]
    log_event("- wordfile had %"PRId64" lines and required %"PRId64
              ^
wordlist.c:860:14: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'long int' [-Wformat=]
wordlist.c:878:15: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'long unsigned int' [-Wformat=]
     log_event("- dupe suppression: hash size %u, "
               ^
wordlist.c:946:15: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'long int' [-Wformat=]
     log_event("- suppressed %"PRId64" duplicate lines "
               ^
wordlist.c:1052:23: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'long int' [-Wformat=]
      sprintf(msg_buf, "- Read block of %"PRId64" "
                       ^
mkv.c: In function 'save_state':
mkv.c:47:16: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'int64_t {aka long int}' [-Wformat=]
  fprintf(file, "%"PRId64 "\n", tidx);
                ^
mkv.c: In function 'restore_state':
mkv.c:52:19: warning: format '%lld' expects argument of type 'long long int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
  if (fscanf(file, "%"PRId64 "\n", &gidx) != 1)
                   ^
mkv.c: In function 'get_markov_start_end':
mkv.c:565:52: warning: format '%llu' expects argument of type 'long long unsigned int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
  if ((start_token != NULL) && (sscanf(start_token, "%"PRIu64, mkv_start) == 1)) {
                                                    ^
mkv.c:566:49: warning: format '%llu' expects argument of type 'long long unsigned int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
   if ((end_token != NULL) && (sscanf(end_token, "%"PRIu64, mkv_end) == 1)) {
                                                 ^
mkv.c:601:14: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
    log_event("- Start: %s converted to %" PRId64, start_token,
              ^
mkv.c:604:21: warning: format '%lld' expects argument of type 'long long int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     fprintf(stderr, "Start: %s converted to %" PRId64
                     ^
mkv.c:619:14: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
    log_event("- End: %s converted to %" PRId64 "", end_token, *mkv_end);
              ^
mkv.c:621:21: warning: format '%lld' expects argument of type 'long long int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     fprintf(stderr, "End: %s converted to %" PRId64
                     ^
mkv.c:629:13: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   log_event("! End = %" PRId64 " is too large (max=%" PRId64 ")", *mkv_end,
             ^
mkv.c:629:13: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
mkv.c:632:20: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
    fprintf(stderr, "Warning: End = %" PRId64 " is too large "
                    ^
mkv.c:632:20: warning: format '%lld' expects argument of type 'long long int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
mkv.c:638:13: warning: format '%lld' expects argument of type 'long long int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   log_event("! MKV start > end (%" PRId64 " > %" PRId64 ")", *mkv_start,
             ^
mkv.c:638:13: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
mkv.c:641:20: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
    fprintf(stderr, "Error: MKV start > end (%" PRId64 " > %" PRId64
                    ^
mkv.c:641:20: warning: format '%lld' expects argument of type 'long long int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
mkv.c: In function 'do_markov_crack':
mkv.c:708:19: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   fprintf(stderr, "%d pwd=%" PRIu64 "%s)\n", mkv_maxlen, mkv_end - mkv_start,
                   ^
mkv.c:734:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
  log_event("- Start-End: %" PRIu64 " - %" PRIu64, mkv_start, mkv_end);
            ^
mkv.c:734:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
pp.c: In function 'save_state':
pp.c:859:17: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
   fprintf(file, "%"PRIu64"\n", (uint64_t)mpz_get_ui(half));
                 ^
pp.c:862:17: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
   fprintf(file, "%"PRIu64"\n", (uint64_t)mpz_get_ui(half));
                 ^
pp.c: In function 'restore_state':
pp.c:870:20: warning: format '%llu' expects argument of type 'long long unsigned int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
   if (fscanf(file, "%"PRIu64"\n", &temp) != 1)
                    ^
pp.c:874:20: warning: format '%llu' expects argument of type 'long long unsigned int *', but argument 3 has type 'uint64_t * {aka long unsigned int *}' [-Wformat=]
   if (fscanf(file, "%"PRIu64"\n", &temp) != 1)
                    ^
unique.c: In function 'unique_run':
unique.c:359:11: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
    printf("\rTotal lines read %"PRIu64" Unique lines written %"PRIu64"\r", totLines, written_lines);
           ^
unique.c:359:11: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
unique.c: In function 'unique':
unique.c:476:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("Total lines read %"PRIu64" Unique lines written %"PRIu64"\n", totLines, written_lines);
            ^
unique.c:476:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
gpg2john.c: In function 'Symmetrically_Encrypted_Data_Packet':
gpg2john.c:1041:10: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'long int' [-Wformat=]
   printf("$gpg$*%d*%"PRId64"*%s*%d*%d*%d*%d*%d*", m_algorithm, (int64_t)totlen, hash, m_spec, m_usage, m_hashAlgorithm, m_cipherAlgorithm, m_count);
          ^
gpg2john.c: In function 'Symmetrically_Encrypted_and_MDC_Packet':
gpg2john.c:1162:10: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'long int' [-Wformat=]
   printf("$gpg$*%d*%"PRId64"*%s*%d*%d*%d*%d*%d*", m_algorithm, (int64_t)totlen, hash, m_spec, m_usage, m_hashAlgorithm, m_cipherAlgorithm, m_count);
          ^
ar: creating aes.a
ar: creating secp256k1.a
genmkvpwd.c: In function 'main':
genmkvpwd.c:238:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("%"PRIu64" G possible passwords (%"PRIu64")\n", nbparts[0] / 1000000000, nbparts[0]);
            ^
genmkvpwd.c:238:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:240:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("%"PRIu64" M possible passwords (%"PRIu64")\n", nbparts[0] / 1000000, nbparts[0]);
            ^
genmkvpwd.c:240:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:242:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("%"PRIu64" K possible passwords (%"PRIu64")\n", nbparts[0] / 1000, nbparts[0]);
            ^
genmkvpwd.c:242:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:244:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("%"PRIu64" possible passwords\n", nbparts[0] );
            ^
genmkvpwd.c:259:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("%"PRIu64" G possible passwords (%"PRIu64")\n", nbparts[0] / 1000000000, nbparts[0]);
            ^
genmkvpwd.c:259:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:261:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("%"PRIu64" M possible passwords (%"PRIu64")\n", nbparts[0] / 1000000, nbparts[0]);
            ^
genmkvpwd.c:261:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:263:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("%"PRIu64" K possible passwords (%"PRIu64")\n", nbparts[0] / 1000, nbparts[0]);
            ^
genmkvpwd.c:263:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:265:12: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 2 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
     printf("%"PRIu64" possible passwords\n", nbparts[0] );
            ^
genmkvpwd.c:281:19: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   fprintf(stderr, "%"PRIu64" G possible passwords (%"PRIu64")\n", nbparts[0] / 1000000000, nbparts[0]);
                   ^
genmkvpwd.c:281:19: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:283:19: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   fprintf(stderr, "%"PRIu64" M possible passwords (%"PRIu64")\n", nbparts[0] / 1000000, nbparts[0]);
                   ^
genmkvpwd.c:283:19: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:285:19: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   fprintf(stderr, "%"PRIu64" K possible passwords (%"PRIu64")\n", nbparts[0] / 1000, nbparts[0]);
                   ^
genmkvpwd.c:285:19: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
genmkvpwd.c:287:19: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
   fprintf(stderr, "%"PRIu64" possible passwords\n", nbparts[0] );
                   ^
genmkvpwd.c:300:18: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
  fprintf(stderr, "starting with %s (%"PRIu64" to %"PRIu64", %f%% of the scope)\n", pwd.password, start, end, 100*((float) end-start)/((float) nbparts[0]) );
                  ^
genmkvpwd.c:300:18: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 5 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
mkvcalcproba.c: In function 'main':
mkvcalcproba.c:186:11: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t {aka long unsigned int}' [-Wformat=]
    printf("\t%d\t%d\t%" PRIu64 "\t%d\n", k, i, index, l);
           ^
```

wpapsk/wpapsk-pmk preprocessor warnings:
```
wpapmk_fmt_plug.c:34:2: warning: #warning Notice: WPAPMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL. [-Wcpp]
 #warning Notice: WPAPMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.
  ^
wpapsk_fmt_plug.c:56:2: warning: #warning Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL. [-Wcpp]
 #warning Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.
  ^
```

rar_common.c warnings which occurred after the jumbo.h changes to fix the warnings caused by commit 136a3e8:
```
In file included from rar_fmt_plug.c:131:0:
rar_common.c: In function 'get_salt':
rar_common.c:249:21: warning: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'long long unsigned int' [-Wformat=]
     fprintf(stderr, "Error loading file from archive '%s', expected %"PRIu64" bytes, got "Zu". Archive possibly damaged.\n", archive_name, psalt->pack_size, count);
                     ^
```
Here, I just replaced `unsigned long long` with `uint64_t`.
But I doubt that the current code works as intended for large archives on 32bit systems where size_t might be smaller than unit64_t.
(I might enhance legacy builds to provide an option to define HAVE_MMAP in a future commit.)


Finally, I applied the new jumbo version string logic to legacy builds.
