### PR TITLE
OpenCL: only complain about --dev and fork on non MPI

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1217,6 +1217,9 @@ static void john_load(void)
 			log_event("Loaded a total of %s", john_loaded_counts());
 			/* make sure the format is properly initialized */
 
+#if HAVE_MPI
+	if (mpi_p == 1) {
+#endif
 #if HAVE_OPENCL
 	/*
 	 * Check if the --devices list contains more OpenCL devices than the
@@ -1243,6 +1246,9 @@ static void john_load(void)
 		error();
 	}
 #endif
+#endif
+#if HAVE_MPI
+	}
 #endif
 
 #if HAVE_OPENCL


### PR DESCRIPTION
As seen in https://github.com/magnumripper/JohnTheRipper/issues/3176#issuecomment-371292880 commit 302a6ec3888354d03f51b60a0e1fa6ad67305f1c broke MPI.

* I'm really not sure what kind of warning (as requested in #3176) should be printed on a MPI run. So, at least as a workaround, I'm disabling the new warnings in case of MPI.