### PR TITLE
Add support for cracking Ansible Vaults

### DIFF
--- a/run/ansible2john.py
+++ b/run/ansible2john.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# This software is Copyright (c) 2018, Dhiru Kholia <kholia at kth.se> and it
+# is hereby released to the general public under the following terms:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.
+#
+# Tested with ansible-vault 2.4.3.0 running on Fedora 27.
+
+
+import sys
+import os
+import struct
+from binascii import hexlify, unhexlify
+
+PY3 = sys.version_info[0] == 3
+
+if not PY3:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+
+
+HEADER = b'$ANSIBLE_VAULT'
+
+
+def process_file(filename):
+    """
+    Parser for Ansible Vault .yml files
+    """
+    bfilename = os.path.basename(filename)
+
+    data = open(filename, "rb").read()
+    if not data.startswith(HEADER):
+        return
+
+    tmpdata = data.splitlines()
+    tmpheader = tmpdata[0].strip().split(b';')
+
+    version = tmpheader[1].strip()
+    cipher_name = tmpheader[2].strip()
+    ciphertext = b''.join(tmpdata[1:])
+    salt, checksum, ct = unhexlify(ciphertext).split(b"\n")
+    if PY3:
+        salt = salt.decode("ascii")
+        checksum = checksum.decode("ascii")
+        ct = ct .decode("ascii")
+        cipher_name = cipher_name .decode("ascii")
+    version = 0
+    if cipher_name != "AES256":
+        sys.stderr.write("%s: unsupported ciper '%s' found!\n" % (bfilename, cipher_name))
+        return
+    cipher = 0
+    sys.stdout.write("%s:$ansible$%d*%d*%s*%s*%s\n" %
+                     (os.path.basename(filename), version, cipher, salt, ct, checksum))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: %s [Ansible Vault .yml file(s)]\n" % sys.argv[0])
+        sys.exit(-1)
+
+    for i in range(1, len(sys.argv)):
+        process_file(sys.argv[i])

--- a/src/ansible_common.h
+++ b/src/ansible_common.h
@@ -1,0 +1,30 @@
+/*
+ * Common code for the Ansible Vault format.
+ */
+
+#include "formats.h"
+
+#define FORMAT_NAME             "Ansible Vault"
+#define FORMAT_TAG              "$ansible$"
+#define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
+#define BINARY_SIZE             32
+#define BINARY_SIZE_CMP         16
+
+#define SALTLEN                 32
+#define BLOBLEN                 8192
+
+struct custom_salt{
+	int salt_length;
+	int iterations;
+	int bloblen;
+	unsigned char salt[SALTLEN];
+	unsigned char checksum[32];
+	unsigned char blob[BLOBLEN];
+};
+
+extern struct fmt_tests ansible_tests[];
+
+int ansible_common_valid(char *ciphertext, struct fmt_main *self);
+void *ansible_common_get_salt(char *ciphertext);
+extern void *ansible_common_get_binary(char *ciphertext);
+unsigned int ansible_common_iteration_count(void *salt);

--- a/src/ansible_common_plug.c
+++ b/src/ansible_common_plug.c
@@ -1,0 +1,121 @@
+/*
+ * Common code for the Ansible Vault format.
+ */
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "ansible_common.h"
+#include "memdbg.h"
+
+struct fmt_tests ansible_tests[] = {
+	{"$ansible$0*0*f623a48ba49f7abf7c1920bc1e2ab2607cda2b5786da2560b8178a6095e5dfd2*ab55de42e4f131f109f1a086f2e8e22f*6767c60857ce1d7aa20226d76ec1abf77837c623bb7e879147ab888ef15a0dbb", "openwall"},
+	{"$ansible$0*0*45252709c61203511abbfdab0a8b498cb3e6259be5211e5b33ccc2fe12211d3f*0c52b98fc5aed891f99e3bcd3c6f250a*8e2d7558cd75b293ad8f3e27b774704279c019d89ba4743b591a3b14883c0851", "åbc"},
+	{NULL}
+};
+
+int ansible_common_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *keeptr, *p;
+	int value, extra;
+
+	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH) != 0)
+		return 0;
+
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+
+	ctcopy += TAG_LENGTH;
+	if ((p = strtokm(ctcopy, "*")) == NULL) // version, for future purposes
+		goto err;
+	if (!isdec(p))
+		goto err;
+	value = atoi(p);
+	if (value != 0)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)   // cipher (fixed for now)
+		goto err;
+	if (!isdec(p))
+		goto err;
+	if (atoi(p) != 0)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)   // salt
+		goto err;
+	if (hexlenl(p, &extra) != SALTLEN * 2 || extra)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)   // ciphertext
+		goto err;
+	if (hexlenl(p, &extra) >= BLOBLEN * 2 || extra)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)   // checksum
+		goto err;
+	if (hexlenl(p, &extra) != 32 * 2 || extra)
+		goto err;
+
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *ansible_common_get_salt(char *ciphertext)
+{
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	int i;
+	char *p;
+	static struct custom_salt *cs;
+
+	cs = mem_calloc_tiny(sizeof(struct custom_salt), sizeof(uint64_t));
+
+	ctcopy += TAG_LENGTH;
+	p = strtokm(ctcopy, "*");
+	p = strtokm(NULL, "*");
+	cs->iterations = 10000;  // fixed
+	cs->salt_length = SALTLEN;
+	p = strtokm(NULL, "*");
+	for (i = 0; i < cs->salt_length; i++)
+		cs->salt[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "*");
+	cs->bloblen = strlen(p) / 2;
+	for (i = 0; i < cs->bloblen; i++)
+		cs->blob[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "*");
+	for (i = 0; i < 32; i++)
+		cs->checksum[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	MEM_FREE(keeptr);
+
+	return (void *)cs;
+}
+
+void *ansible_common_get_binary(char *ciphertext)
+{
+	static union {
+		unsigned char c[BINARY_SIZE];
+		uint32_t dummy;
+	} buf;
+	unsigned char *out = buf.c;
+	char *p;
+	int i;
+
+	memset(buf.c, 0, BINARY_SIZE);
+	p = strrchr(ciphertext, '*') + 1;
+	for (i = 0; i < BINARY_SIZE_CMP; i++) {
+		out[i] = (atoi16[ARCH_INDEX(*p)] << 4) | atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+
+	return out;
+}
+
+unsigned int ansible_common_iteration_count(void *salt)
+{
+	struct custom_salt *cs = salt;
+
+	return (unsigned int) cs->iterations;
+}

--- a/src/ansible_fmt_plug.c
+++ b/src/ansible_fmt_plug.c
@@ -1,0 +1,201 @@
+/*
+ * JtR format to crack Ansible Vault non-hashes.
+ *
+ * This software is Copyright (c) 2018, Dhiru Kholia <kholia at kth.se> and it
+ * is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_ansible;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_ansible);
+#else
+
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#define OMP_SCALE               1  // MKPC and OMP_SCALE tuned on Core i5-6500
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "options.h"
+#include "jumbo.h"
+#include "hmac_sha.h"
+#include "pbkdf2_hmac_sha256.h"
+#include "ansible_common.h"
+#include "memdbg.h"
+
+#define FORMAT_LABEL            "ansible"
+#ifdef SIMD_COEF_32
+#define ALGORITHM_NAME          "PBKDF2-SHA256 HMAC-256 " SHA256_ALGORITHM_NAME
+#else
+#if ARCH_BITS >= 64
+#define ALGORITHM_NAME          "PBKDF2-SHA256 HMAC-256 64/" ARCH_BITS_STR " " SHA2_LIB
+#else
+#define ALGORITHM_NAME          "PBKDF2-SHA256 HMAC-256 32/" ARCH_BITS_STR " " SHA2_LIB
+#endif
+#endif
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        0
+#define PLAINTEXT_LENGTH        125
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define BINARY_ALIGN            1
+#define SALT_ALIGN              sizeof(uint64_t)
+#ifdef SIMD_COEF_32
+#define MIN_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA256
+#define MAX_KEYS_PER_CRYPT      (SSE_GROUP_SZ_SHA256 * 2)
+#else
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      16
+#endif
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+
+static struct custom_salt *cur_salt;
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+
+	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
+	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);
+}
+
+static void done(void)
+{
+	MEM_FREE(saved_key);
+	MEM_FREE(crypt_out);
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (struct custom_salt *)salt;
+}
+
+static void ansible_set_key(char *key, int index)
+{
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index += MIN_KEYS_PER_CRYPT) {
+		unsigned char master[MIN_KEYS_PER_CRYPT][64];
+		int i;
+#ifdef SIMD_COEF_32
+		int lens[MIN_KEYS_PER_CRYPT];
+		unsigned char *pin[MIN_KEYS_PER_CRYPT], *pout[MIN_KEYS_PER_CRYPT];
+
+		for (i = 0; i < MIN_KEYS_PER_CRYPT; ++i) {
+			lens[i] = strlen(saved_key[index+i]);
+			pin[i] = (unsigned char*)saved_key[index+i];
+			pout[i] = master[i];
+		}
+		pbkdf2_sha256_sse((const unsigned char**)pin, lens, cur_salt->salt, cur_salt->salt_length, cur_salt->iterations, pout, 64, 32);
+#else
+		for (i = 0; i < MIN_KEYS_PER_CRYPT; ++i)
+			pbkdf2_sha256((unsigned char *)saved_key[index+i], strlen(saved_key[index+i]), cur_salt->salt, cur_salt->salt_length, cur_salt->iterations, master[i], 64, 32);
+#endif
+		for (i = 0; i < MIN_KEYS_PER_CRYPT; ++i) {
+			JTR_hmac_sha256(master[i], 32, cur_salt->blob, cur_salt->bloblen, (unsigned char*)crypt_out[index+i], 16);
+		}
+	}
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (((uint32_t*)binary)[0] == crypt_out[index][0])
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE_CMP);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main fmt_ansible = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
+		{
+			"iteration count",
+		},
+		{ FORMAT_TAG },
+		ansible_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		ansible_common_valid,
+		fmt_default_split,
+		ansible_common_get_binary,
+		ansible_common_get_salt,
+		{
+			ansible_common_iteration_count,
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		ansible_set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */


### PR DESCRIPTION
I am still working on,

* Avoiding `cracked` logic (DONE)

* OpenMP tuning (DONE according to https://github.com/magnumripper/JohnTheRipper/issues/3091)

* GPU format. Do we have HMAC-SHA256 on the GPU?

I might leave the GPU support for a new PR.