### PR TITLE
Add a make target to copy OpenCL code

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -917,6 +917,15 @@ strip: default
 cppcheck:
 	$(CPPCHECK) --enable=all --force -q .
 
+### Copy OpenCL stuff to run/kernels
+#
+.PHONY: kernel-copy
+
+kernel-copy:
+	$(MKDIR) ../run/kernels
+	$(CP) opencl/*.cl ../run/kernels
+	$(CP) opencl_*.h ../run/kernels
+
 install: strip shell-completion
 #ifneq ($(prefix), ../run)
 #	@echo Copying binaries to $(prefix)


### PR DESCRIPTION
### Summary

* OpenCL code (kernels and headers) are copied only for an OpenCL build;
* While building binaries, it is reasonable to create an OpenCL build and name it `john-opencl`, then `make clean` to build what will be the `john` binary; [1]
* All OpenCL stuff will be deleted during the `make clean`. A make target to do "the copy" will be a helper tool in this situation.

[1] 1st the OpenCL binary. Then, all fallback binaries, for example.