### PR TITLE
Bugfix for 32-bit SSE4.1 and SSSE3 detection

### DIFF
--- a/src/x86-sse.h
+++ b/src/x86-sse.h
@@ -97,8 +97,10 @@
  * except in OpenMP-enabled builds, where it's aligned by different means.
  */
 #define CPU_REQ_AVX			1
+#ifndef CPU_REQ_XOP
 #undef CPU_NAME
 #define CPU_NAME			"AVX"
+#endif
 #ifdef CPU_FALLBACK_BINARY_DEFAULT
 #undef CPU_FALLBACK_BINARY
 #define CPU_FALLBACK_BINARY		"john-non-avx"

--- a/src/x86.S
+++ b/src/x86.S
@@ -1297,15 +1297,15 @@ BF_body:
 #define EF_ID				$0x00200000
 
 /* Leaf 7 */
-#define C7_AVX2				$0x00000020 /* AVX2 */
-#define C7_AVX512F			$0x00010000 /* AVX512F */
-#define C7_AVX512BW			$0x40010000 /* + AVX512BW */
+#define C7_AVX2				$0x00000020 /* AVX2 (ebx) */
+#define C7_AVX512F			$0x00010020 /* + AVX512F (ebx) */
+#define C7_AVX512BW			$0x40010020 /* + AVX512BW (ebx) */
 
 /* Leaf 1 */
 #define CF_MMX				$0x00800000
-#define CF_SSE2				$0x04000000 /* SSE2 */
-#define CF_SSSE3			$0x04000200 /* + SSSE3 */
-#define CF_SSE4_1			$0x04080200 /* + SSE4.1 */
+#define CF_SSE2				$0x04000000 /* SSE2 (edx) */
+#define CF_SSSE3			$0x00000200 /* SSSE3 (ecx) */
+#define CF_SSE4_1			$0x00080200 /* + SSE4.1 (ecx) */
 #define CF_XSAVE_OSXSAVE_AVX		$0x1C000000
 
 #define CF_XOP				$0x00000800
@@ -1419,21 +1419,27 @@ CPU_detect_XOP:
 	popl %edx
 	popl %eax
 #endif
-	popl %ecx
-#if DES_BS_VECTOR >= 4
-	xchgl %edx,%eax
+#if CPU_REQ_SSE4_1 || CPU_REQ_SSSE3
+	movl $1,%eax
+	cpuid
 #if CPU_REQ_SSE4_1
 	andl CF_SSE4_1,%ecx
 	cmpl CF_SSE4_1,%ecx
-	jne CPU_detect_ret
 #elif CPU_REQ_SSSE3
 	andl CF_SSSE3,%ecx
 	cmpl CF_SSSE3,%ecx
-	jne CPU_detect_ret
-#else
+#endif
+	je CPU_detect_end_of_jumbo
+	popl %ecx
+	xorl %eax,%eax
+	jmp CPU_detect_ret
+CPU_detect_end_of_jumbo:
+#endif
+	popl %ecx
+#if DES_BS_VECTOR >= 4
+	xchgl %edx,%eax
 	andl CF_SSE2,%eax
 	jz CPU_detect_ret		/* No SSE2 */
-#endif
 	xchgl %edx,%eax
 #elif DES_X2
 	xchgl %edx,%eax


### PR DESCRIPTION
Take two. I managed to test this with a virtual machine with cpuid masks, I believe this one really fixes the problems. @claudioandre please test, and merge if it works.

The 32-bit cpuid assembler code is friggin' obfuscated code, with `xchgl` back and forth and push/pop. Very hard to follow through all `#ifdef`'s.