### PR TITLE
mask: add FMT_MASK flag to raw-SHA512-opencl

### DIFF
--- a/src/opencl_rawsha512_gpl_fmt_plug.c
+++ b/src/opencl_rawsha512_gpl_fmt_plug.c
@@ -861,7 +861,7 @@ struct fmt_main fmt_opencl_rawsha512_gpl = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_MASK,
 		{NULL},
 		{FORMAT_TAG},
 		sha512_common_tests_rawsha512_20


### PR DESCRIPTION
```
$ ../run/john  -format:mask -list=formats
../run/john: /usr/local/cuda-8.0/targets/x86_64-linux/lib/libOpenCL.so.1: no version information available (required by ../run/john)
oldoffice-opencl, descrypt-opencl, krb5pa-md5-opencl, LM-opencl, 
mscash-opencl, mysql-sha1-opencl, nt-opencl, ntlmv2-opencl, Raw-MD4-opencl, 
Raw-MD5-opencl, Raw-SHA1-opencl, Raw-SHA256-opencl, Raw-SHA512-opencl, 
salted-sha1-opencl, SL3-opencl, XSHA512-opencl
```