### PR TITLE
Add a cracking rule that converts words in t9

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -745,6 +745,9 @@ l Az"[1-90][0-9][0-9]" <+
 -c (?a c Az"[1-90][0-9][0-9]" <+
 <[\-9] l A\p[z0]"[a-z][a-z]"
 <- l ^[a-z] $[a-z]
+# T9 text
+l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D*
+l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D#
 
 # Wordlist mode rules
 [List.Rules:Wordlist]

--- a/run/john.conf
+++ b/run/john.conf
@@ -866,8 +866,8 @@ o[0-9A-E][ -~] Q M o[0-9A-E][ -~] Q
 i[0-9A-E][ -~] i[0-9A-E][ -~]
 
 [List.Rules:T9]
-l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D*
-l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D#
+/?D l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D*
+/?D l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 /?D s?D#
 
 # Default Loopback mode rules.
 [List.Rules:Loopback]
@@ -904,6 +904,7 @@ l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st
 .include [List.Rules:Jumbo]
 .include [List.Rules:best64]
 .include [List.Rules:KoreLogic]
+.include [List.Rules:T9]
 
 # Incremental modes
 

--- a/run/john.conf
+++ b/run/john.conf
@@ -745,9 +745,6 @@ l Az"[1-90][0-9][0-9]" <+
 -c (?a c Az"[1-90][0-9][0-9]" <+
 <[\-9] l A\p[z0]"[a-z][a-z]"
 <- l ^[a-z] $[a-z]
-# T9 text
-l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D*
-l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D#
 
 # Wordlist mode rules
 [List.Rules:Wordlist]
@@ -867,6 +864,10 @@ o[0-9A-Z][ -~]
 i[0-9A-Z][ -~]
 o[0-9A-E][ -~] Q M o[0-9A-E][ -~] Q
 i[0-9A-E][ -~] i[0-9A-E][ -~]
+
+[List.Rules:T9]
+l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D*
+l sa2 sb2 sc2 sd3 se3 sf3 sg4 sh4 si4 sj5 sk5 sl5 sm6 sn6 so6 sp7 sq7 sr7 ss7 st8 su8 sv8 sw9 sx9 sy9 sz9 s?D#
 
 # Default Loopback mode rules.
 [List.Rules:Loopback]


### PR DESCRIPTION
Following the comment from some company claiming they can get passwords
typed from a phone call via T9.

There was a discovery that Fidelity investment was doing that kind of password conversion to be able to get passwords typed by phone.

I've successfully run this rule against Troy Hunt pwned password lists and found a few hundreds.

I think List.Rules:Extra is a good place don't hesitate to tell me if there's a better one.