### PR TITLE
Major mask mode changes

### DIFF
--- a/doc/MASK
+++ b/doc/MASK
@@ -68,14 +68,16 @@ This should be used with -max-len (and possibly -min-len) to do any good.
 The -max-len=N option will truncate the mask so no words longer than N are
 produced.
 
-The -min-len=N option will skip generation of words shorter than N, and more
-importantly in this case, it will iterate length from -min-len to -max-len (or
-format's max length, if -max-len was not given).  So to produce all possible
-words from 3 to 5 letters, use -mask=?l -min-len=3 -max-len=5.  In case the
-specified mask is shorter, the last part of it will be expanded, for example
-"-mask=?u?l -max-len=5" will use an effective mask of ?u?l?l?l?l. Whenever
-iterating over lengths, the ETA shows estimated time to complete the *current*
-length, as opposed to the whole run.
+The -min-len=N option will skip generation of words shorter than N.
+
+If not in "hybrid mask" mode, and either -min-len or -max-len option was used,
+we will iterate lengths (as in "incremental mask") from -min-len to -max-len
+(or format's min or max length, if one was not given).  So to produce all
+possible words from 3 to 5 letters, use -mask=?l -min-len=3 -max-len=5.  In
+case the specified mask is shorter, the last part of it will be expanded, for
+example "-mask=?u?l -max-len=5" will use an effective mask of ?u?l?l?l?l.
+Whenever using incremental mask, the ETA at any given time shows estimated
+time to complete the *current* length, as opposed to the whole run.
 
 You can escape special characters with \.  So to produce a literal "?l" you
 could say \?l or ?\l and it will not be parsed as a placeholder.  Similarly,

--- a/src/bt.c
+++ b/src/bt.c
@@ -35,7 +35,6 @@ typedef struct {
 	unsigned short collisions;
 	unsigned short iter;
 	unsigned int offset_table_idx;
-
 } auxilliary_offset_data;
 
 /* Interface pointers */
@@ -465,7 +464,7 @@ static unsigned int create_tables()
 	alarm(0);
 
 	hash_table_idx = 0;
-	while (offset_data[i].collisions > 0) {
+	while (i < offset_table_size && offset_data[i].collisions > 0) {
 		done++;
 
 		while (hash_table_idx < hash_table_size) {

--- a/src/cracker.h
+++ b/src/cracker.h
@@ -34,6 +34,14 @@ extern void crk_init(struct db_main *db, void (*fix_state)(void),
 extern int crk_process_key(char *key);
 
 /*
+ * Process all/any keys already loaded with crk_process_key, regardless of
+ * max_keys_per_crypt.  After this, it's safe to call reset() mid-run.
+ * The return value is non-zero if aborted or everything got cracked (the
+ * event_abort flag can be used to find out which of these has happened).
+ */
+extern int crk_process_buffer(void);
+
+/*
  * Resets the guessed keys buffer and processes all the buffered keys for
  * this salt. The return value is the same as for crk_process_key().
  */

--- a/src/john.c
+++ b/src/john.c
@@ -1130,6 +1130,7 @@ static void john_load(void)
 		if (options.report_utf8 || options.target_enc == UTF_8)
 			dummy_format.params.flags |= FMT_UTF8;
 		dummy_format.params.label = "stdout";
+		dummy_format.methods.reset = &fmt_default_reset;
 		dummy_format.methods.clear_keys = &fmt_default_clear_keys;
 
 		if (!options.target_enc || options.input_enc != UTF_8)
@@ -1873,6 +1874,15 @@ static void john_done(void)
 {
 	if ((options.flags & (FLG_CRACKING_CHK | FLG_STDOUT)) ==
 	    FLG_CRACKING_CHK) {
+		if (!event_abort && mask_iter_warn) {
+			log_event("Warning: Incremental mask started at length %d",
+			          mask_iter_warn);
+			if (john_main_process)
+				fprintf(stderr,
+				        "Warning: incremental mask started at length %d"
+				        " - try the CPU format for shorter lengths.\n",
+				        mask_iter_warn);
+		}
 		if (event_abort) {
 			char *abort_msg = (aborted_by_timer) ?
 			          "Session stopped (max run-time reached)" :

--- a/src/loader.h
+++ b/src/loader.h
@@ -139,8 +139,11 @@ struct db_salt {
 /* Number of passwords with this salt */
 	int count;
 
-/* Sequential id for a given salt. Sequential id does not change even if some
- * salts are removed during cracking */
+/*
+ * Sequential id for a given salt. Sequential id does not change even if some
+ * salts are removed during cracking (except possibly if a FMT_REMOVE format
+ * renumbers the salts while re-iterating them).
+ */
 	int sequential_id;
 
 #ifndef BENCH_BUILD

--- a/src/mask.c
+++ b/src/mask.c
@@ -1,7 +1,6 @@
 /*
  * This file is part of John the Ripper password cracker,
- * Copyright (c) 2013 by Solar Designer
- * Copyright (c) 2013-2014 by magnum
+ * Copyright (c) 2013-2018 by magnum
  * Copyright (c) 2014 by Sayantan Datta
  *
  * Redistribution and use in source and binary forms, with or without
@@ -13,7 +12,6 @@
 #include <stdio.h> /* for fprintf(stderr, ...) */
 #include <string.h>
 #include <ctype.h>
-#include <assert.h>
 
 #include "arch.h"
 #include "misc.h" /* for error() */
@@ -33,6 +31,8 @@
 #include "memdbg.h"
 #include "mask_ext.h"
 
+//#define MASK_DEBUG
+
 extern void wordlist_hybrid_fix_state(void);
 extern void mkv_hybrid_fix_state(void);
 extern void inc_hybrid_fix_state(void);
@@ -46,9 +46,11 @@ static char *mask = NULL, *template_key;
 static int max_keylen, rec_len, restored_len, restored;
 static uint64_t rec_cl, cand_length;
 static struct fmt_main *mask_fmt;
+struct db_main *mask_db;
 static int mask_bench_index;
-static int parent_fix_state_pending, iterate_lengths;
-int mask_add_len, mask_num_qw, mask_cur_len;
+static int parent_fix_state_pending, increment_lengths;
+static unsigned int int_mask_sum, format_cannot_reset;
+int mask_add_len, mask_num_qw, mask_cur_len, mask_iter_warn;
 
 /*
  * This keeps track of whether we have any 8-bit in our non-hybrid mask.
@@ -95,9 +97,6 @@ static void parse_hex(char *string)
 	unsigned char *s = (unsigned char*)string;
 	unsigned char *d = s;
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s)\n", __FUNCTION__, string);
-#endif
 	if (!string || !*string)
 		return;
 
@@ -108,10 +107,8 @@ static void parse_hex(char *string)
 	} else if (*s == '\\' && s[1] == 'x' &&
 	    atoi16[s[2]] != 0x7f && atoi16[s[3]] != 0x7f) {
 		char c = (atoi16[s[2]] << 4) + atoi16[s[3]];
-		if (!c && !warned++)
-		if (john_main_process)
-			fprintf(stderr, "Warning: \\x00 in mask terminates "
-			        "the string\n");
+		if (!c && !warned++ && john_main_process)
+			fprintf(stderr, "Warning: \\x00 in mask terminates the string\n");
 		if (strchr("\\[]?-", c))
 			*d++ = '\\';
 		*d++ = c;
@@ -136,9 +133,6 @@ static char* expand_cplhdr(char *string)
 	char *d = out;
 	int in_brackets = 0, esc=0;
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s)\n", __FUNCTION__, string);
-#endif
 	if (!string || !*string)
 		return string;
 
@@ -173,7 +167,7 @@ static char* expand_cplhdr(char *string)
 			if (!esc) {
 				if (*s == '[') {
 					++in_brackets;
-					if (s[1] == ']')  {
+					if (s[1] == ']') {
 						// empty brace. Abort with error.
 						fprintf(stderr,"Mask error: "
 							"empty group [] not valid\n");
@@ -189,11 +183,11 @@ static char* expand_cplhdr(char *string)
 	}
 	*d = '\0';
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s) return: %s\n", __FUNCTION__, string, out);
-#endif
 	return out;
 }
+
+#define add_range(a, b)	for (j = a; j <= b; j++) *o++ = j
+#define add_string(str)	for (s = (char*)str; *s; s++) *o++ = *s
 
 /*
  * Convert a single placeholder like ?l (given as 'l' char arg.) to a string.
@@ -207,10 +201,6 @@ static char* plhdr2string(char p, int fmt_case)
 	char *s, *o = out;
 	int j;
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%c)\n", __FUNCTION__, p);
-#endif
-
 	/*
 	 * Force lowercase for case insignificant formats. Dupes will
 	 * be removed, so e.g. ?l?u == ?l.
@@ -221,9 +211,6 @@ static char* plhdr2string(char p, int fmt_case)
 		if (p == 'U')
 			p = 'L';
 	}
-
-#define add_range(a, b)	for (j = a; j <= b; j++) *o++ = j
-#define add_string(str)	for (s = (char*)str; *s; s++) *o++ = *s
 
 	if ((options.internal_cp == ASCII ||
 	     options.internal_cp == UTF_8) &&
@@ -930,6 +917,7 @@ static char* plhdr2string(char p, int fmt_case)
 	return out;
 }
 #undef add_string
+#undef add_range
 
 /*
  * Expands all non-custom placeholders in string and returns a new resulting
@@ -946,9 +934,6 @@ static char* expand_plhdr(char *string, int fmt_case)
 	char *d = out;
 	int ab = 0;
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s)\n", __FUNCTION__, string);
-#endif
 	if (!string || !*string)
 		return string;
 
@@ -984,10 +969,43 @@ static char* expand_plhdr(char *string, int fmt_case)
 		*d++ = ']';
 	*d = '\0';
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s) return: %s\n", __FUNCTION__, string, out);
-#endif
 	return out;
+}
+
+/* Drop length-1-ranges eg. [a] -> a. Modifies string in-place. */
+static char* drop1range(char *mask)
+{
+	char *s = mask, *d = mask;
+
+	while ((*d = *s)) {
+		if (*s == '\\')
+			*++d = *++s;
+		else if (*s == '[') {
+			int len = 0;
+			char *s1 = s;
+
+			while (s1[1] && !(s1[1] == ']' && s1[0] != '\\')) {
+				if (*s1++ != '\\')
+					len++;
+			}
+			if (s1[1] == ']') {
+				if (len == 1) {
+					len = s1 - s;
+					s++;
+					while (len--)
+						*d++ = *s++;
+					s++;
+				} else
+					while (len--)
+						*d++ = *s++;
+				continue;
+			}
+		}
+		d++;
+		s++;
+	}
+
+	return mask;
 }
 
 /*
@@ -1036,9 +1054,6 @@ static int mask_len(char *mask)
 		}
 	}
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s): %d\n", __FUNCTION__, mask, len);
-#endif
 	return len;
 }
 
@@ -1046,8 +1061,8 @@ static int mask_len(char *mask)
  * valid braces:
  * [abcd], [[[[[abcde], []]abcde]]], [[[ab]cdefr]]
  * invalid braces:
- * [[ab][c], parsed as two separate ranges [[ab] and [c]
- * [[ab][, error, sets parse_ok to 0.
+ * [[ab][c], parsed as two separate ranges [[ab] and [c] (no error)
+ * [[ab][, error
  *
  * This function must pass any escaped characters on, as-is (still escaped).
  */
@@ -1056,9 +1071,6 @@ static void parse_braces(char *mask, mask_parsed_ctx *parsed_mask)
 	int i, j ,k;
 	int cl_br_enc;
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s)\n", __FUNCTION__, mask);
-#endif
 	for (i = 0; i < MAX_NUM_MASK_PLHDR; i++) {
 		store_cl(i, -1);
 		store_op(i, -1);
@@ -1097,10 +1109,13 @@ static void parse_braces(char *mask, mask_parsed_ctx *parsed_mask)
 		k++;
 	}
 
-	parsed_mask->parse_ok = 1;
 	for (i = 0; i < MAX_NUM_MASK_PLHDR; i++)
-		if ((load_op(i) == -1) ^ (load_cl(i) == -1))
-			parsed_mask->parse_ok = 0;
+		if ((load_op(i) == -1) ^ (load_cl(i) == -1)) {
+			if (john_main_process)
+				fprintf(stderr, "Parsing unsuccessful, missing closing"
+				        " bracket\n");
+			error();
+		}
 }
 
 /*
@@ -1116,9 +1131,6 @@ static void parse_qtn(char *mask, mask_parsed_ctx *parsed_mask)
 {
 	int i, j, k;
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s)\n", __FUNCTION__, mask);
-#endif
 	for (i = 0; i < MAX_NUM_MASK_PLHDR; i++)
 		parsed_mask->stack_qtn[i] = -1;
 
@@ -1127,15 +1139,11 @@ static void parse_qtn(char *mask, mask_parsed_ctx *parsed_mask)
 			i++;
 			continue;
 		}
-		else
-		if (mask[i] == '?')
-		if (i + 1 < strlen(mask))
-		if (strchr(BUILT_IN_CHARSET, ARCH_INDEX(mask[i + 1]))) {
+		else if (mask[i] == '?' && i + 1 < strlen(mask) &&
+		         strchr(BUILT_IN_CHARSET, ARCH_INDEX(mask[i + 1]))) {
 			j = 0;
-			while (load_op(j) != -1 &&
-			       load_cl(j) != -1) {
-				if (i > load_op(j) &&
-				    i < load_cl(j))
+			while (load_op(j) != -1 && load_cl(j) != -1) {
+				if (i > load_op(j) && i < load_cl(j))
 					goto cont;
 				j++;
 			}
@@ -1178,32 +1186,19 @@ static int calc_pos_in_key(const char *mask, mask_parsed_ctx *parsed_mask,
 				i++;
 				ret_pos++;
 			}
-		        continue;
+			continue;
 		}
 		t = search_stack(parsed_mask, i);
-		i = t ? t + 1: i + 1;
+		i = t ? t + 1 : i + 1;
 		ret_pos++;
 	}
 
 	return ret_pos;
 }
 
-/*
- * This function will finally remove any escape characters (after honoring
- * them of course, if they protected any of our specials)
- */
-static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
-                          mask_cpu_context *cpu_mask_ctx)
-{
-	int i, qtn_ctr, op_ctr, cl_ctr;
-	char *p;
-	int fmt_case = (mask_fmt->params.flags & FMT_CASE);
-
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s)\n", __FUNCTION__, mask);
-#endif
 #define count(i) cpu_mask_ctx->ranges[i].count
-#define fill_range() 							\
+
+#define fill_range()	  \
 	if (a > b) {							\
 		for (x = a; x >= b; x--)				\
 			if (!memchr((const char*)cpu_mask_ctx->		\
@@ -1218,19 +1213,39 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 				chars[count(i)++] = x;			\
 	}
 
-/* Safe in non-bracketed if/for: The final ';' comes with the invocation */
 #define add_string(string)						\
 	for (p = (char*)string; *p; p++)				\
 		cpu_mask_ctx->ranges[i].chars[count(i)++] = *p
 
 #define set_range_start()						\
-	for (j = 0; j < cpu_mask_ctx->ranges[i].count; j++)		\
+	for (j = 0; j < count(i); j++)		\
 			if (cpu_mask_ctx->ranges[i].chars[0] + j !=	\
 			    cpu_mask_ctx->ranges[i].chars[j])		\
 				break;					\
-	if (j == cpu_mask_ctx->ranges[i].count)				\
+	if (j == count(i))				\
 		cpu_mask_ctx->ranges[i].start =				\
-			cpu_mask_ctx->ranges[i].chars[0];
+			cpu_mask_ctx->ranges[i].chars[0]
+
+#define check_n_insert 						\
+	if (!memchr((const char*)cpu_mask_ctx->ranges[i].chars,	\
+		(int)mask[j], count(i)))			\
+		cpu_mask_ctx->ranges[i].chars[count(i)++] = mask[j]
+
+/*
+ * This function will finally remove any escape characters (after honoring
+ * them of course, if they protected any of our specials).
+ * Called by finalize_mask()
+ */
+static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
+                          mask_cpu_context *cpu_mask_ctx, int len)
+{
+	int i, qtn_ctr, op_ctr, cl_ctr;
+	char *p;
+	int fmt_case = (mask_fmt->params.flags & FMT_CASE);
+
+#ifdef MASK_DEBUG
+	fprintf(stderr, "%s(%s, %d)\n", __FUNCTION__, mask, len);
+#endif
 
 	for (i = 0; i < MAX_NUM_MASK_PLHDR; i++) {
 		cpu_mask_ctx->ranges[i].start =
@@ -1246,20 +1261,18 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 	cpu_mask_ctx->ps1 = MAX_NUM_MASK_PLHDR;
 
 	qtn_ctr = op_ctr = cl_ctr = 0;
+
 	for (i = 0; i < MAX_NUM_MASK_PLHDR; i++) {
+		int pos;
+
 		if ((unsigned int)load_op(op_ctr) <
 		    (unsigned int)load_qtn(qtn_ctr)) {
-#define check_n_insert 						\
-	(!memchr((const char*)cpu_mask_ctx->ranges[i].chars,	\
-		(int)mask[j], count(i)))			\
-		cpu_mask_ctx->ranges[i].chars[count(i)++] = mask[j];
-
 			int j;
 
-			cpu_mask_ctx->
-			ranges[i].pos = calc_pos_in_key(mask,
-						        parsed_mask,
-				                        load_op(op_ctr));
+			pos = calc_pos_in_key(mask, parsed_mask, load_op(op_ctr));
+			if (pos >= len && !format_cannot_reset)
+				break;
+			cpu_mask_ctx->ranges[i].pos = pos;
 
 			for (j = load_op(op_ctr) + 1; j < load_cl(cl_ctr);) {
 				int a , b;
@@ -1267,7 +1280,7 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 				if (mask[j] == '\\') {
 					j++;
 					if (j >= load_cl(cl_ctr)) break;
-					if check_n_insert
+					check_n_insert;
 				}
 				else if (mask[j] == '-' &&
 				         j + 1 < load_cl(cl_ctr) &&
@@ -1276,12 +1289,11 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 					int x;
 
 /*
- * Remove the character mask[j-1] added in previous iteration, only if it
+ * Remove the character mask[j - 1] added in previous iteration, only if it
  * was added.
-*/
-					if (!memchr((const char*)cpu_mask_ctx->
-					    ranges[i].chars, (int)mask[j - 1],
-					            count(i)))
+ */
+					if (!memchr((const char*)cpu_mask_ctx->ranges[i].chars,
+					            (int)mask[j - 1], count(i)))
 						count(i)--;
 
 					a = (unsigned char)mask[j - 1];
@@ -1298,12 +1310,11 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 					 int x;
 
 /*
- * Remove the character mask[j-1] added in previous iteration, only if it
+ * Remove the character mask[j - 1] added in previous iteration, only if it
  * was added.
-*/
-					if (!memchr((const char*)cpu_mask_ctx->
-					    ranges[i].chars, (int)mask[j - 1],
-					            count(i)))
+ */
+					if (!memchr((const char*)cpu_mask_ctx->ranges[i].chars,
+					            (int)mask[j - 1], count(i)))
 						count(i)--;
 
 					a = (unsigned char)mask[j - 1];
@@ -1313,7 +1324,7 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 
 					j += 2;
 				}
-				else if check_n_insert
+				else check_n_insert;
 
 				j++;
 			}
@@ -1323,16 +1334,15 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 			op_ctr++;
 			cl_ctr++;
 			cpu_mask_ctx->count++;
-#undef check_n_insert
 		}
 		else if ((unsigned int)load_op(op_ctr) >
 		         (unsigned int)load_qtn(qtn_ctr))  {
 			int j;
 
-			cpu_mask_ctx->
-			ranges[i].pos = calc_pos_in_key(mask,
-							parsed_mask,
-							load_qtn(qtn_ctr));
+			pos = calc_pos_in_key(mask, parsed_mask, load_qtn(qtn_ctr));
+			if (pos >= len && !format_cannot_reset)
+				break;
+			cpu_mask_ctx->ranges[i].pos = pos;
 
 			add_string(plhdr2string(mask[load_qtn(qtn_ctr) + 1],
 			                        fmt_case));
@@ -1342,9 +1352,9 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 			cpu_mask_ctx->count++;
 		}
 	}
-#undef count
-#undef swap
-#undef fill_range
+#ifdef MASK_DEBUG
+	fprintf(stderr, "%s() count is %d\n", __FUNCTION__, cpu_mask_ctx->count);
+#endif
 	for (i = 0; i < cpu_mask_ctx->count - 1; i++) {
 		cpu_mask_ctx->ranges[i].next = i + 1;
 		cpu_mask_ctx->active_positions[i] = 1;
@@ -1353,11 +1363,21 @@ static void init_cpu_mask(const char *mask, mask_parsed_ctx *parsed_mask,
 	cpu_mask_ctx->active_positions[i] = 1;
 }
 
+#undef check_n_insert
+#undef count
+#undef swap
+#undef fill_range
+
 static void save_restore(mask_cpu_context *cpu_mask_ctx, int range_idx, int ch)
 {
 	static int bckp_range_idx, bckp_next, toggle;
 
-	if (range_idx == -1) return;
+#ifdef MASK_DEBUG
+	fprintf(stderr, "%s(%s)\n", __FUNCTION__, ch ? toggle ? "restoring" : "no-op" : "saving");
+#endif
+
+	if (range_idx == -1)
+		return;
 
 	/* save state */
 	if (!ch) {
@@ -1372,18 +1392,23 @@ static void save_restore(mask_cpu_context *cpu_mask_ctx, int range_idx, int ch)
 	}
 }
 
-/* truncates mask after range idx */
+static void skip_position(mask_cpu_context *cpu_mask_ctx, int *arr);
+
+/*
+ * Truncates mask after range idx.  Called by generate_template_key()
+ */
 static void truncate_mask(mask_cpu_context *cpu_mask_ctx, int range_idx)
 {
 	int i;
 
 #ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%d %d)\n", __FUNCTION__, range_idx, mask_max_skip_loc);
+	fprintf(stderr, "%s(%d) max skip %d\n", __FUNCTION__, range_idx, mask_max_skip_loc);
 #endif
 
 	if (range_idx < mask_max_skip_loc && mask_max_skip_loc != -1) {
-		fprintf(stderr, "Format internal ranges cannot be truncated!\n");
-		fprintf(stderr, "Use a bigger key length or non-gpu format.\n");
+		fprintf(stderr, "Format internal ranges (first %d range positions)"
+		        " cannot be truncated!\n", mask_max_skip_loc + 1);
+		fprintf(stderr, "Use a larger min-length, or non-gpu format.\n");
 		error();
 	}
 
@@ -1411,21 +1436,22 @@ static void truncate_mask(mask_cpu_context *cpu_mask_ctx, int range_idx)
 
 	if (options.node_count && !(options.flags & FLG_MASK_STACKED))
 		mask_tot_cand = mask_tot_cand *
-			(options.node_max + 1 - options.node_min) /
-			options.node_count;
+			(options.node_max + 1 - options.node_min) / options.node_count;
 }
 
 /*
  * Returns the template of the keys corresponding to the mask.
+ * Called by do_mask_crack()
  */
 static char* generate_template_key(char *mask, const char *key, int key_len,
-				   mask_parsed_ctx *parsed_mask,
-				   mask_cpu_context *cpu_mask_ctx)
+                                   mask_parsed_ctx *parsed_mask,
+                                   mask_cpu_context *cpu_mask_ctx,
+                                   int template_len)
 {
 	int i, k, t, j, l, offset;
 
 #ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s) key %s len %d (max %d)\n", __FUNCTION__, mask, key, key_len, max_keylen);
+	fprintf(stderr, "%s(%s) ext key %s ext key_len %d (max %d)\n", __FUNCTION__, mask, key, key_len, template_len);
 #endif
 
 	i = 0, k = 0, j = 0, l = 0, offset = 0;
@@ -1441,7 +1467,8 @@ static char* generate_template_key(char *mask, const char *key, int key_len,
 			cpu_mask_ctx->ranges[j++].offset = offset;
 		} else if (mask[i] == '\\') {
 			i++;
-			if (i >= strlen(mask)) break;
+			if (i >= strlen(mask))
+				break;
 			template_key[k++] = mask[i++];
 		} else if (key != NULL && (mask[i + 1] == 'w' ||
 			mask[i + 1] == 'W') && mask[i] == '?') {
@@ -1453,10 +1480,10 @@ static char* generate_template_key(char *mask, const char *key, int key_len,
 		} else
 			template_key[k++] = mask[i++];
 
-		if (k >= (unsigned int)max_keylen) {
-			save_restore(cpu_mask_ctx, j - 1, 0);
+		if (k >= (unsigned int)template_len) {
+			save_restore(cpu_mask_ctx, j - 1, 0); // save
 			truncate_mask(cpu_mask_ctx, j - 1);
-			k = max_keylen;
+			k = template_len;
 			break;
 		}
 	}
@@ -1481,7 +1508,7 @@ static char* generate_template_key(char *mask, const char *key, int key_len,
 		}
 	}
 #ifdef MASK_DEBUG
-	fprintf(stderr, "Mask '%s' has%s 8-bit\n", template_key, mask_has_8bit ? "" : " no");
+	fprintf(stderr, "%s(): Mask '%s' has%s 8-bit\n", __FUNCTION__, template_key, mask_has_8bit ? "" : " no");
 #endif
 
 	return template_key;
@@ -1494,7 +1521,7 @@ static MAYBE_INLINE char* mask_cp_to_utf8(char *in)
 
 	if (mask_has_8bit &&
 	    (options.internal_cp != UTF_8 && options.target_enc == UTF_8))
-		return cp_to_utf8_r(in, out, options.eff_maxlength);
+		return cp_to_utf8_r(in, out, max_keylen);
 
 	return in;
 }
@@ -1522,7 +1549,7 @@ static MAYBE_INLINE char* mask_cp_to_utf8(char *in)
 	}
 
 #define init_key(ps)							\
-	while (ps != MAX_NUM_MASK_PLHDR) {				\
+	while (ps < MAX_NUM_MASK_PLHDR) {				\
 		template_key[ranges(ps).pos + ranges(ps).offset] =	\
 		ranges(ps).chars[ranges(ps).iter];			\
 		ps = ranges(ps).next;					\
@@ -1533,7 +1560,7 @@ static MAYBE_INLINE char* mask_cp_to_utf8(char *in)
 
 #define set_template_key(ps, start)					\
 	template_key[ranges(ps).pos + ranges(ps).offset] =		\
-		start ? start + ranges(ps).iter:			\
+		start ? start + ranges(ps).iter :			\
 		ranges(ps).chars[ranges(ps).iter];
 
 static int generate_keys(mask_cpu_context *cpu_mask_ctx,
@@ -1579,7 +1606,7 @@ static int generate_keys(mask_cpu_context *cpu_mask_ctx,
 	else if (cpu_mask_ctx->cpu_count >= 4) {
 		ps = ranges(ps4).next;
 
-	/* Initialize the remaining placeholders other than the first four */
+		/* Initialize the remaining placeholders other than the first four */
 		init_key(ps);
 
 		while (1) {
@@ -1710,7 +1737,8 @@ static void skip_position(mask_cpu_context *cpu_mask_ctx, int *arr)
 
 	if (arr != NULL) {
 		int k = 0;
-		while (k < MASK_FMT_INT_PLHDR && arr[k] >= 0 && arr[k] < cpu_mask_ctx->count) {
+		while (k < MASK_FMT_INT_PLHDR && arr[k] >= 0 &&
+		       arr[k] < cpu_mask_ctx->count) {
 			int j, i, flag1 = 0, flag2 = 0;
 			cpu_mask_ctx->active_positions[arr[k]] = 0;
 			cpu_mask_ctx->ranges[arr[k]].next = MAX_NUM_MASK_PLHDR;
@@ -1729,7 +1757,7 @@ static void skip_position(mask_cpu_context *cpu_mask_ctx, int *arr)
 
 			if (flag1)
 				cpu_mask_ctx->ranges[j].next =
-					flag2?i:MAX_NUM_MASK_PLHDR;
+					flag2 ? i : MAX_NUM_MASK_PLHDR;
 			k++;
 		}
 	}
@@ -1744,18 +1772,25 @@ static void skip_position(mask_cpu_context *cpu_mask_ctx, int *arr)
 		}
 }
 
+/*
+ * Divide a work between multiple nodes.  Called by finalize_mask()
+ */
 static uint64_t divide_work(mask_cpu_context *cpu_mask_ctx)
 {
 	uint64_t offset, my_candidates, total_candidates, ctr;
 	int ps;
 	double fract;
 
+#ifdef MASK_DEBUG
+	fprintf(stderr, "%s()\n", __FUNCTION__);
+#endif
+
 	fract = (double)(options.node_max - options.node_min + 1) /
 		options.node_count;
 
 	offset = 1;
 	ps = cpu_mask_ctx->ps1;
-	while(ps != MAX_NUM_MASK_PLHDR) {
+	while(ps < MAX_NUM_MASK_PLHDR) {
 		if (cpu_mask_ctx->ranges[ps].pos < max_keylen)
 			offset *= cpu_mask_ctx->ranges[ps].count;
 		ps = cpu_mask_ctx->ranges[ps].next;
@@ -1770,7 +1805,7 @@ static uint64_t divide_work(mask_cpu_context *cpu_mask_ctx)
 	if (options.node_max == options.node_count)
 		my_candidates = total_candidates - offset;
 
-	if (!my_candidates && !iterate_lengths) {
+	if (!my_candidates && !increment_lengths) {
 		if (john_main_process)
 			fprintf(stderr, "%u: Insufficient work. Cannot distribute "
 			        "work among nodes!\n", options.node_min);
@@ -1779,7 +1814,7 @@ static uint64_t divide_work(mask_cpu_context *cpu_mask_ctx)
 
 	ctr = 1;
 	ps = cpu_mask_ctx->ps1;
-	while(ps != MAX_NUM_MASK_PLHDR) {
+	while(ps < MAX_NUM_MASK_PLHDR) {
 		cpu_mask_ctx->ranges[ps].iter = (offset / ctr) %
 			cpu_mask_ctx->ranges[ps].count;
 		ctr *= cpu_mask_ctx->ranges[ps].count;
@@ -1803,11 +1838,6 @@ static double get_progress(void)
 	if (!mask_tot_cand)
 		return -1;
 
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s() try %"PRIu64" candlen %"PRIu64" tot %"PRIu64"\n", __FUNCTION__,
-	        status.cands, cand_length, total);
-#endif
-
 	if (cand_length)
 		total += cand_length;
 
@@ -1821,7 +1851,7 @@ void mask_save_state(FILE *file)
 	fprintf(file, "%"PRIu64"\n", rec_cand + 1);
 	fprintf(file, "%d\n", rec_ctx.count);
 	fprintf(file, "%d\n", rec_ctx.offset);
-	if (iterate_lengths) {
+	if (increment_lengths) {
 		fprintf(file, "%d\n", rec_len);
 		fprintf(file, "%"PRIu64"\n", cand_length + 1);
 	}
@@ -1851,7 +1881,7 @@ int mask_restore_state(FILE *file)
 	else
 		return fail;
 
-	if (iterate_lengths) {
+	if (increment_lengths) {
 		if (fscanf(file, "%d\n", &d) == 1)
 			restored_len = d;
 		else
@@ -1903,25 +1933,28 @@ void remove_slash(char *mask)
 	}
 }
 
+/*
+ * Stretch mask to mask_cur_len. If iterating over lengths, that means
+ * current length - otherwise it's our minimum length (eg. 8 for WPAPSK).
+ * Called by finalize_mask() but never for a hybrid mask.
+ */
 char *stretch_mask(char *mask, mask_parsed_ctx *parsed_mask)
 {
 	char *stretched_mask;
 	int i, j, k;
 
 #ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s)\n", __FUNCTION__, mask);
+	fprintf(stderr, "%s(%s) to len %d\n", __FUNCTION__, mask, mask_cur_len);
 #endif
 
 	j = strlen(mask);
-	stretched_mask = (char*)mem_alloc((options.eff_maxlength + 2) * j);
+	stretched_mask =
+		mem_alloc_tiny((mask_cur_len + 2) * j, MEM_ALIGN_NONE);
 
 	strcpy(stretched_mask, mask);
 	k = mask_len(mask);
-	while (k && k <
-	       (iterate_lengths ? options.eff_maxlength : options.eff_minlength)) {
-#ifdef MASK_DEBUG
-		fprintf(stderr, "%s(): %d/%d %s\n", __FUNCTION__, k, options.eff_maxlength, stretched_mask);
-#endif
+
+	while (k && k < mask_cur_len) {
 		i = strlen(mask) - 1;
 		if (mask[i] == '\\' && i - 1 >= 0) {
 			i--;
@@ -1932,45 +1965,72 @@ char *stretch_mask(char *mask, mask_parsed_ctx *parsed_mask)
 			strnzcpy(stretched_mask + j, mask + i, 3);
 			j += 2;
 		}
-		else if (mask[i] != ']') {
-		 	if (strchr(BUILT_IN_CHARSET, ARCH_INDEX(mask[i])) &&
-			    i - 1 >= 0 && mask[i - 1] == '?') {
-				strnzcpy(stretched_mask + j, mask + i - 1, 3);
-				j += 2;
-			}
-			else {
-			      stretched_mask[j] = mask[i];
-			      j++;
-			}
-		}
-		else /*if (mask[i] == ']')*/ {
+		else if (mask[i] == ']') {
+			/* Repeat a trailing range word[abc] -> word[abc][abc] */
 			int l = 0;
-			while (parsed_mask->stack_op_br[l] != -1) l++;
-			if (parsed_mask->stack_cl_br[l-1] == i) {
-				i = parsed_mask->stack_op_br[l-1];
+
+			while (parsed_mask->stack_op_br[l] != -1)
+				l++;
+			if (parsed_mask->stack_cl_br[l - 1] == i) {
+				i = parsed_mask->stack_op_br[l - 1];
 				strcpy(stretched_mask + j, mask + i);
 				j += strlen(mask + i);
 			}
 			else {
-			      stretched_mask[j] = mask[i];
-			      j++;
+				stretched_mask[j] = mask[i];
+				j++;
 			}
 		}
+		else if (strchr(BUILT_IN_CHARSET, ARCH_INDEX(mask[i])) &&
+		         i - 1 >= 0 && mask[i - 1] == '?') {
+			/* Repeat a trailing placeholder word?d -> word?d?d */
+			strnzcpy(stretched_mask + j, mask + i - 1, 3);
+			j += 2;
+		}
+		else if (!format_cannot_reset && strlen(mask) > 1 && mask[0] == '?' &&
+		         strchr(BUILT_IN_CHARSET, ARCH_INDEX(mask[1]))) {
+			/* Repeat a leading placeholder ?dword -> ?d?dword */
+			memmove(stretched_mask + 2, stretched_mask, j + 1);
+			memcpy(stretched_mask, mask, 2);
+			j += 2;
+		} else if (!format_cannot_reset && strlen(mask) > 3 && mask[0] == '[') {
+			/* Repeat a leading range [abc]word -> [abc][abc]word */
+			int e;
+
+			for (e = 1; e < strlen(mask); e++) {
+				if (mask[e] == ']' && (mask[e - 1] != '\\' ||
+				     (e > 2 && mask[e - 1] == '\\' && mask[e - 2] == '\\'))) {
+					e++;
+					memmove(stretched_mask + e, stretched_mask, j + 1);
+					memcpy(stretched_mask, mask, e);
+					j += e;
+					break;
+				}
+			}
+		} else if (0) {
+			/* Repeat last range WOR[range]D -> WOR[range][range]D */
+		} else if (0) {
+			/* Repeat last placeholder WOR?dD -> WOR?d?dD */
+		} else {
+			/*
+			 * Last resort, just add trailing spaces. This is
+			 * likely useless but OTOH it will finish very fast.
+			 */
+			stretched_mask[j] = ' ';
+			j++;
+		}
+
 		k++;
 	}
 	stretched_mask[j] = '\0';
 
-	i = 0;
-	while (parsed_mask->stack_cl_br[i] != -1) {
-		parsed_mask->stack_cl_br[i] = -1;
-		parsed_mask->stack_op_br[i++] = -1;
-	}
-
 #ifdef MASK_DEBUG
-	fprintf(stderr, "%s:%s returned\n", __FUNCTION__, stretched_mask);
+	fprintf(stderr, "%s(): %s --> %s\n", __FUNCTION__, mask, stretched_mask);
 #endif
 	return stretched_mask;
 }
+
+static void finalize_mask(int len);
 
 /*
  * Notes about escapes, lists and ranges:
@@ -2000,14 +2060,20 @@ char *stretch_mask(char *mask, mask_parsed_ctx *parsed_mask)
 void mask_init(struct db_main *db, char *unprocessed_mask)
 {
 	static char test_mask[] = "?a?a?l?u?d?d?s?s";
-	int i, max_static_range;
+	int i;
 
+	mask_db = db;
 	mask_fmt = db->format;
+
+	/* These formats are too wierd for magnum to get working */
+	if (!strcasecmp(mask_fmt->params.label, "descrypt-opencl") ||
+	    !strcasecmp(mask_fmt->params.label, "lm-opencl"))
+		format_cannot_reset = 1;
 
 	if ((options.req_minlength >= 0 || options.req_maxlength) &&
 	    (options.eff_minlength != options.eff_maxlength) &&
 	    !(options.flags & FLG_MASK_STACKED))
-		iterate_lengths = 1;
+		increment_lengths = 1;
 
 	max_keylen = options.eff_maxlength;
 
@@ -2037,8 +2103,8 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 		if (!options.mask)
 			options.mask = "";
 
-		if (2 * max_keylen < strlen(options.mask))
-			options.mask[2 * max_keylen] = 0;
+		if (2 * options.eff_maxlength < strlen(options.mask))
+			options.mask[2 * options.eff_maxlength] = 0;
 	}
 
 	if (!(options.flags & FLG_MASK_STACKED)) {
@@ -2060,7 +2126,7 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 		unprocessed_mask = options.mask;
 
 	mask = unprocessed_mask;
-	template_key = (char*)mem_alloc(0x400);
+	template_key = mem_alloc(0x400);
 
 	/* Handle command-line (or john.conf) masks given in UTF-8 */
 	if (options.input_enc == UTF_8 && options.internal_cp != UTF_8) {
@@ -2078,7 +2144,7 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 		if (*options.custom_mask[i])
 			options.custom_mask[i] =
 				str_alloc_copy(expand_plhdr(options.custom_mask[i],
-				    db->format->params.flags & FMT_CASE));
+				    mask_fmt->params.flags & FMT_CASE));
 
 	/* Finally expand custom placeholders ?1 .. ?9 */
 	mask = expand_cplhdr(mask);
@@ -2100,39 +2166,67 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 		if (*options.custom_mask[i])
 			parse_hex(options.custom_mask[i]);
 
+	/* Drop braces around a single-character [z] -> z */
+	mask = drop1range(mask);
+
+	if (format_cannot_reset) {
+		if (options.flags & FLG_MASK_STACKED)
+			mask_cur_len = 0;
+		else
+			mask_cur_len = increment_lengths ?
+				options.eff_maxlength : options.eff_minlength;
+		finalize_mask(max_keylen);
+	} else if (!((mask_fmt->params.flags & FMT_MASK) && increment_lengths)) {
+		mask_cur_len = options.eff_minlength;
+		finalize_mask(max_keylen);
+	}
+
+	if (format_cannot_reset && increment_lengths && mask_skip_ranges[0] != -1) {
+		int inc_min =
+			mask_int_cand.int_cpu_mask_ctx->ranges[mask_max_skip_loc].pos + 1;
+		if (options.eff_minlength < inc_min) {
+			mask_iter_warn = inc_min;
+			fprintf(stderr, "Note: %s format can't currently increment length from %d, using %d instead\n",
+			        mask_fmt->params.label, options.eff_minlength, inc_min);
+			options.eff_minlength = inc_min;
+		}
+	}
+}
+
+/*
+ * Finalizes the mask for current length (stretching it to mask_cur_len if
+ * applicable).  Sets up CPU-side mask and calls mask_ext for setting up
+ * GPU-side mask.  Called by do_mask_crack() if iterating lengths, otherwise
+ * from mask_init() above.
+ */
+static void finalize_mask(int len)
+{
+	int i, max_static_range;
+
 #ifdef MASK_DEBUG
-	fprintf(stderr, "Custom masks expanded (this is 'mask' when passed to "
-	        "parse_braces()):\n%s\n", mask);
+	fprintf(stderr, "\n%s(%d) mask %s\n", __FUNCTION__, len, mask);
 #endif
+	/* Reset things, in case we're iterating over lengths */
+	memset(&cpu_mask_ctx, 0, sizeof(cpu_mask_ctx));
+	memset(&parsed_mask, 0, sizeof(parsed_mask));
+	MEM_FREE(mask_skip_ranges);
+	MEM_FREE(mask_int_cand.int_cand);
+	MEM_FREE(template_key_offsets);
 
 	/* Parse ranges */
 	parse_braces(mask, &parsed_mask);
 
-	if (parsed_mask.parse_ok) {
-		if (!(options.flags & FLG_MASK_STACKED) &&
-		    (iterate_lengths || options.eff_minlength)) {
-			mask = stretch_mask(mask, &parsed_mask);
-			parse_braces(mask, &parsed_mask);
-			if (!parsed_mask.parse_ok) {
-				if (john_main_process)
-					fprintf(stderr, "Parse unsuccessful,"
-					 " missing closing"
-					 " bracket\n");
-				error();
-			}
-
-		}
-		parse_qtn(mask, &parsed_mask);
-	} else {
-		if (john_main_process)
-			fprintf(stderr, "Parsing unsuccessful, missing closing"
-			        " bracket\n");
-		error();
+	if (!(options.flags & FLG_MASK_STACKED) &&
+	    (options.eff_minlength > mask_len(mask) || mask_len(mask) < len)) {
+		mask = stretch_mask(mask, &parsed_mask);
+		parse_braces(mask, &parsed_mask);
 	}
+	parse_qtn(mask, &parsed_mask);
 
 	i = 0; mask_add_len = 0; mask_num_qw = 0; max_static_range = 0;
 	while (i < strlen(mask)) {
 		int t;
+
 		if ((t = search_stack(&parsed_mask, i))) {
 			mask_add_len++;
 			i = t + 1;
@@ -2146,7 +2240,7 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 			mask_num_qw++;
 			i += 2;
 			if ((options.flags & FLG_MASK_STACKED) &&
-			    mask_add_len >= (unsigned int)max_keylen &&
+			    mask_add_len >= (unsigned int)len &&
 			    mask_num_qw == 1) {
 				if (john_main_process)
 				fprintf(stderr, "Hybrid mask must contain ?w/?W"
@@ -2160,8 +2254,8 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 	}
 	if (options.flags & FLG_MASK_STACKED) {
 		mask_has_8bit = 1; /* Parent mode's word might have 8-bit */
-		if (mask_add_len > max_keylen - 1)
-			mask_add_len = max_keylen - 1;
+		if (mask_add_len > len - 1)
+			mask_add_len = len - 1;
 
 		if (mask_num_qw == 0) {
 			if (john_main_process)
@@ -2170,22 +2264,15 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 			error();
 		}
 	} else {
-		if (mask_add_len > max_keylen)
-			mask_add_len = max_keylen;
-		else
-		if (options.req_maxlength && mask_add_len < max_keylen) {
-			if (john_main_process)
-				fprintf(stderr, "Error: mask is shorter than "
-				        "-max-length parameter\n");
-			error();
-		}
 		if (mask_num_qw && john_main_process)
-		fprintf(stderr, "Warning: ?w has no special meaning in pure "
-		        "mask mode\n");
+			fprintf(stderr,
+			        "Warning: ?w has no special meaning in pure mask mode\n");
+		if (mask_add_len > len)
+			mask_add_len = len;
 	}
 
 #ifdef MASK_DEBUG
-	fprintf(stderr, "qw %d minlen %d maxlen %d fmt_len %d mask_add_len %d mask len %d\n", mask_num_qw, options.eff_minlength, options.eff_maxlength, max_keylen, mask_add_len, mask_len(mask));
+	fprintf(stderr, "%s() qw %d minlen %d maxlen %d fmt_len %d mask_add_len %d mask len %d\n", __FUNCTION__, mask_num_qw, options.eff_minlength, max_keylen, len, mask_add_len, mask_len(mask));
 #endif
 	/* We decrease these here instead of changing parent modes. */
 	if (options.flags & FLG_MASK_STACKED) {
@@ -2198,44 +2285,57 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 			options.eff_maxlength /= mask_num_qw;
 		}
 #ifdef MASK_DEBUG
-		fprintf(stderr, "effective minlen %d maxlen %d fmt_len %d\n",
+		fprintf(stderr, "%s(): effective minlen %d maxlen %d fmt_len %d\n",
+		        __FUNCTION__,
 		        options.eff_minlength, options.eff_maxlength,
 		        options.eff_maxlength - mask_add_len);
 #endif
 	}
 
-	template_key_offsets = (int*)mem_alloc((mask_num_qw + 1) * sizeof(int));
+	template_key_offsets = mem_alloc((mask_num_qw + 1) * sizeof(int));
 
 	for (i = 0; i < mask_num_qw + 1; i++)
 		template_key_offsets[i] = -1;
 
 #ifdef MASK_DEBUG
-	fprintf(stderr, "Custom masks expanded (this is 'mask' when passed to "
-	        "init_cpu_mask()):\n%s\n", mask);
+	fprintf(stderr, "%s(): masks expanded (this is 'mask' when passed to "
+	        "init_cpu_mask()):\n%s\n", __FUNCTION__, mask);
 #endif
-	init_cpu_mask(mask, &parsed_mask, &cpu_mask_ctx);
+	init_cpu_mask(mask, &parsed_mask, &cpu_mask_ctx, len);
 
-	mask_calc_combination(&cpu_mask_ctx, max_static_range);
+	mask_ext_calc_combination(&cpu_mask_ctx, max_static_range);
 
-/*	fprintf(stderr, "MASK_FMT_INT_PLHDRs:");
+#ifdef MASK_DEBUG
+	fprintf(stderr, "%s() MASK_FMT_INT_PLHDRs: max static range %d: ",
+	        __FUNCTION__, max_static_range);
 	for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges; i++)
-	fprintf(stderr, "%d ", mask_skip_ranges[i]);
-	fprintf(stderr, "\n");*/
+		fprintf(stderr, "%d ", mask_skip_ranges[i]);
+	fprintf(stderr, "\n");
+#endif
+	int_mask_sum = 0;
+	for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges; i++)
+		int_mask_sum |= mask_skip_ranges[i] << (8 * i);
 
 	skip_position(&cpu_mask_ctx, mask_skip_ranges);
 
 	/* If running hybrid (stacked), we let the parent mode distribute */
-	if (options.node_count && !(options.flags & FLG_MASK_STACKED))
-		cand = divide_work(&cpu_mask_ctx);
-	else {
+	if (options.node_count && !(options.flags & FLG_MASK_STACKED)) {
+		if (restored)
+			restored = 0;
+		else
+			cand = divide_work(&cpu_mask_ctx);
+	} else {
 		cand = 1;
 		for (i = 0; i < cpu_mask_ctx.count; i++)
 			if ((int)(cpu_mask_ctx.active_positions[i]))
 			if ((options.flags & FLG_MASK_STACKED) ||
-			    cpu_mask_ctx.ranges[i].pos < max_keylen)
+			    cpu_mask_ctx.ranges[i].pos < len)
 				cand *= cpu_mask_ctx.ranges[i].count;
 	}
 	mask_tot_cand = cand * mask_int_cand.num_int_cand;
+
+	log_event("- Requested internal mask factor: %d, actual now %d",
+	          mask_int_cand_target, mask_int_cand.num_int_cand);
 }
 
 void mask_crk_init(struct db_main *db)
@@ -2255,10 +2355,11 @@ void mask_crk_init(struct db_main *db)
 
 void mask_done()
 {
+#ifdef MASK_DEBUG
+	fprintf(stderr, "%s()\n", __FUNCTION__);
+#endif
+
 	if (!(options.flags & FLG_MASK_STACKED)) {
-		if (parsed_mask.parse_ok &&
-		    options.req_maxlength > 0)
-			MEM_FREE(mask);
 		/* For reporting DONE regardless of rounding errors */
 		if (!event_abort) {
 			mask_tot_cand = status.cands;
@@ -2272,10 +2373,8 @@ void mask_done()
 
 	MEM_FREE(template_key);
 	MEM_FREE(template_key_offsets);
-	if (mask_skip_ranges)
-		MEM_FREE(mask_skip_ranges);
-	if (mask_int_cand.int_cand)
-		MEM_FREE(mask_int_cand.int_cand);
+	MEM_FREE(mask_skip_ranges);
+	MEM_FREE(mask_int_cand.int_cand);
 	mask_int_cand.num_int_cand = 0;
 	mask_int_cand_target = 0;
 }
@@ -2286,15 +2385,19 @@ int do_mask_crack(const char *extern_key)
 	int i;
 
 #ifdef MASK_DEBUG
-	fprintf(stderr, "%s(%s)\n", __FUNCTION__, extern_key);
+	fprintf(stderr, "%s(%s) (format %s internal mask)\n", __FUNCTION__, extern_key, mask_fmt->params.flags & FMT_MASK ? "has" : "doesn't have");
 #endif
 
 	mask_parent_keys++;
 
-	/* If --min-len is used, we iterate max_keylen */
-	if (!(options.flags & FLG_MASK_STACKED) && iterate_lengths) {
-		int template_key_len = -1;
-		int max_len = max_keylen;
+	/*
+	 * If not in hybrid mode and --min-len and/or --max-len are used (and
+	 * different), we iterate over lengths, stretching/truncating mask per
+	 * length.
+	 */
+	if (increment_lengths) {
+		int i;
+		unsigned int last_mask_sum = int_mask_sum;
 
 		mask_cur_len = restored_len ?
 			restored_len : options.eff_minlength;
@@ -2302,36 +2405,60 @@ int do_mask_crack(const char *extern_key)
 		restored_len = 0;
 
 		if (mask_cur_len == 0) {
-			if (crk_process_key(fmt_null_key))
-				return 1;
+			if (john_main_process) {
+				if (!format_cannot_reset && mask_fmt->params.flags & FMT_MASK) {
+					finalize_mask(0);
+					generate_template_key(mask, NULL, 0, &parsed_mask,
+					                      &cpu_mask_ctx, 0);
+					if (last_mask_sum != int_mask_sum) {
+						last_mask_sum = int_mask_sum;
+#ifdef MASK_DEBUG
+						fprintf(stderr, "%s() calling format reset()\n", __FUNCTION__);
+#endif
+						mask_fmt->methods.reset(mask_db);
+					}
+				}
+				if (crk_process_key(fmt_null_key))
+					return 1;
+			}
 			mask_cur_len++;
 		}
 
-		for (i = mask_cur_len; i <= max_len; i++) {
-			mask_cur_len = max_keylen = i;
+		for (i = mask_cur_len; i <= options.eff_maxlength; i++) {
+			mask_cur_len = i;
 			cand_length = rec_cl ? rec_cl - 1 : status.cands;
 			rec_cl = 0;
 
-			assert(extern_key == NULL);
-
-			save_restore(&cpu_mask_ctx, 0, 1);
-			generate_template_key(mask, extern_key, key_len,
-					      &parsed_mask, &cpu_mask_ctx);
-
-			if (options.node_count && !(options.flags & FLG_MASK_STACKED)) {
-				if (restored) {
-					restored = 0;
-				}
-				else {
-					cand = divide_work(&cpu_mask_ctx);
-					mask_tot_cand = cand * mask_int_cand.num_int_cand;
-				}
+			/* Process remaining keys of last length, if needed */
+			if (!format_cannot_reset && mask_fmt->params.flags & FMT_MASK) {
+#ifdef MASK_DEBUG
+				fprintf(stderr, "%s() calling crk_process_buffer() for remaining candidates of last length\n", __FUNCTION__);
+#endif
+				if (crk_process_buffer())
+					return 1;
 			}
 
-			if (template_key_len == strlen(template_key)) break;
+			if (format_cannot_reset)
+				save_restore(&cpu_mask_ctx, 0, 1); // restore
+			else
+				finalize_mask(mask_cur_len);
 
-			template_key_len = strlen(template_key);
+			generate_template_key(mask, extern_key, key_len, &parsed_mask,
+			                      &cpu_mask_ctx, mask_cur_len);
 
+			/* Update internal masks if needed. */
+			if (!format_cannot_reset && mask_fmt->params.flags & FMT_MASK &&
+			    last_mask_sum != int_mask_sum) {
+#ifdef MASK_DEBUG
+				fprintf(stderr, "%s() calling format reset()\n", __FUNCTION__);
+#endif
+				mask_fmt->methods.reset(mask_db);
+				last_mask_sum = int_mask_sum;
+			}
+
+#ifdef MASK_DEBUG
+			fprintf(stderr, "%s() generating keys for len %d\n", __FUNCTION__, mask_cur_len);
+#endif
 			if (options.flags & FLG_TEST_CHK) {
 				if (bench_generate_keys(&cpu_mask_ctx, &cand))
 					return 1;
@@ -2340,17 +2467,17 @@ int do_mask_crack(const char *extern_key)
 					return 1;
 			}
 
-			if (i < max_len && cfg_get_bool("Mask", NULL,
-			                                "MaskLengthIterStatus", 1))
+			if (mask_cur_len < options.eff_maxlength &&
+			    cfg_get_bool("Mask", NULL, "MaskLengthIterStatus", 1))
 				event_pending = event_status = 1;
 		}
 	} else {
 		static int old_keylen = -1;
 
 		if (old_keylen != key_len) {
-			save_restore(&cpu_mask_ctx, 0, 1);
+			save_restore(&cpu_mask_ctx, 0, 1); // restore
 			generate_template_key(mask, extern_key, key_len, &parsed_mask,
-		                      &cpu_mask_ctx);
+			                      &cpu_mask_ctx, max_keylen);
 			old_keylen = key_len;
 		}
 

--- a/src/mask.h
+++ b/src/mask.h
@@ -1,7 +1,6 @@
 /*
  * This file is part of John the Ripper password cracker,
- * Copyright (c) 2013 by Solar Designer
- * Copyright (c) 2013-2015 by magnum
+ * Copyright (c) 2013-2018 by magnum
  * Copyright (c) 2014 by Sayantan Datta
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,7 +22,7 @@
 #define MASK_FMT_INT_PLHDR 4
 
 // Maximum number of placeholders in a mask.
-#define MAX_NUM_MASK_PLHDR 127
+#define MAX_NUM_MASK_PLHDR 125
 
 //#define MASK_DEBUG
 
@@ -34,8 +33,6 @@ typedef struct {
 	int stack_cl_br[MAX_NUM_MASK_PLHDR + 1];
 	/* store locations of valid ? in mask */
 	int stack_qtn[MAX_NUM_MASK_PLHDR + 1];
-	/* 1 if parse is successful, otherwise 0 */
-	int parse_ok;
 } mask_parsed_ctx;
 
  /* Range of characters for a placeholder in the mask */
@@ -120,5 +117,8 @@ extern uint64_t mask_parent_keys;
 
 /* Current length when pure mask mode iterates over lengths */
 extern int mask_cur_len;
+
+/* Incremental mask iteration started at this length (contrary to options) */
+extern int mask_iter_warn;
 
 #endif

--- a/src/mask_ext.c
+++ b/src/mask_ext.c
@@ -1,5 +1,6 @@
 /*
  * This file is part of John the Ripper password cracker,
+ * Copyright (c) 2013-2018 by magnum
  * Copyright (c) 2014 by Sayantan Datta
  *
  * Redistribution and use in source and binary forms, with or without
@@ -14,11 +15,13 @@
 #include "memory.h"
 #include "memdbg.h"
 
+//#define MASK_DEBUG
+
 int *mask_skip_ranges = NULL;
 int mask_max_skip_loc = -1;
 int mask_int_cand_target = 0;
 int mask_gpu_is_static = 0;
-mask_int_cand_ctx mask_int_cand = {NULL, NULL, 1};
+mask_int_cand_ctx mask_int_cand = { NULL, NULL, 1 };
 
 static void combination_util(int *data, int start, int end, int index,
                              int r, mask_cpu_context *ptr, int *delta)
@@ -63,7 +66,8 @@ static void generate_int_keys(mask_cpu_context *ptr)
 	for (i = 0; i < mask_int_cand.num_int_cand; i++) \
 		mask_int_cand.int_cand[i].x[t] =	 \
 			ptr->ranges[mask_skip_ranges[t]].chars \
-			[(i/repeat) % modulo];
+			[(i/repeat) % modulo]
+
 #define cond(t) t < MASK_FMT_INT_PLHDR && mask_skip_ranges[t] != -1
 
 	for (i = 1; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
@@ -95,12 +99,9 @@ static void generate_int_keys(mask_cpu_context *ptr)
 }
 
 static void check_static_gpu_mask(int max_static_range)
-{	unsigned int i;
+{
+	unsigned int i;
 	mask_gpu_is_static = 1;
-
-#ifdef MASK_DEBUG
-	fprintf(stderr, "%s()\n", __FUNCTION__);
-#endif
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
 		if (max_static_range <= mask_skip_ranges[i]) {
@@ -109,9 +110,14 @@ static void check_static_gpu_mask(int max_static_range)
 		}
 
 	mask_gpu_is_static |= !(options.flags & FLG_MASK_STACKED);
+
+#ifdef MASK_DEBUG
+	fprintf(stderr, "%s() return: mask is%s static\n", __FUNCTION__, mask_gpu_is_static ? "" : "n't");
+#endif
 }
 
-void mask_calc_combination(mask_cpu_context *ptr, int max_static_range) {
+void mask_ext_calc_combination(mask_cpu_context *ptr, int max_static_range)
+{
 	int *data, i, n;
 	int delta_to_target = 0x7fffffff;
 
@@ -123,7 +129,9 @@ void mask_calc_combination(mask_cpu_context *ptr, int max_static_range) {
 	mask_int_cand.int_cpu_mask_ctx = NULL;
 	mask_int_cand.int_cand = NULL;
 
-	if (!mask_int_cand_target) return;
+	if (!mask_int_cand_target)
+		return;
+
 	if (MASK_FMT_INT_PLHDR > 4) {
 		fprintf(stderr, "MASK_FMT_INT_PLHDR value must not exceed 4.\n");
 		error();
@@ -158,7 +166,9 @@ void mask_calc_combination(mask_cpu_context *ptr, int max_static_range) {
 
 	check_static_gpu_mask(max_static_range);
 
-	/*for (i = 0; i < mask_int_cand.num_int_cand && mask_int_cand.int_cand; i++)
-		fprintf(stderr, "%c%c%c%c\n", mask_int_cand.int_cand[i].x[0], mask_int_cand.int_cand[i].x[1], mask_int_cand.int_cand[i].x[2], mask_int_cand.int_cand[i].x[3]);*/
+#if 0
+	for (i = 0; i < mask_int_cand.num_int_cand && mask_int_cand.int_cand; i++)
+		fprintf(stderr, "%c%c%c%c\n", mask_int_cand.int_cand[i].x[0], mask_int_cand.int_cand[i].x[1], mask_int_cand.int_cand[i].x[2], mask_int_cand.int_cand[i].x[3]);
+#endif
 	MEM_FREE(data);
 }

--- a/src/mask_ext.h
+++ b/src/mask_ext.h
@@ -1,5 +1,6 @@
 /*
  * This file is part of John the Ripper password cracker,
+ * Copyright (c) 2013-2018 by magnum
  * Copyright (c) 2014 by Sayantan Datta
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,11 +25,34 @@ typedef struct {
 	int num_int_cand;
 } mask_int_cand_ctx;
 
-extern void mask_calc_combination(mask_cpu_context *, int);
+extern void mask_ext_calc_combination(mask_cpu_context *, int);
+
+/*
+ * Mask ranges that are generated on GPU (and skipped on CPU, which
+ * may explain the unintuitive name).
+ * Note that if mask_skip_ranges[n] is eg. 0, it doesn't mean pos. 0 in
+ * the key, but the first pos of key that is a mask range/placeholder.
+ */
 extern int *mask_skip_ranges;
+
+/*
+ * Max. mask pos that are generated on GPU.
+ */
 extern int mask_max_skip_loc;
+
+/*
+ * Format's requested number of internal candidates. Should be based on
+ * actual GPU speed.
+ */
 extern int mask_int_cand_target;
+
+/*
+ * Masks like ?d?d or ?d?w are "static" on GPU, as in "positions are static".
+ * ?w?d is not static (base word length may vary), but ?d?w?d may be static
+ * as long as last ?d is not GPU-side.
+ */
 extern int mask_gpu_is_static;
+
 extern mask_int_cand_ctx mask_int_cand;
 
 #endif

--- a/src/opencl_DES_bs_b_plug.c
+++ b/src/opencl_DES_bs_b_plug.c
@@ -606,11 +606,11 @@ static void reset(struct db_main *db)
 
 		build_salt(0);
 
-		salt = db -> salts;
+		salt = db->salts;
 		do {
-			salt_val = *(WORD *)(salt -> salt);
+			salt_val = *(WORD *)(salt->salt);
 			build_salt(salt_val);
-		} while((salt = salt -> next));
+		} while((salt = salt->next));
 
 		if (mask_mode) {
 			release_kernel();
@@ -669,10 +669,10 @@ static int des_crypt_25(int *pcount, struct db_salt *salt)
 
 	process_keys(current_gws, lws);
 
-	if (salt && num_uncracked_hashes(current_salt) != salt -> count &&
+	if (salt && num_uncracked_hashes(current_salt) != salt->count &&
 	/* In case there are duplicate hashes, num_uncracked_hashes is always less than salt->count, as
 	 * num_uncracked_hashes tracks only unique hashes. */
-		num_uncracked_hashes(current_salt) > salt -> count)
+		num_uncracked_hashes(current_salt) > salt->count)
 		update_buffer(salt);
 
 	HANDLE_CLERROR(clSetKernelArg(kernels[gpu_id][0], 1, sizeof(cl_mem), &buffer_processed_salts[current_salt]), "Failed setting kernel argument buffer_processed_salts, kernel DES_bs_25.\n");
@@ -688,10 +688,10 @@ static int des_crypt_25(int *pcount, struct db_salt *salt)
 
 void opencl_DES_bs_b_register_functions(struct fmt_main *fmt)
 {
-	fmt -> methods.done = &clean_all_buffers;
-	fmt -> methods.reset = &reset;
-	fmt -> methods.set_salt = &set_salt;
-	fmt -> methods.crypt_all = &des_crypt_25;
+	fmt->methods.done = &clean_all_buffers;
+	fmt->methods.reset = &reset;
+	fmt->methods.set_salt = &set_salt;
+	fmt->methods.crypt_all = &des_crypt_25;
 
 	opencl_DES_bs_init_global_variables = &init_global_variables;
 }

--- a/src/opencl_DES_bs_b_plug.c
+++ b/src/opencl_DES_bs_b_plug.c
@@ -7,7 +7,6 @@
 
 #ifdef HAVE_OPENCL
 
-#include <assert.h>
 #include <string.h>
 #include <sys/time.h>
 
@@ -40,8 +39,6 @@ static void create_clobj_kpc(size_t gws)
 
 	buffer_unchecked_hashes = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE, (gws * iter_count + PADDING) * sizeof(DES_bs_vector) * 64, NULL, &ret_code);
 	HANDLE_CLERROR(ret_code, "Create buffer_unchecked_hashes failed.\n");
-
-	assert(gws * iter_count <= ((0x1 << 27) - 1));
 }
 
 static void release_clobj_kpc()
@@ -274,9 +271,6 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 		gws_limit >>= 1;
 #endif
 
-	assert(gws_limit > PADDING);
-	assert(!(gws_limit & (gws_limit - 1)));
-
 	if (gws_tune_flag)
 		global_work_size = gws_init;
 
@@ -318,7 +312,7 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 	set_kernel_args_kpc();
 
 	/* for hash_ids[2*x + 1], 27 bits for storing gid and 5 bits for bs depth. */
-	assert(global_work_size <= ((1U << 28) - 1));
+	//assert(global_work_size <= ((1U << 28) - 1));
 	fmt_opencl_DES.params.max_keys_per_crypt = global_work_size << des_log_depth;
 	fmt_opencl_DES.params.min_keys_per_crypt = 1U << des_log_depth;
 }
@@ -421,8 +415,6 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 		}
 		if (local_work_size > lws_limit)
 			local_work_size = lws_limit;
-
-		assert(local_work_size <= lws_limit);
 
 		if (lws_tune_flag) {
 			time_ms = 0;

--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -672,24 +672,24 @@ static void reset(struct db_main *db)
 			unsigned int max_uncracked_hashes = 0;
 			WORD test_salt = 0;
 
-			salt = db -> salts;
+			salt = db->salts;
 			max_uncracked_hashes = 0;
 			do {
-				if (salt -> count > max_uncracked_hashes) {
-					max_uncracked_hashes = salt -> count;
-					test_salt = *(WORD *)salt -> salt;
+				if (salt->count > max_uncracked_hashes) {
+					max_uncracked_hashes = salt->count;
+					test_salt = *(WORD *)salt->salt;
 				}
 
-			} while ((salt = salt -> next));
+			} while ((salt = salt->next));
 			forced_global_keys = 0;
 			auto_tune_all(100, &fmt_opencl_DES, test_salt, mask_mode, extern_lws_limit, &forced_global_keys);
 		}
 
-		salt = db -> salts;
+		salt = db->salts;
 		num_salts = 0;
 		do {
-			salt_list[num_salts++] = (*(WORD *)salt -> salt);
-		} while ((salt = salt -> next));
+			salt_list[num_salts++] = (*(WORD *)salt->salt);
+		} while ((salt = salt->next));
 
 		if (num_salts > 1 && john_main_process)
 			fprintf(stderr, "Note: building per-salt kernels. "
@@ -754,10 +754,10 @@ static int des_crypt_25(int *pcount, struct db_salt *salt)
 
 	process_keys(current_gws, lws);
 
-	if (salt && num_uncracked_hashes(current_salt) != salt -> count &&
+	if (salt && num_uncracked_hashes(current_salt) != salt->count &&
 	/* In case there are duplicate hashes, num_uncracked_hashes is always less than salt->count, as
 	 * num_uncracked_hashes tracks only unique hashes. */
-		num_uncracked_hashes(current_salt) > salt -> count)
+		num_uncracked_hashes(current_salt) > salt->count)
 		update_buffer(salt);
 
 	current_gws *= iter_count;
@@ -771,10 +771,10 @@ static int des_crypt_25(int *pcount, struct db_salt *salt)
 
 void opencl_DES_bs_f_register_functions(struct fmt_main *fmt)
 {
-	fmt -> methods.done = &clean_all_buffers;
-	fmt -> methods.reset = &reset;
-	fmt -> methods.set_salt = &set_salt;
-	fmt -> methods.crypt_all = &des_crypt_25;
+	fmt->methods.done = &clean_all_buffers;
+	fmt->methods.reset = &reset;
+	fmt->methods.set_salt = &set_salt;
+	fmt->methods.crypt_all = &des_crypt_25;
 
 	opencl_DES_bs_init_global_variables = &init_global_variables;
 }

--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -7,7 +7,6 @@
 
 #ifdef HAVE_OPENCL
 
-#include <assert.h>
 #include <string.h>
 #include <sys/time.h>
 
@@ -45,8 +44,6 @@ static void create_clobj_kpc(size_t gws)
 
 	buffer_unchecked_hashes = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE, (gws * iter_count + PADDING) * sizeof(DES_bs_vector) * 64, NULL, &ret_code);
 	HANDLE_CLERROR(ret_code, "Create buffer_unchecked_hashes failed.\n");
-
-	assert(gws * iter_count <= ((0x1 << 27) - 1));
 }
 
 static void release_clobj_kpc()
@@ -336,9 +333,6 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 		gws_limit >>= 1;
 #endif
 
-	assert(gws_limit > PADDING);
-	assert(!(gws_limit & (gws_limit - 1)));
-
 	if (gws_tune_flag)
 		global_work_size = gws_init;
 
@@ -380,7 +374,7 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 	set_kernel_args_kpc();
 
 	/* for hash_ids[2*x + 1], 27 bits for storing gid and 5 bits for bs depth. */
-	assert(global_work_size <= ((1U << 28) - 1));
+	//assert(global_work_size <= ((1U << 28) - 1));
 	fmt_opencl_DES.params.max_keys_per_crypt = global_work_size << des_log_depth;
 	fmt_opencl_DES.params.min_keys_per_crypt = 1U << des_log_depth;
 }
@@ -480,8 +474,6 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 		}
 		if (local_work_size > lws_limit)
 			local_work_size = lws_limit;
-
-		assert(local_work_size <= lws_limit);
 
 		if (lws_tune_flag) {
 			time_ms = 0;

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -7,7 +7,6 @@
 
 #ifdef HAVE_OPENCL
 
-#include <assert.h>
 #include <string.h>
 #include <sys/time.h>
 
@@ -45,8 +44,6 @@ static void create_clobj_kpc(size_t gws)
 
 	buffer_unchecked_hashes = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE, (gws * iter_count + PADDING) * sizeof(DES_bs_vector) * 64, NULL, &ret_code);
 	HANDLE_CLERROR(ret_code, "Create buffer_unchecked_hashes failed.\n");
-
-	assert(gws * iter_count <= ((0x1 << 27) - 1));
 }
 
 static void release_clobj_kpc()
@@ -349,9 +346,6 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 		gws_limit >>= 1;
 #endif
 
-	assert(gws_limit > PADDING);
-	assert(!(gws_limit & (gws_limit - 1)));
-
 	if (gws_tune_flag)
 		global_work_size = gws_init;
 
@@ -393,7 +387,7 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 	set_kernel_args_kpc();
 
 	/* for hash_ids[2*x + 1], 27 bits for storing gid and 5 bits for bs depth. */
-	assert(global_work_size <= ((1U << 28) - 1));
+	//assert(global_work_size <= ((1U << 28) - 1));
 	fmt_opencl_DES.params.max_keys_per_crypt = global_work_size << des_log_depth;
 	fmt_opencl_DES.params.min_keys_per_crypt = 1U << des_log_depth;
 }
@@ -493,8 +487,6 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 		}
 		if (local_work_size > lws_limit)
 			local_work_size = lws_limit;
-
-		assert(local_work_size <= lws_limit);
 
 		if (lws_tune_flag) {
 			time_ms = 0;

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -685,25 +685,25 @@ static void reset(struct db_main *db)
 			unsigned int max_uncracked_hashes = 0;
 			WORD test_salt = 0;
 
-			salt = db -> salts;
+			salt = db->salts;
 			max_uncracked_hashes = 0;
 			do {
-				if (salt -> count > max_uncracked_hashes) {
-					max_uncracked_hashes = salt -> count;
-					test_salt = *(WORD *)salt -> salt;
+				if (salt->count > max_uncracked_hashes) {
+					max_uncracked_hashes = salt->count;
+					test_salt = *(WORD *)salt->salt;
 				}
 
-			} while ((salt = salt -> next));
+			} while ((salt = salt->next));
 
 			forced_global_keys = 0;
 			auto_tune_all(100, &fmt_opencl_DES, test_salt, mask_mode, extern_lws_limit, &forced_global_keys);
 		}
 
-		salt = db -> salts;
+		salt = db->salts;
 		num_salts = 0;
 		do {
-			salt_list[num_salts++] = (*(WORD *)salt -> salt);
-		} while ((salt = salt -> next));
+			salt_list[num_salts++] = (*(WORD *)salt->salt);
+		} while ((salt = salt->next));
 
 		if (num_salts > 1 && john_main_process)
 			fprintf(stderr, "Note: building per-salt kernels. "
@@ -768,10 +768,10 @@ static int des_crypt_25(int *pcount, struct db_salt *salt)
 
 	process_keys(current_gws, lws);
 
-	if (salt && num_uncracked_hashes(current_salt) != salt -> count &&
+	if (salt && num_uncracked_hashes(current_salt) != salt->count &&
 	/* In case there are duplicate hashes, num_uncracked_hashes is always less than salt->count, as
 	 * num_uncracked_hashes tracks only unique hashes. */
-		num_uncracked_hashes(current_salt) > salt -> count)
+		num_uncracked_hashes(current_salt) > salt->count)
 		update_buffer(salt);
 
 	current_gws *= iter_count;
@@ -785,10 +785,10 @@ static int des_crypt_25(int *pcount, struct db_salt *salt)
 
 void opencl_DES_bs_h_register_functions(struct fmt_main *fmt)
 {
-	fmt -> methods.done = &clean_all_buffers;
-	fmt -> methods.reset = &reset;
-	fmt -> methods.set_salt = &set_salt;
-	fmt -> methods.crypt_all = &des_crypt_25;
+	fmt->methods.done = &clean_all_buffers;
+	fmt->methods.reset = &reset;
+	fmt->methods.set_salt = &set_salt;
+	fmt->methods.crypt_all = &des_crypt_25;
 
 	opencl_DES_bs_init_global_variables = &init_global_variables;
 }

--- a/src/opencl_DES_bs_plug.c
+++ b/src/opencl_DES_bs_plug.c
@@ -8,7 +8,6 @@
 #ifdef HAVE_OPENCL
 
 #include <string.h>
-#include <assert.h>
 
 #include "arch.h"
 #include "common.h"
@@ -166,16 +165,12 @@ static void select_bitmap(unsigned int num_ld_hashes, WORD *uncracked_hashes_t, 
 		}
 		if (buf_sz >= 536870912)
 			buf_sz = 536870912;
-		assert(!(buf_sz & (buf_sz - 1)));
 		if (((*bitmap_size_bits) >> 3) > buf_sz)
 			*bitmap_size_bits = buf_sz << 3;
-		assert(!((*bitmap_size_bits) & ((*bitmap_size_bits) - 1)));
 	}
 
 	prepare_bitmap_1(*bitmap_size_bits, bitmaps_ptr, (unsigned WORD *)uncracked_hashes_t, num_ld_hashes);
 
-	assert(!((*bitmap_size_bits) & ((*bitmap_size_bits) - 1)));
-	assert(*bitmap_size_bits <= 0xffffffff);
 	get_num_bits(bits_req, (*bitmap_size_bits));
 
 	hash_chk_params->bitmap_size_bits = (unsigned int)(*bitmap_size_bits);

--- a/src/opencl_DES_bs_plug.c
+++ b/src/opencl_DES_bs_plug.c
@@ -178,9 +178,9 @@ static void select_bitmap(unsigned int num_ld_hashes, WORD *uncracked_hashes_t, 
 	assert(*bitmap_size_bits <= 0xffffffff);
 	get_num_bits(bits_req, (*bitmap_size_bits));
 
-	hash_chk_params -> bitmap_size_bits = (unsigned int)(*bitmap_size_bits);
-	hash_chk_params -> cmp_steps = cmp_steps;
-	hash_chk_params -> cmp_bits = bits_req;
+	hash_chk_params->bitmap_size_bits = (unsigned int)(*bitmap_size_bits);
+	hash_chk_params->cmp_steps = cmp_steps;
+	hash_chk_params->cmp_bits = bits_req;
 
 	*bitmap_size_bits *= cmp_steps;
 }
@@ -195,8 +195,8 @@ static void fill_buffer(struct db_salt *salt, unsigned int *max_uncracked_hashes
 	OFFSET_TABLE_WORD *offset_table;
 	unsigned int hash_table_size, offset_table_size;
 
-	salt_val = *(WORD *)salt -> salt;
-	num_uncracked_hashes(salt_val) = salt -> count;
+	salt_val = *(WORD *)salt->salt;
+	num_uncracked_hashes(salt_val) = salt->count;
 
 	uncracked_hashes = (WORD *) mem_calloc(2 * num_uncracked_hashes(salt_val), sizeof(WORD));
 	uncracked_hashes_t = (WORD *) mem_calloc(2 * num_uncracked_hashes(salt_val), sizeof(WORD));
@@ -218,8 +218,8 @@ static void fill_buffer(struct db_salt *salt, unsigned int *max_uncracked_hashes
 		}
 	} while ((pw = pw->next));
 
-	if (salt -> count > *max_uncracked_hashes)
-		*max_uncracked_hashes = salt -> count;
+	if (salt->count > *max_uncracked_hashes)
+		*max_uncracked_hashes = salt->count;
 
 	num_uncracked_hashes(salt_val) = create_perfect_hash_table(64, (void *)uncracked_hashes_t,
 				num_uncracked_hashes(salt_val),
@@ -418,10 +418,10 @@ void build_tables(struct db_main *db)
 	memset(hash_chk_params, 0, 4096 * sizeof(DES_hash_check_params));
 
 	if (db) {
-	struct db_salt *salt = db -> salts;
+	struct db_salt *salt = db->salts;
 	do {
 		fill_buffer(salt, &max_uncracked_hashes, &max_hash_table_size);
-	} while((salt = salt -> next));
+	} while((salt = salt->next));
 	}
 	else {
 		fill_buffer_self_test(&max_uncracked_hashes, &max_hash_table_size);
@@ -504,11 +504,11 @@ void set_common_kernel_args_kpc(cl_mem buffer_unchecked_hashes, cl_mem buffer_bs
 void update_buffer(struct db_salt *salt)
 {
 	unsigned int _max_uncracked_hashes = 0, _max_hash_table_size = 0;
-	WORD salt_val = *(WORD *)salt -> salt;
+	WORD salt_val = *(WORD *)salt->salt;
 	release_fill_buffer(salt_val);
 
-	if (salt -> count > LOW_THRESHOLD &&
-		(num_uncracked_hashes(salt_val) - num_uncracked_hashes(salt_val) / 10) < salt -> count)
+	if (salt->count > LOW_THRESHOLD &&
+		(num_uncracked_hashes(salt_val) - num_uncracked_hashes(salt_val) / 10) < salt->count)
 		return;
 
 	fill_buffer(salt, &_max_uncracked_hashes, &_max_hash_table_size);
@@ -1156,7 +1156,7 @@ size_t create_keys_kernel_set_args(int mask_mode)
 	des_finalize_int_keys();
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else

--- a/src/opencl_bf_fmt_plug.c
+++ b/src/opencl_bf_fmt_plug.c
@@ -103,7 +103,7 @@ static int get_hash_6(int index) {
 }
 
 static int salt_hash(void *salt) {
-	return ((BF_salt *)salt) -> salt[0] & 0x3FF ;
+	return ((BF_salt *)salt)->salt[0] & 0x3FF ;
 }
 
 static void set_salt(void *salt) {

--- a/src/opencl_bf_std_plug.c
+++ b/src/opencl_bf_std_plug.c
@@ -335,13 +335,13 @@ void opencl_BF_std_crypt(BF_salt *salt, int n)
 {
 	int 			index=0,j ;
 	static unsigned int 	salt_api[4] ;
-	unsigned int 		rounds = salt -> rounds ;
+	unsigned int 		rounds = salt->rounds ;
 	static unsigned int 	BF_out[2*BF_N] ;
 
-	salt_api[0] = salt -> salt[0] ;
-	salt_api[1] = salt -> salt[1] ;
-	salt_api[2] = salt -> salt[2] ;
-	salt_api[3] = salt -> salt[3] ;
+	salt_api[0] = salt->salt[0] ;
+	salt_api[1] = salt->salt[1] ;
+	salt_api[2] = salt->salt[2] ;
+	salt_api[3] = salt->salt[3] ;
 
 	exec_bf(salt_api, BF_out, rounds, n) ;
 

--- a/src/opencl_hash_check_128_plug.c
+++ b/src/opencl_hash_check_128_plug.c
@@ -1,7 +1,5 @@
 #if HAVE_OPENCL
 
-#include <assert.h>
-
 #include "options.h"
 #include "opencl_hash_check_128.h"
 #include "mask_ext.h"
@@ -306,10 +304,8 @@ char* ocl_hc_128_select_bitmap(unsigned int num_ld_hashes)
 		}
 		if (buf_sz >= 536870912)
 			buf_sz = 536870912;
-		assert(!(buf_sz & (buf_sz - 1)));
 		if ((bitmap_size_bits >> 3) > buf_sz)
 			bitmap_size_bits = buf_sz << 3;
-		assert(!(bitmap_size_bits & (bitmap_size_bits - 1)));
 		cmp_steps = 1;
 	}
 
@@ -352,7 +348,6 @@ void ocl_hc_128_crobj(cl_kernel kernel)
 		max_alloc_size_bytes >>= 1;
 	}
 	if (max_alloc_size_bytes >= 536870912) max_alloc_size_bytes = 536870912;
-	assert(!(max_alloc_size_bytes & (max_alloc_size_bytes - 1)));
 
 	if (!cache_size_bytes) cache_size_bytes = 1024;
 

--- a/src/opencl_krb5pa-md5_fmt_plug.c
+++ b/src/opencl_krb5pa-md5_fmt_plug.c
@@ -32,7 +32,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 
 #include "misc.h"
 #include "common.h"
@@ -708,7 +707,11 @@ static void select_bitmap(unsigned int num_loaded_hashes)
 		else
 			bitmap_size_bits = 2048 * 1024;
 	}
-	assert(num_loaded_hashes <= 1100100);
+	else {
+		fprintf(stderr, "Too many hashes (%d), max is 1100100\n",
+		        num_loaded_hashes);
+		error();
+	}
 
 	prepare_bitmap_4(bitmap_size_bits, &bitmaps, num_loaded_hashes);
 }

--- a/src/opencl_lm_b_plug.c
+++ b/src/opencl_lm_b_plug.c
@@ -7,7 +7,6 @@
 
 #if HAVE_OPENCL
 
-#include <assert.h>
 #include <string.h>
 #include <sys/time.h>
 
@@ -629,9 +628,6 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 		gws_limit >>= 1;
 #endif
 
-	assert(gws_limit > PADDING);
-	assert(!(gws_limit & (gws_limit - 1)));
-
 	if (gws_tune_flag)
 		global_work_size = gws_init;
 
@@ -672,7 +668,7 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 	set_kernel_args_gws();
 
 	/* for hash_ids[3*x + 1], 27 bits for storing gid and 5 bits for bs depth. */
-	assert(global_work_size <= ((1U << 28) - 1));
+	//assert(global_work_size <= ((1U << 28) - 1));
 	fmt_opencl_lm.params.max_keys_per_crypt = global_work_size << lm_log_depth;
 	fmt_opencl_lm.params.min_keys_per_crypt = 1U << lm_log_depth;
 }
@@ -770,8 +766,6 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 		}
 		if (local_work_size > lws_limit)
 			local_work_size = lws_limit;
-
-		assert(local_work_size <= lws_limit);
 
 		if (lws_tune_flag) {
 			time_ms = 0;
@@ -1016,10 +1010,8 @@ static char* select_bitmap(unsigned int num_ld_hashes, int *loaded_hashes, unsig
 		}
 		if (buf_sz >= 536870912)
 			buf_sz = 536870912;
-		assert(!(buf_sz & (buf_sz - 1)));
 		if (((*bitmap_size_bits) >> 3) > buf_sz)
 			*bitmap_size_bits = buf_sz << 3;
-		assert(!((*bitmap_size_bits) & ((*bitmap_size_bits) - 1)));
 		cmp_steps = 1;
 	}
 
@@ -1029,7 +1021,6 @@ static char* select_bitmap(unsigned int num_ld_hashes, int *loaded_hashes, unsig
 	else
 		prepare_bitmap_2(*bitmap_size_bits, bitmaps_ptr, loaded_hashes);
 
-	assert(!((*bitmap_size_bits) & ((*bitmap_size_bits) - 1)));
 	get_num_bits(bits_req, (*bitmap_size_bits));
 
 	sprintf(kernel_params,
@@ -1259,7 +1250,6 @@ static int lm_crypt(int *pcount, struct db_salt *salt)
 		MEM_FREE(bitmaps);
 	}
 
-	assert(current_gws <= global_work_size + PADDING);
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_raw_keys, CL_FALSE, 0, current_gws * sizeof(opencl_lm_transfer), opencl_lm_keys, 0, NULL, NULL ), "Failed Copy data to gpu");
 
 	if (!mask_gpu_is_static)

--- a/src/opencl_lm_b_plug.c
+++ b/src/opencl_lm_b_plug.c
@@ -350,14 +350,12 @@ static void create_buffer(unsigned int num_loaded_hashes, OFFSET_TABLE_WORD *off
 
 	opencl_lm_init_index();
 
-	active_placeholders = 0;
+	active_placeholders = 1;
 	if (mask_skip_ranges)
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++) {
 		if (mask_skip_ranges[i] != -1)
 			active_placeholders++;
 	}
-	else
-		active_placeholders = 1;
 
 	buffer_lm_key_idx = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, 768 * sizeof(unsigned int), opencl_lm_index768, &ret_code);
 	HANDLE_CLERROR(ret_code, "Failed creating buffer_lm_key_idx.");
@@ -437,7 +435,7 @@ static void init_kernels(char *bitmap_params, unsigned int full_unroll, size_t s
 	unsigned int i;
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -606,7 +604,7 @@ static size_t find_smem_lws_limit(unsigned int full_unroll, unsigned int use_loc
 			(long double)(end.tv_usec - start.tv_usec) / 1000.000)
 
 /* Sets global_work_size and max_keys_per_crypt. */
-static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_flag, void (*set_key)(char *, int), int mask_mode)
+static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_flag, struct fmt_main *format, int mask_mode)
 {
 	unsigned int i;
 	char key[PLAINTEXT_LENGTH + 1] = "alterit";
@@ -645,10 +643,11 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 		create_buffer_gws(global_work_size);
 		set_kernel_args_gws();
 
+		format->methods.clear_keys();
 		for (i = 0; i < (global_work_size << lm_log_depth); i++) {
 			key[i & 3] = i & 255;
 			key[(i & 3) + 3] = i ^ 0x3E;
-			set_key(key, i);
+			format->methods.set_key(key, i);
 		}
 
 		gettimeofday(&startc, NULL);
@@ -678,7 +677,7 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 	fmt_opencl_lm.params.min_keys_per_crypt = 1U << lm_log_depth;
 }
 
-static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, long double kernel_run_ms, void (*set_key)(char *, int), int mask_mode)
+static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, long double kernel_run_ms, struct fmt_main *format, int mask_mode)
 {
 	unsigned int full_unroll = 0;
 	unsigned int use_local_mem = 1;
@@ -740,10 +739,11 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 	s_mem_limited_lws = find_smem_lws_limit(
 			full_unroll, use_local_mem, force_global_keys);
 #if 0
-	fprintf(stdout, "Limit_smem:"Zu", Full_unroll_flag:%u,"
+	fprintf(stdout, "%s() Limit_smem:"Zu", Full_unroll_flag:%u,"
 		"Use_local_mem:%u, Force_global_keys:%u\n",
-		s_mem_limited_lws, full_unroll, use_local_mem,
-		force_global_keys);
+	        __FUNCTION__,
+	        s_mem_limited_lws, full_unroll, use_local_mem,
+	        force_global_keys);
 #endif
 
 	if (s_mem_limited_lws == 0x800000 || !s_mem_limited_lws) {
@@ -754,8 +754,8 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 		init_kernels(bitmap_params, full_unroll, 0, use_local_mem && s_mem_limited_lws, 0);
 		set_kernel_args();
 
-		gws_tune(1024, 2 * kernel_run_ms, gws_tune_flag, set_key, mask_mode);
-		gws_tune(global_work_size, kernel_run_ms, gws_tune_flag, set_key, mask_mode);
+		gws_tune(1024, 2 * kernel_run_ms, gws_tune_flag, format, mask_mode);
+		gws_tune(global_work_size, kernel_run_ms, gws_tune_flag, format, mask_mode);
 
 		lws_limit = get_kernel_max_lws(gpu_id, crypt_kernel);
 
@@ -780,10 +780,11 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 			while (local_work_size <= lws_limit &&
 				local_work_size <= PADDING) {
 				int pcount, i;
+				format->methods.clear_keys();
 				for (i = 0; i < (global_work_size << lm_log_depth); i++) {
 					key[i & 3] = i & 255;
 					key[(i & 3) + 3] = i ^ 0x3F;
-					set_key(key, i);
+					format->methods.set_key(key, i);
 				}
 				gettimeofday(&startc, NULL);
 				pcount = (int)(global_work_size << lm_log_depth);
@@ -806,7 +807,7 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 				local_work_size *= 2;
 			}
 			local_work_size = best_lws;
-			gws_tune(global_work_size, kernel_run_ms, gws_tune_flag, set_key, mask_mode);
+			gws_tune(global_work_size, kernel_run_ms, gws_tune_flag, format, mask_mode);
 		}
 	}
 
@@ -844,8 +845,8 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 		}
 
 		set_kernel_args();
-		gws_tune(1024, 2 * kernel_run_ms, gws_tune_flag, set_key, mask_mode);
-		gws_tune(global_work_size, kernel_run_ms, gws_tune_flag, set_key, mask_mode);
+		gws_tune(1024, 2 * kernel_run_ms, gws_tune_flag, format, mask_mode);
+		gws_tune(global_work_size, kernel_run_ms, gws_tune_flag, format, mask_mode);
 
 		if (global_work_size < s_mem_limited_lws) {
 			s_mem_limited_lws = global_work_size;
@@ -859,15 +860,17 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 			while (local_work_size <= s_mem_limited_lws &&
 				local_work_size <= PADDING) {
 				int pcount, i;
+
 				release_kernels();
 				init_kernels(bitmap_params, full_unroll, local_work_size, use_local_mem, 0);
 				set_kernel_args();
 				set_kernel_args_gws();
 
+				format->methods.clear_keys();
 				for (i = 0; i < (global_work_size << lm_log_depth); i++) {
 					key[i & 3] = i & 255;
 					key[(i & 3) + 3] = i ^ 0x3E;
-					set_key(key, i);
+					format->methods.set_key(key, i);
 				}
 
 				gettimeofday(&startc, NULL);
@@ -910,7 +913,7 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 			release_kernels();
 			init_kernels(bitmap_params, full_unroll, local_work_size, use_local_mem, 0);
 			set_kernel_args();
-			gws_tune(global_work_size, kernel_run_ms, gws_tune_flag, set_key, mask_mode);
+			gws_tune(global_work_size, kernel_run_ms, gws_tune_flag, format, mask_mode);
 		}
 	}
 	if (options.verbosity > VERB_LEGACY)
@@ -1091,6 +1094,11 @@ static char* prepare_table(struct db_salt *salt, OFFSET_TABLE_WORD **offset_tabl
 	return bitmap_params;
 }
 
+static char *get_key(int index)
+{
+      get_key_body();
+}
+
 static char *get_key_mm(int index)
 {
 	static char out[PLAINTEXT_LENGTH + 1];
@@ -1138,9 +1146,7 @@ static char *get_key_mm(int index)
 
 static void reset(struct db_main *db)
 {
-	static int initialized;
-
-	if (initialized) {
+	if (db->real && db == db->real) {
 		struct db_salt *salt;
 		unsigned int *bitmaps = NULL;
 		OFFSET_TABLE_WORD *offset_table = NULL;
@@ -1162,7 +1168,7 @@ static void reset(struct db_main *db)
 			fmt_opencl_lm.methods.get_key = get_key_mm;
 		}
 
-		auto_tune_all(bitmap_params, num_loaded_hashes, 300, fmt_opencl_lm.methods.set_key, mask_mode);
+		auto_tune_all(bitmap_params, num_loaded_hashes, 100, &fmt_opencl_lm, mask_mode);
 		MEM_FREE(offset_table);
 		MEM_FREE(bitmaps);
 	}
@@ -1206,13 +1212,12 @@ static void reset(struct db_main *db)
 		}
 		bitmap_params = select_bitmap(num_loaded_hashes, loaded_hashes, &bitmap_size_bits, &bitmaps);
 		create_buffer(num_loaded_hashes, offset_table, offset_table_size, hash_table_size, bitmaps, bitmap_size_bits);
-		auto_tune_all(bitmap_params, num_loaded_hashes, 300, opencl_lm_set_key, 0);
+		auto_tune_all(bitmap_params, num_loaded_hashes, 100, &fmt_opencl_lm, 0);
 
 		MEM_FREE(offset_table);
 		MEM_FREE(bitmaps);
 		MEM_FREE(loaded_hashes);
 		hash_ids[0] = 0;
-		initialized++;
 	}
 }
 
@@ -1221,20 +1226,15 @@ static void init_global_variables()
 	mask_int_cand_target = opencl_speed_index(gpu_id) / 300;
 }
 
-static char *get_key(int index)
-{
-      get_key_body();
-}
-
 static int lm_crypt(int *pcount, struct db_salt *salt)
 {
-	cl_event evnt;
-	const int count = mask_mode ? *pcount : (*pcount + LM_DEPTH - 1) >> LM_LOG_DEPTH;
+	const int count = mask_mode ?
+		*pcount : (*pcount + LM_DEPTH - 1) >> LM_LOG_DEPTH;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 	current_gws = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
 
 #if 0
-	fprintf(stderr, "pcount %d count %d lws "Zu" gws "Zu" cur_gws "Zu"\n", *pcount, count, local_work_size, global_work_size, current_gws);
+	fprintf(stderr, "pcount %d count %d lws "Zu" gws "Zu" cur_gws "Zu" static: %d\n", *pcount, count, local_work_size, global_work_size, current_gws, mask_gpu_is_static);
 #endif
 	if (salt != NULL && salt->count > 4500 &&
 		(num_loaded_hashes - num_loaded_hashes / 10) > salt->count) {
@@ -1260,16 +1260,15 @@ static int lm_crypt(int *pcount, struct db_salt *salt)
 	}
 
 	assert(current_gws <= global_work_size + PADDING);
-	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_raw_keys, CL_TRUE, 0, current_gws * sizeof(opencl_lm_transfer), opencl_lm_keys, 0, NULL, NULL ), "Failed Copy data to gpu");
+	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_raw_keys, CL_FALSE, 0, current_gws * sizeof(opencl_lm_transfer), opencl_lm_keys, 0, NULL, NULL ), "Failed Copy data to gpu");
 
 	if (!mask_gpu_is_static)
-		HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_TRUE, 0, current_gws * sizeof(unsigned int), opencl_lm_int_key_loc, 0, NULL, NULL ), "Failed Copy data to gpu");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_FALSE, 0, current_gws * sizeof(unsigned int), opencl_lm_int_key_loc, 0, NULL, NULL ), "Failed Copy data to gpu");
 
-	HANDLE_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &current_gws, lws, 0, NULL, &evnt), "Failed enqueue kernel lm_bs_*.");
-	clWaitForEvents(1, &evnt);
-	clReleaseEvent(evnt);
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &current_gws, lws, 0, NULL, NULL), "Failed enqueue kernel lm_bs_*.");
+	BENCH_CLERROR(clFinish(queue[gpu_id]), "Kernel failed");
 
-	HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, sizeof(unsigned int), hash_ids, 0, NULL, NULL), "Write FAILED\n");
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, sizeof(unsigned int), hash_ids, 0, NULL, NULL), "Read FAILED\n");
 
 	if (hash_ids[0] > num_loaded_hashes) {
 		fprintf(stderr, "Error, crypt_all kernel.\n");
@@ -1277,9 +1276,9 @@ static int lm_crypt(int *pcount, struct db_salt *salt)
 	}
 
 	if (hash_ids[0]) {
-		HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, (3 * hash_ids[0] + 1) * sizeof(unsigned int), hash_ids, 0, NULL, NULL), "Write FAILED\n");
-		HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_bitmap_dupe, CL_TRUE, 0, ((hash_table_size - 1)/32 + 1) * sizeof(cl_uint), zero_buffer, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_bitmap_dupe.");
-		HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, sizeof(cl_uint), zero_buffer, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_hash_ids.");
+		BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, (3 * hash_ids[0] + 1) * sizeof(unsigned int), hash_ids, 0, NULL, NULL), "Read FAILED\n");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_bitmap_dupe, CL_TRUE, 0, ((hash_table_size - 1)/32 + 1) * sizeof(cl_uint), zero_buffer, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_bitmap_dupe.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, sizeof(cl_uint), zero_buffer, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_hash_ids.");
 	}
 
 	*pcount *= mask_int_cand.num_int_cand;

--- a/src/opencl_mscash2_fmt_plug.c
+++ b/src/opencl_mscash2_fmt_plug.c
@@ -95,13 +95,13 @@ static void reset(struct db_main *db)
 			self->params.max_keys_per_crypt += selectDevice(gpu_device_list[i], self);
 
 		///Allocate memory
-		key_host = mem_calloc(self -> params.max_keys_per_crypt, sizeof(*key_host));
-		dcc_hash_host = (cl_uint*)mem_alloc(4 * sizeof(cl_uint) * self -> params.max_keys_per_crypt);
-		dcc2_hash_host = (cl_uint*)mem_alloc(4 * sizeof(cl_uint) * self -> params.max_keys_per_crypt);
-		hmac_sha1_out  = (cl_uint*)mem_alloc(5 * sizeof(cl_uint) * self -> params.max_keys_per_crypt);
+		key_host = mem_calloc(self->params.max_keys_per_crypt, sizeof(*key_host));
+		dcc_hash_host = (cl_uint*)mem_alloc(4 * sizeof(cl_uint) * self->params.max_keys_per_crypt);
+		dcc2_hash_host = (cl_uint*)mem_alloc(4 * sizeof(cl_uint) * self->params.max_keys_per_crypt);
+		hmac_sha1_out  = (cl_uint*)mem_alloc(5 * sizeof(cl_uint) * self->params.max_keys_per_crypt);
 
-		memset(dcc_hash_host, 0, 4 * sizeof(cl_uint) * self -> params.max_keys_per_crypt);
-		memset(dcc2_hash_host, 0, 4 * sizeof(cl_uint) * self -> params.max_keys_per_crypt);
+		memset(dcc_hash_host, 0, 4 * sizeof(cl_uint) * self->params.max_keys_per_crypt);
+		memset(dcc2_hash_host, 0, 4 * sizeof(cl_uint) * self->params.max_keys_per_crypt);
 
 		initialized++;
 	}

--- a/src/opencl_mscash2_helper_plug.c
+++ b/src/opencl_mscash2_helper_plug.c
@@ -7,7 +7,6 @@
 #ifdef HAVE_OPENCL
 
 #include <sys/time.h>
-#include <assert.h>
 
 #include "opencl_mscash2_helper_plug.h"
 #include "options.h"
@@ -239,7 +238,6 @@ static size_t autoTune(int jtrUniqDevId, long double kernelRunMs)
 			lwsLimit = 8;
 		if (lwsInit > 8)
 			lwsInit = 8;
-		assert(lwsInit <= lwsLimit);
 	}
 
 	if (gwsInit > gwsLimit)
@@ -433,13 +431,6 @@ static size_t autoTune(int jtrUniqDevId, long double kernelRunMs)
 		createDevObjGws(devParam[jtrUniqDevId].devGws, jtrUniqDevId);
 	}
 
-	assert(!(devParam[jtrUniqDevId].devLws & (devParam[jtrUniqDevId].devLws -1)));
-	assert(!(gwsRound & (devParam[jtrUniqDevId].devLws - 1)));
-	assert(!(devParam[jtrUniqDevId].devGws % gwsRound));
-	assert(devParam[jtrUniqDevId].devLws <= lwsLimit);
-	assert(devParam[jtrUniqDevId].devGws <= gwsLimit);
-	assert(devParam[jtrUniqDevId].devLws <= PADDING);
-
 	if (options.verbosity > VERB_LEGACY)
 	fprintf(stdout, "Device %d  GWS: "Zu", LWS: "Zu"\n", jtrUniqDevId,
 			devParam[jtrUniqDevId].devGws, devParam[jtrUniqDevId].devLws);
@@ -451,8 +442,6 @@ static size_t autoTune(int jtrUniqDevId, long double kernelRunMs)
 size_t selectDevice(int jtrUniqDevId, struct fmt_main *self)
 {
 	char buildOpts[300];
-
-	assert(jtrUniqDevId < MAX_GPU_DEVICES);
 
 	sprintf(buildOpts, "-D SALT_BUFFER_SIZE=" Zu, SALT_BUFFER_SIZE);
 	opencl_init("$JOHN/kernels/pbkdf2_kernel.cl", jtrUniqDevId, buildOpts);

--- a/src/opencl_mscash_fmt_plug.c
+++ b/src/opencl_mscash_fmt_plug.c
@@ -16,7 +16,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #include "arch.h"
@@ -529,7 +528,11 @@ static void select_bitmap(unsigned int num_loaded_hashes)
 		else
 			bitmap_size_bits = 2048 * 1024;
 	}
-	assert(num_loaded_hashes <= 1100100);
+	else {
+		fprintf(stderr, "Too many hashes (%d), max is 1100100\n",
+		        num_loaded_hashes);
+		error();
+	}
 
 	prepare_bitmap_4(bitmap_size_bits, &bitmaps, num_loaded_hashes);
 }

--- a/src/opencl_mscash_fmt_plug.c
+++ b/src/opencl_mscash_fmt_plug.c
@@ -266,7 +266,7 @@ static void init_kernel(void)
 	clReleaseKernel(crypt_kernel);
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -432,7 +432,7 @@ static char *get_key(int index)
 		out[i] = *key++;
 	out[i] = 0;
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				out[static_gpu_locations[i]] =
@@ -537,6 +537,7 @@ static void select_bitmap(unsigned int num_loaded_hashes)
 static void prepare_table(struct db_main *db)
 {
 	struct db_salt *salt;
+	int seq_ids = 0;
 
 	max_num_loaded_hashes = 0;
 	max_hash_table_size = 1;
@@ -597,12 +598,13 @@ static void prepare_table(struct db_main *db)
 			error();
 		}
 		num_loaded_hashes = salt->count;
+		salt->sequential_id = seq_ids++;
 
-		num_loaded_hashes = create_perfect_hash_table(128, (void *)loaded_hashes,
-				num_loaded_hashes,
-			        &offset_table,
-			        &offset_table_size,
-			        &hash_table_size, 0);
+		num_loaded_hashes = create_perfect_hash_table(128, (void*)loaded_hashes,
+		                                              num_loaded_hashes,
+		                                              &offset_table,
+		                                              &offset_table_size,
+		                                              &hash_table_size, 0);
 
 		if (!num_loaded_hashes) {
 			MEM_FREE(hash_table_128);

--- a/src/opencl_mysqlsha1_fmt_plug.c
+++ b/src/opencl_mysqlsha1_fmt_plug.c
@@ -16,7 +16,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #include "arch.h"
@@ -160,7 +159,6 @@ static void create_clobj(void)
 		max_alloc_size_bytes >>= 1;
 	}
 	if (max_alloc_size_bytes >= 536870912) max_alloc_size_bytes = 536870912;
-	assert(!(max_alloc_size_bytes & (max_alloc_size_bytes - 1)));
 
 	if (!cache_size_bytes) cache_size_bytes = 1024;
 
@@ -679,10 +677,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		}
 		if (buf_sz >= 536870912)
 			buf_sz = 536870912;
-		assert(!(buf_sz & (buf_sz - 1)));
 		if ((bitmap_size_bits >> 3) > buf_sz)
 			bitmap_size_bits = buf_sz << 3;
-		assert(!(bitmap_size_bits & (bitmap_size_bits - 1)));
 		cmp_steps = 1;
 	}
 
@@ -972,11 +968,6 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 	}
 
 	clear_keys();
-
-	assert(!(local_work_size & (local_work_size -1)));
-	assert(!(global_work_size % local_work_size));
-	assert(local_work_size <= lws_limit);
-	assert(global_work_size <= gws_limit);
 
 	self->params.max_keys_per_crypt = global_work_size;
 	if (options.verbosity > VERB_LEGACY)

--- a/src/opencl_mysqlsha1_fmt_plug.c
+++ b/src/opencl_mysqlsha1_fmt_plug.c
@@ -270,7 +270,7 @@ static void init_kernel(unsigned int num_ld_hashes, char *bitmap_para)
 	shift128_ot_sz = shift128 % offset_table_size;
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -434,7 +434,7 @@ static char *get_key(int index)
 		out[i] = *key++;
 	out[i] = 0;
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				out[static_gpu_locations[i]] =
@@ -488,11 +488,11 @@ static void prepare_table(struct db_salt *salt) {
 		error();
 	}
 
-	num_loaded_hashes = create_perfect_hash_table(192, (void *)loaded_hashes,
-				num_loaded_hashes,
-			        &offset_table,
-			        &offset_table_size,
-			        &hash_table_size, 0);
+	num_loaded_hashes = create_perfect_hash_table(192, (void*)loaded_hashes,
+	                                              num_loaded_hashes,
+	                                              &offset_table,
+	                                              &offset_table_size,
+	                                              &hash_table_size, 0);
 
 	if (!num_loaded_hashes) {
 		MEM_FREE(hash_table_192);

--- a/src/opencl_nt_fmt_plug.c
+++ b/src/opencl_nt_fmt_plug.c
@@ -267,7 +267,7 @@ static void init_kernel(unsigned int num_ld_hashes, char *bitmap_para)
 	shift64_ot_sz = (((1ULL << 63) % offset_table_size) * 2) % offset_table_size;
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -510,7 +510,7 @@ static char *get_key(int index)
 		out[i] = *key++;
 	out[i] = 0;
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				out[static_gpu_locations[i]] =

--- a/src/opencl_ntlmv2_fmt_plug.c
+++ b/src/opencl_ntlmv2_fmt_plug.c
@@ -32,7 +32,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #include "arch.h"
@@ -749,7 +748,11 @@ static void select_bitmap(unsigned int num_loaded_hashes)
 		else
 			bitmap_size_bits = 2048 * 1024;
 	}
-	assert(num_loaded_hashes <= 1100100);
+	else {
+		fprintf(stderr, "Too many hashes (%d), max is 1100100\n",
+		        num_loaded_hashes);
+		error();
+	}
 
 	prepare_bitmap_4(bitmap_size_bits, &bitmaps, num_loaded_hashes);
 }

--- a/src/opencl_oldoffice_fmt_plug.c
+++ b/src/opencl_oldoffice_fmt_plug.c
@@ -248,7 +248,7 @@ static void reset(struct db_main *db)
 	}
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges != NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -634,7 +634,7 @@ static char *get_key(int index)
 	ret = utf16_to_enc(u16);
 
 	/* Apply GPU-side mask */
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				ret[static_gpu_locations[i]] =

--- a/src/opencl_rawmd4_fmt_plug.c
+++ b/src/opencl_rawmd4_fmt_plug.c
@@ -197,7 +197,7 @@ static void init_kernel(unsigned int num_ld_hashes, char *bitmap_para)
 	shift64_ot_sz = (((1ULL << 63) % offset_table_size) * 2) % offset_table_size;
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -362,7 +362,7 @@ static char *get_key(int index)
 		out[i] = *key++;
 	out[i] = 0;
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				out[static_gpu_locations[i]] =

--- a/src/opencl_rawmd4_fmt_plug.c
+++ b/src/opencl_rawmd4_fmt_plug.c
@@ -19,7 +19,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #include "arch.h"
@@ -565,11 +564,6 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 	}
 
 	clear_keys();
-
-	assert(!(local_work_size & (local_work_size -1)));
-	assert(!(global_work_size % local_work_size));
-	assert(local_work_size <= lws_limit);
-	assert(global_work_size <= gws_limit);
 
 	self->params.max_keys_per_crypt = global_work_size;
 	if (options.verbosity > VERB_LEGACY)

--- a/src/opencl_rawmd5_fmt_plug.c
+++ b/src/opencl_rawmd5_fmt_plug.c
@@ -19,7 +19,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #include "arch.h"
@@ -590,11 +589,6 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 	}
 
 	clear_keys();
-
-	assert(!(local_work_size & (local_work_size -1)));
-	assert(!(global_work_size % local_work_size));
-	assert(local_work_size <= lws_limit);
-	assert(global_work_size <= gws_limit);
 
 	self->params.max_keys_per_crypt = global_work_size;
 	if (options.verbosity > VERB_LEGACY)

--- a/src/opencl_rawmd5_fmt_plug.c
+++ b/src/opencl_rawmd5_fmt_plug.c
@@ -198,7 +198,7 @@ static void init_kernel(unsigned int num_ld_hashes, char *bitmap_para)
 	shift64_ot_sz = (((1ULL << 63) % offset_table_size) * 2) % offset_table_size;
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -387,7 +387,7 @@ static char *get_key(int index)
 		out[i] = *key++;
 	out[i] = 0;
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				out[static_gpu_locations[i]] =

--- a/src/opencl_rawsha1_fmt_plug.c
+++ b/src/opencl_rawsha1_fmt_plug.c
@@ -16,7 +16,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #include "arch.h"
@@ -139,7 +138,6 @@ static void create_clobj(void)
 		max_alloc_size_bytes >>= 1;
 	}
 	if (max_alloc_size_bytes >= 536870912) max_alloc_size_bytes = 536870912;
-	assert(!(max_alloc_size_bytes & (max_alloc_size_bytes - 1)));
 
 	if (!cache_size_bytes) cache_size_bytes = 1024;
 
@@ -631,10 +629,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		}
 		if (buf_sz >= 536870912)
 			buf_sz = 536870912;
-		assert(!(buf_sz & (buf_sz - 1)));
 		if ((bitmap_size_bits >> 3) > buf_sz)
 			bitmap_size_bits = buf_sz << 3;
-		assert(!(bitmap_size_bits & (bitmap_size_bits - 1)));
 		cmp_steps = 1;
 	}
 
@@ -924,11 +920,6 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 	}
 
 	clear_keys();
-
-	assert(!(local_work_size & (local_work_size -1)));
-	assert(!(global_work_size % local_work_size));
-	assert(local_work_size <= lws_limit);
-	assert(global_work_size <= gws_limit);
 
 	self->params.max_keys_per_crypt = global_work_size;
 	if (options.verbosity > VERB_LEGACY)

--- a/src/opencl_rawsha1_fmt_plug.c
+++ b/src/opencl_rawsha1_fmt_plug.c
@@ -249,7 +249,7 @@ static void init_kernel(unsigned int num_ld_hashes, char *bitmap_para)
 	shift128_ot_sz = shift128 % offset_table_size;
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -386,7 +386,7 @@ static char *get_key(int index)
 		out[i] = *key++;
 	out[i] = 0;
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				out[static_gpu_locations[i]] =

--- a/src/opencl_rawsha256_fmt_plug.c
+++ b/src/opencl_rawsha256_fmt_plug.c
@@ -466,8 +466,8 @@ static char *get_key(int index)
 	memcpy(ret, ((char *)&plaintext[saved_idx[t] >> 6]), PLAINTEXT_LENGTH);
 	ret[saved_idx[t] & 63] = '\0';
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
-
+	if (saved_idx[t] & 63 &&
+	    mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			ret[(saved_int_key_loc[t] & (0xff << (i * 8))) >> (i * 8)] =
 			    mask_int_cand.int_cand[int_index].x[i];

--- a/src/opencl_rawsha512_gpl_fmt_plug.c
+++ b/src/opencl_rawsha512_gpl_fmt_plug.c
@@ -377,7 +377,7 @@ static void tune(struct db_main *db)
 {
 	char *tmp_value;
 	size_t gws_limit;
-	unsigned long long autotune_limit = 500ULL;
+	unsigned long long autotune_limit = 100ULL;
 
 	if ((tmp_value = getenv("_GPU_AUTOTUNE_LIMIT")))
 		autotune_limit = (unsigned long long)atoll(tmp_value);
@@ -538,8 +538,8 @@ static char *get_key(int index)
 	memcpy(ret, ((char *)&plaintext[saved_idx[t] >> 6]), PLAINTEXT_LENGTH);
 	ret[saved_idx[t] & 63] = '\0';
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
-
+	if (saved_idx[t] & 63 &&
+	    mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			ret[(saved_int_key_loc[t] & (0xff << (i * 8))) >> (i * 8)] =
 			    mask_int_cand.int_cand[int_index].x[i];

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -16,7 +16,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #include "arch.h"
@@ -152,7 +151,6 @@ static void create_clobj(void)
 		max_alloc_size_bytes >>= 1;
 	}
 	if (max_alloc_size_bytes >= 536870912) max_alloc_size_bytes = 536870912;
-	assert(!(max_alloc_size_bytes & (max_alloc_size_bytes - 1)));
 
 	if (!cache_size_bytes) cache_size_bytes = 1024;
 
@@ -684,10 +682,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		}
 		if (buf_sz >= 536870912)
 			buf_sz = 536870912;
-		assert(!(buf_sz & (buf_sz - 1)));
 		if ((bitmap_size_bits >> 3) > buf_sz)
 			bitmap_size_bits = buf_sz << 3;
-		assert(!(bitmap_size_bits & (bitmap_size_bits - 1)));
 		cmp_steps = 1;
 	}
 
@@ -948,11 +944,6 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 	}
 
 	clear_keys();
-
-	assert(!(local_work_size & (local_work_size -1)));
-	assert(!(global_work_size % local_work_size));
-	assert(local_work_size <= lws_limit);
-	assert(global_work_size <= gws_limit);
 
 	self->params.max_keys_per_crypt = global_work_size;
 	if (options.verbosity > VERB_LEGACY)

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -266,7 +266,7 @@ static void init_kernel(unsigned int num_ld_hashes, char *bitmap_para)
 	shift128_ot_sz = shift128 % offset_table_size;
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -435,7 +435,7 @@ static char *get_key(int index)
 		out[i] = *key++;
 	out[i] = 0;
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				out[static_gpu_locations[i]] =

--- a/src/opencl_sl3_fmt_plug.c
+++ b/src/opencl_sl3_fmt_plug.c
@@ -22,7 +22,6 @@ john_register_one(&FMT_STRUCT);
 #else
 
 #include <string.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #include "arch.h"
@@ -134,8 +133,6 @@ static void create_clobj(void)
 		max_alloc_size_bytes >>= 1;
 	}
 	if (max_alloc_size_bytes >= 536870912) max_alloc_size_bytes = 536870912;
-	assert(!(max_alloc_size_bytes & (max_alloc_size_bytes - 1)));
-
 	if (!cache_size_bytes) cache_size_bytes = 1024;
 
 	zero_buffer = (cl_uint*)mem_calloc(hash_table_size/32 + 1, sizeof(cl_uint));
@@ -641,10 +638,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		}
 		if (buf_sz >= 536870912)
 			buf_sz = 536870912;
-		assert(!(buf_sz & (buf_sz - 1)));
 		if ((bitmap_size_bits >> 3) > buf_sz)
 			bitmap_size_bits = buf_sz << 3;
-		assert(!(bitmap_size_bits & (bitmap_size_bits - 1)));
 		cmp_steps = 1;
 	}
 
@@ -898,11 +893,6 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 	}
 
 	clear_keys();
-
-	assert(!(local_work_size & (local_work_size -1)));
-	assert(!(global_work_size % local_work_size));
-	assert(local_work_size <= lws_limit);
-	assert(global_work_size <= gws_limit);
 
 	self->params.max_keys_per_crypt = global_work_size;
 	if (options.verbosity > VERB_LEGACY)

--- a/src/opencl_sl3_fmt_plug.c
+++ b/src/opencl_sl3_fmt_plug.c
@@ -243,7 +243,7 @@ static void init_kernel(unsigned int num_ld_hashes, char *bitmap_para)
 	shift128_ot_sz = shift128 % offset_table_size;
 
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else
@@ -392,7 +392,7 @@ static char *get_key(int index)
 		out[i] = *key++;
 	out[i] = 0;
 
-	if (mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
 		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
 			if (mask_gpu_is_static)
 				out[static_gpu_locations[i]] =

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -81,7 +81,7 @@ static void (*rec_save_mode)(FILE *file);
 static void (*rec_save_mode2)(FILE *file);
 static void (*rec_save_mode3)(FILE *file);
 
-extern int cracker_max_keys_per_crypt();
+extern int crk_max_keys_per_crypt();
 
 static void rec_name_complete(void)
 {
@@ -282,7 +282,7 @@ static void save_salt_state()
 	// then we end up skipping processing some data. So we save this value, and then
 	// when we resume IF this value is not the same, we ignore the salt resume, and just
 	// start from salt zero.
-	fprintf(rec_file, "%d\n", cracker_max_keys_per_crypt());
+	fprintf(rec_file, "%d\n", crk_max_keys_per_crypt());
 }
 
 void rec_save(void)
@@ -634,18 +634,17 @@ static void restore_salt_state(int type)
 		// still have exactly same count of max_crypts_per  If the max
 		// changes, then we simply start over at salt#1 to avoid any
 		// salt records NOT being processed. properly.
-		status.resume_salt_crypts_per = strtoul(buf2, NULL, 10);
+		status.resume_salt = strtoul(buf2, NULL, 10);
 	} else if (type == 1) {
 		// tells cracker to ignore the check, since this information was not
 		// available in v1 slt records. v1 salt will NOT resume in cracker.c
-		status.resume_salt_crypts_per = -1;
+		status.resume_salt = 0;
 	}
 	for (i = 0; i < 16; ++i) {
 		h[i] = atoi16[ARCH_INDEX(buf[i*2])] << 4;
 		h[i] += atoi16[ARCH_INDEX(buf[i*2+1])];
 	}
 	status.resume_salt_md5 = hash;
-	status.resume_salt = 1;
 }
 
 void rec_restore_mode(int (*restore_mode)(FILE *file))

--- a/src/status.c
+++ b/src/status.c
@@ -65,7 +65,6 @@ static clock_t get_time(void)
 void status_init(double (*get_progress)(void), int start)
 {
 	if (start) {
-		status.resume_salt = 0;
 		if (!status_restored_time)
 			memset(&status, 0, sizeof(status));
 		status.start_time = get_time();

--- a/src/status.h
+++ b/src/status.h
@@ -42,7 +42,6 @@ struct status_main {
 	int progress;
 	int resume_salt;
 	uint32_t *resume_salt_md5;
-	int resume_salt_crypts_per;
 };
 
 extern struct status_main status;

--- a/src/ztex/jtr_mask.c
+++ b/src/ztex/jtr_mask.c
@@ -28,7 +28,7 @@ static int static_gpu_locations[MASK_FMT_INT_PLHDR];
 	//
 	int i;
 	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
-		if (mask_skip_ranges!= NULL && mask_skip_ranges[i] != -1)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
 			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
 				ranges[mask_skip_ranges[i]].pos;
 		else


### PR DESCRIPTION
Executive summary:
- Mask stretching can now stretch a mask starting with a range, not only ones ending with one. For example, you always could `-mask=admin?d -min-len=6` but now you can also do `-mask=?dadmin -min-len=6`. There's a pending change that will also stretch a mask like `FOO?dBAR` into `FOO?d?dBAR`, `FOO?d?d?dBAR` and so on but that's not included here.
- Any incremental (iterated length) mask with GPU-internal-mask formats is now supported, even from length 0. This means we'll have to call `reset()` between lengths and that takes a while (new auto-tune) but it sure is faster than not handling it at all.
- Many other bug fixes, tweaks and enhancements.

Two formats are yet to handle all of the above, namely `LM-opencl` and `DEScrypt-opencl`.  I worked like a galley slave with this for more than two (three?) weeks but they didn't make it yet. They will however cope a whole lot better now, adapting and warn when things are not 100% what you may have asked for. I intend to fix them as well, sooner or later.