### PR TITLE
Remove duplicate #include preprocessor directives

### DIFF
--- a/src/bitlocker_fmt_plug.c
+++ b/src/bitlocker_fmt_plug.c
@@ -42,7 +42,6 @@ john_register_one(&fmt_bitlocker);
 #include "aes.h"
 #include "aes_ccm.h"
 #include "sha.h"
-#include "sha.h"
 #include "jumbo.h"
 #include "bitlocker_common.h"
 #define CPU_FORMAT              1

--- a/src/electrum_fmt_plug.c
+++ b/src/electrum_fmt_plug.c
@@ -32,7 +32,6 @@ john_register_one(&fmt_electrum);
 #endif
 #include <openssl/bn.h>
 
-#include "arch.h"
 #include "misc.h"
 #include "common.h"
 #include "formats.h"

--- a/src/external.c
+++ b/src/external.c
@@ -29,7 +29,6 @@
 #include "external.h"
 #include "mask.h"
 #include "regex.h"
-#include "options.h"
 #include "unicode.h"
 #include "memdbg.h"
 

--- a/src/inc.c
+++ b/src/inc.c
@@ -27,7 +27,6 @@
 #include "external.h"
 #include "cracker.h"
 #include "john.h"
-#include "options.h"
 #include "unicode.h"
 #include "mask.h"
 #include "regex.h"

--- a/src/logger.c
+++ b/src/logger.c
@@ -49,7 +49,6 @@
 #include "status.h"
 #include "options.h"
 #include "config.h"
-#include "options.h"
 #include "recovery.h"
 #include "unicode.h"
 #include "dynamic.h"

--- a/src/mscash2_fmt_plug.c
+++ b/src/mscash2_fmt_plug.c
@@ -69,7 +69,6 @@ john_register_one(&fmt_mscash2);
 #include "formats.h"
 #include "unicode.h"
 #include "options.h"
-#include "unicode.h"
 #include "sha.h"
 #include "md4.h"
 #include "simd-intrinsics.h"

--- a/src/nukedclan_fmt_plug.c
+++ b/src/nukedclan_fmt_plug.c
@@ -32,7 +32,6 @@ john_register_one(&fmt_nk);
 #include "formats.h"
 #include "params.h"
 #include "options.h"
-#include "common.h"
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/src/opencl_7z_fmt_plug.c
+++ b/src/opencl_7z_fmt_plug.c
@@ -182,7 +182,6 @@ static const char *warn[] = {
 
 // This file contains auto-tuning routine(s). It has to be included after formats definitions.
 #include "opencl_autotune.h"
-#include "memdbg.h"
 
 /* ------- Helper functions ------- */
 static size_t get_task_max_work_group_size()

--- a/src/opencl_DES_bs_plug.c
+++ b/src/opencl_DES_bs_plug.c
@@ -817,8 +817,6 @@ typedef union {
 	kp += 1;					\
 }
 
-#include "memdbg.h"
-
 static void des_finalize_int_keys()
 {
 	key_page *int_key_page[MASK_FMT_INT_PLHDR];

--- a/src/opencl_dashlane_fmt_plug.c
+++ b/src/opencl_dashlane_fmt_plug.c
@@ -29,7 +29,6 @@ john_register_one(&fmt_opencl_dashlane);
 #include <omp.h>
 #endif
 
-#include "arch.h"
 #include "formats.h"
 #include "common.h"
 #include "dashlane_common.h"

--- a/src/opencl_electrum_modern_fmt_plug.c
+++ b/src/opencl_electrum_modern_fmt_plug.c
@@ -30,7 +30,6 @@ john_register_one(&fmt_opencl_electrum_modern);
 #endif
 
 #include "misc.h"
-#include "arch.h"
 #include "common.h"
 #include "formats.h"
 #include "options.h"

--- a/src/opencl_keystore_fmt_plug.c
+++ b/src/opencl_keystore_fmt_plug.c
@@ -93,7 +93,6 @@ static cl_int cl_err;
 
 // This file contains auto-tuning routine(s). Has to be included after formats definitions.
 #include "opencl_autotune.h"
-#include "memdbg.h"
 
 static const char * warn[] = {
 	"xfer: ",  ", crypt: ",  ", xfer: "

--- a/src/opencl_krb5_asrep_aes_fmt_plug.c
+++ b/src/opencl_krb5_asrep_aes_fmt_plug.c
@@ -92,7 +92,6 @@ static int split_events[] = { 2, -1, -1 };
 
 //This file contains auto-tuning routine(s). Has to be included after formats definitions.
 #include "opencl_autotune.h"
-#include "memdbg.h"
 
 /* ------- Helper functions ------- */
 static size_t get_task_max_work_group_size()

--- a/src/opencl_libreoffice_aes_fmt_plug.c
+++ b/src/opencl_libreoffice_aes_fmt_plug.c
@@ -25,8 +25,6 @@ john_register_one(&fmt_opencl_odf_aes);
 #include "common.h"
 #include "misc.h"
 #include "options.h"
-#include "common.h"
-#include "formats.h"
 #include "aes.h"
 #include "libreoffice_common.h"
 #define INCLUDE_AES_HASHES      1

--- a/src/opencl_libreoffice_fmt_plug.c
+++ b/src/opencl_libreoffice_fmt_plug.c
@@ -30,8 +30,6 @@ john_register_one(&fmt_opencl_odf);
 #include "common.h"
 #include "misc.h"
 #include "options.h"
-#include "common.h"
-#include "formats.h"
 #include "libreoffice_common.h"
 #define INCLUDE_BF_HASHES       1
 #include "libreoffice_variable_code.h"

--- a/src/opencl_pem_fmt_plug.c
+++ b/src/opencl_pem_fmt_plug.c
@@ -29,7 +29,6 @@ john_register_one(&fmt_opencl_pem);
 #include <omp.h>
 #endif
 
-#include "arch.h"
 #include "formats.h"
 #include "common.h"
 #include "pem_common.h"

--- a/src/opencl_staroffice_fmt_plug.c
+++ b/src/opencl_staroffice_fmt_plug.c
@@ -32,8 +32,6 @@ john_register_one(&fmt_opencl_sxc);
 #include "common.h"
 #include "misc.h"
 #include "options.h"
-#include "common.h"
-#include "formats.h"
 #include "staroffice_common.h"
 #include "common-opencl.h"
 

--- a/src/pomelo_plug.c
+++ b/src/pomelo_plug.c
@@ -300,8 +300,6 @@ int PHS_pomelo(void *out, size_t outlen, const void *in, size_t inlen, const voi
 // For the machine today, it is recommended that: 5 <= t_cost + m_cost <= 25;
 // one may use the parameters: m_cost = 15; t_cost = 0; (256 MegaByte memory)
 
-#include "memdbg.h"
-
 #define F0(i)  {               \
     i0 = ((i) - 0*4)  & mask1; \
     i1 = ((i) - 2*4)  & mask1; \

--- a/src/rar2john.c
+++ b/src/rar2john.c
@@ -59,7 +59,6 @@
 #include "params.h"
 #include "crc32.h"
 #include "unicode.h"
-#include "jumbo.h"
 #include "base64_convert.h"
 #include "sha2.h"
 #include "rar2john.h"

--- a/src/rawSHA512_common_plug.c
+++ b/src/rawSHA512_common_plug.c
@@ -12,7 +12,6 @@
 #include "johnswap.h"
 #include "base64_convert.h"
 #include "rawSHA512_common.h"
-#include "johnswap.h"
 #include "memdbg.h"
 
 struct fmt_tests sha512_common_tests_rawsha512_111[] = {

--- a/src/stribog_fmt_plug.c
+++ b/src/stribog_fmt_plug.c
@@ -28,7 +28,6 @@ john_register_one(&fmt_stribog_512);
 #endif
 #endif
 
-#include "arch.h"
 #include "misc.h"
 #include "common.h"
 #include "formats.h"

--- a/src/sunmd5_fmt_plug.c
+++ b/src/sunmd5_fmt_plug.c
@@ -45,13 +45,11 @@ john_register_one(&fmt_sunmd5);
 
 #include "misc.h"
 #include "options.h"
-#include "misc.h"
 #include "params.h"
 #include "memory.h"
 #include "common.h"
 #include "formats.h"
 #include "loader.h"
-#include "memory.h"
 #include "md5.h"
 #include "simd-intrinsics.h"
 #include "memdbg.h"


### PR DESCRIPTION
I always kept the first #include directive, to avoid any breakage.


If there were development guidelines pointing out which dependencies exist between certain includes, I might have kept other #include directives, to keep alphabetic sorting intact, except for such dependencies.
