### PR TITLE
Star/Libre Office. Handle their buggy SHA1 logic (optional)

### DIFF
--- a/src/staroffice_common.h
+++ b/src/staroffice_common.h
@@ -9,7 +9,8 @@
 #define FORMAT_NAME             "StarOffice (.sxc, .sdw, .sxd, .sxw, .sxi)"
 #define FORMAT_TAG              "$sxc$*"
 #define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
-#define BINARY_SIZE             20
+#define BINARY_SIZE             8
+#define FULL_BINARY_SIZE        20
 
 struct custom_salt {
 	int cipher_type; // FIXME: cipher_type seems to be ignored. NOTE: only samples with Blowfish exist / are known.
@@ -24,6 +25,9 @@ struct custom_salt {
 	unsigned char salt[32];
 	unsigned char content[1024];
 };
+
+// mimic bug in Star/Libre office SHA1. Needed for any string of length 52 to 55 mod(64)
+extern void SHA1_Libre_Buggy(unsigned char *data, int len, uint32_t results[5]);
 
 extern struct fmt_tests staroffice_tests[];
 

--- a/src/staroffice_fmt_plug.c
+++ b/src/staroffice_fmt_plug.c
@@ -48,7 +48,7 @@ john_register_one(&fmt_sxc);
 #endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        -1
-// keep plaintext length under 52 to avoid having to deal with the Libra/Star office SHA1 bug
+// keep plaintext length under 52 to avoid having to deal with the Libre/Star office SHA1 bug
 #define PLAINTEXT_LENGTH        51
 #define SALT_SIZE               sizeof(struct custom_salt)
 #define BINARY_ALIGN            sizeof(uint32_t)


### PR DESCRIPTION
The logic added will work for busted AND correct logic SHA1.  Libre is correcting the bug, so we have to handle both flavors.

I reduced the PLAINTEXT length to 51, so that the first part of crypt_all does not have to deal with the bug. If we go above 51 bytes, then we will have to do the BKDF2 code twice (for some passwords). It is more simple to just accept 51 bytes only.

Then, the change is handled in the code after the pbkdf2.  It stores 2 4 byte ints in the binary. Each are just the first 4 bytes of the hash.  They will be the same value for lengths which do not trigger the bug.  BUT if the data object is of a length that triggers the bug, then the 2nd 32 bit value will be a hash using the busted SHA1 code.

Then in cmp_exact, we fully perform the hash, test and possibly re-sha1 with busted and test again, to fully validate we did not have a 32 bit collision.

I have not tested on opencl (but the build bots will do that).

@kholia do you have a 'real' hash from one of the busted lengths to test this with?  If so, the new code should crack it fine.