### PR TITLE
Do not use realpath(3) on CygWin

### DIFF
--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -62,9 +62,11 @@
 
 #define LOG_SIZE 1024*16
 
+#if !defined(__CYGWIN__)
 // If true, use realpath(3) for translating eg. "-I./kernels" into an absolute
 // path before submitting as JIT compile option to OpenCL.
 #define I_REALPATH 1
+#endif
 
 // If we are a release build, only output OpenCL build log if
 // there was a fatal error (or --verbosity was increased).

--- a/src/configure
+++ b/src/configure
@@ -17432,18 +17432,18 @@ Cross compiling ............................ ${cross_compiling}
 Legacy arch header ......................... ${ARCH_LINK}
 
 Optional libraries/features found:
-OpenMPI support (default disabled) ......... ${using_mpi}
+Memory map (share/page large files) ........ ${using_mmap}
 Fork support ............................... ${ac_cv_func_fork_works}
 OpenMP support ............................. ${using_omp}
 OpenCL support ............................. ${using_cl}
 Generic crypt(3) format .................... ${using_crypt}
-librexgen (regex cracking mode) ............ ${using_rexgen}
 libgmp (PRINCE mode and faster SRP formats)  ${ac_cv_lib_gmp___gmpz_init}
-libpcap (vncpcap2john and SIPdump) ......... ${using_pcap}
+128-bit integer (faster PRINCE mode) ....... ${have_int128}
 libz (pkzip format, gpg2john) .............. ${using_zlib}
 libbz2 (gpg2john extra decompression logic)  ${using_bz2}
-128-bit integer (faster PRINCE mode) ....... ${have_int128}
-Memory map (share/page large files) ........ ${using_mmap}
+libpcap (vncpcap2john and SIPdump) ......... ${using_pcap}
+librexgen (regex cracking mode) ............ ${using_rexgen}
+OpenMPI support (default disabled) ......... ${using_mpi}
 ZTEX USB-FPGA module 1.15y support ......... ${ztex}
 
 EOF

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1257,18 +1257,18 @@ Cross compiling ............................ ${cross_compiling}
 Legacy arch header ......................... ${ARCH_LINK}
 
 Optional libraries/features found:
-OpenMPI support (default disabled) ......... ${using_mpi}
+Memory map (share/page large files) ........ ${using_mmap}
 Fork support ............................... ${ac_cv_func_fork_works}
 OpenMP support ............................. ${using_omp}
 OpenCL support ............................. ${using_cl}
 Generic crypt(3) format .................... ${using_crypt}
-librexgen (regex cracking mode) ............ ${using_rexgen}
 libgmp (PRINCE mode and faster SRP formats)  ${ac_cv_lib_gmp___gmpz_init}
-libpcap (vncpcap2john and SIPdump) ......... ${using_pcap}
+128-bit integer (faster PRINCE mode) ....... ${have_int128}
 libz (pkzip format, gpg2john) .............. ${using_zlib}
 libbz2 (gpg2john extra decompression logic)  ${using_bz2}
-128-bit integer (faster PRINCE mode) ....... ${have_int128}
-Memory map (share/page large files) ........ ${using_mmap}
+libpcap (vncpcap2john and SIPdump) ......... ${using_pcap}
+librexgen (regex cracking mode) ............ ${using_rexgen}
+OpenMPI support (default disabled) ......... ${using_mpi}
 ZTEX USB-FPGA module 1.15y support ......... ${ztex}
 
 EOF


### PR DESCRIPTION
* realpath(3) is not able to produce the complete path on Windows + CygWin dlls.
* To me, this patch works better.

**[edited]** My fault, I added one unrelated commit. But they can be a set of tweaks.
* Group together all "no" on the configure report (easier to scan).