### PR TITLE
Add support for cracking Telegram (Android) hashes

### DIFF
--- a/run/dynamic.conf
+++ b/run/dynamic.conf
@@ -1232,6 +1232,21 @@ Test=$dynamic_1518$b19d46258f6a00f151367024789d71f1:smurfs
 Test=$dynamic_1518$065c78f47a7da2e2ca2bd76eed10f6cd:ralphy1
 Test=$dynamic_1518$82f7dd8a757d1a79126817940336087d:Kitesurfing1
 
+# Telegram for Android hashes. Use ../run/telegram2john.py to extract the hashes.
+[List.Generic:dynamic_1528]
+Expression=sha256($s.$p.$s) (Telegram for Android)
+Flag=MGF_INPUT_32_BYTE
+Flag=MGF_SALTED
+Flag=MGF_FLAT_BUFFERS
+SaltLen=16
+Func=DynamicFunc__clean_input_kwik
+Func=DynamicFunc__append_salt
+Func=DynamicFunc__append_keys
+Func=DynamicFunc__append_salt
+Func=DynamicFunc__SHA256_crypt_input1_to_output1_FINAL
+Test=$dynamic_1528$dab5552484cc327bd6d23b2a1ceb55b6ffb30f305bc09962a9102a6cec63773c$HEX$9533cd79bf8739bdd47ff8998aaf578c:1234
+Test=$dynamic_1528$cad3fe1d4df2bf68c23f003e771c79fa42d10ae9a03671019d9c91a266a91372$HEX$901c3371d7de4b525b0e0a6abf4f392e:0987
+
 # this should be last line of the file.  Put other formats before this.  The formats in
 # the following included file are replacement formats for the MD4/5 formats which use
 # 'intermixed' SSE for speed, BUT which can not process longer passwords, due to being

--- a/run/telegram2john.py
+++ b/run/telegram2john.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python2
+
+"""Utility to extract "hashes" from Telegram Android app's userconfing.xml file(s)"""
+
+# Tested with Telegram for Android v4.8.4 in February, 2018.
+#
+# Special thanks goes to https://github.com/Banaanhangwagen for documenting
+# this hashing scheme.
+#
+# See "UserConfig.java" from https://github.com/DrKLO/Telegram/ for details on
+# the hashing scheme.
+#
+# Written by Dhiru Kholia <dhiru at openwall.com> in February, 2018 for JtR
+# project.
+#
+# This software is Copyright (c) 2018, Dhiru Kholia <dhiru at openwall.com> and
+# it is hereby released to the general public under the following terms:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.
+#
+# pylint: disable=invalid-name,line-too-long
+
+
+import os
+import sys
+import base64
+import binascii
+import traceback
+import xml.etree.ElementTree as ET
+
+PY3 = sys.version_info[0] == 3
+
+if not PY3:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+
+
+def process_xml_file(filename):
+    tree = ET.parse(filename)
+    root = tree.getroot()
+    h = None
+    salt = None
+
+    for item in root:
+        # the "user" key doesn't seem very useful without cleaning it up
+        if item.tag == 'string':
+            name = item.attrib['name']
+            if name == "passcodeHash1":
+                h = item.text
+            if name == "passcodeSalt":
+                salt = item.text
+    if not h or not salt:
+        return
+
+    h = h.lower()
+    salt = binascii.hexlify(base64.b64decode(salt))
+    if PY3:
+        salt = salt.decode("ascii")
+
+    sys.stdout.write("$dynamic_1528$%s$HEX$%s\n" % (h, salt))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: %s <userconfing.xml file(s)>\n" %
+                         sys.argv[0])
+        sys.exit(-1)
+
+    for j in range(1, len(sys.argv)):
+        process_xml_file(sys.argv[j])


### PR DESCRIPTION
This fixes https://github.com/magnumripper/JohnTheRipper/issues/3183.

The passcode length is limited to 4. So no GPU support is needed ;)

@Banaanhangwagen You might be interested in this. Thanks for your work on this topic!