### PR TITLE
electrum2john.py - Fix error due to unassigned variable

### DIFF
--- a/run/electrum2john.py
+++ b/run/electrum2john.py
@@ -131,7 +131,7 @@ def process_file(filename, options):
         sys.stderr.write("%s: Unrecognized wallet format!\n" % (bname))
         return
     if wallet.get("seed_version") not in (11, 12, 13) and wallet_type != "imported":  # all 2.x versions as of Oct 2016
-        sys.stderr.write("%s: Unsupported Electrum2 seed version '%d' found!\n" % (bname, seed_version))
+        sys.stderr.write("%s: Unsupported Electrum2 seed version '%d' found!\n" % (bname, wallet.get("seed_version")))
         return
     xprv = None
     version = 2  # hack


### PR DESCRIPTION
### Summary

In electrum2john.py, the error message for unsupported Electrum seed version contains a small bug.