### PR TITLE
Add support for cracking Adobe AEM hashes

### DIFF
--- a/run/aem2john.py
+++ b/run/aem2john.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# JtR utility to convert native Adobe AEM (Adobe Experience Manager) hashes to
+# an existing JtR hash format.
+
+# This software is Copyright (c) 2018, Dhiru Kholia <kholia at kth.se> and it
+# is hereby released to the general public under the following terms:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.
+#
+# See "generateHash" in PasswordUtil.java from the following project,
+# https://github.com/apache/jackrabbit-oak.
+
+
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if not PY3:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+
+# Input,
+#   {SHA-256}a9d4b340cb43807b-1000-33b8875ff3f9619e6ae984add262fb6b6f043e8ff9b065f4fb0863021aada275
+#   {SHA-256}fe90d85cdcd7e79c-1000-ef182cdc47e60b472784e42a6e167d26242648c6b2e063dfd9e27eec9aa38912
+#   {SHA-512}fe90d85cdcd7e79c-1000-4c29a0ac964e7bbc5380797f294d15928288cbcde3d501eb8746296de8d6c06b2b5ff27b56ae174744fe69ee157614ad126c1315ee3b67c891e42753e01a3e37
+#
+# Output,
+#   $sspr$3$1000$a9d4b340cb43807b$33b8875ff3f9619e6ae984add262fb6b6f043e8ff9b065f4fb0863021aada275
+#   $sspr$3$1000$fe90d85cdcd7e79c$ef182cdc47e60b472784e42a6e167d26242648c6b2e063dfd9e27eec9aa38912
+#   $sspr$4$1000$fe90d85cdcd7e79c$4c29a0ac964e7bbc5380797f294d15928288cbcde3d501eb8746296de8d6c06b2b5ff27b56ae174744fe69ee157614ad126c1315ee3b67c891e42753e01a3e37
+#
+# Passwords -> admin, Aa12345678!@
+
+tag = "{SHA-256}"
+tag_length = len(tag)
+
+def process_file(filename):
+    with open(filename, "r") as f:
+        for line in f.readlines():
+            line = line.rstrip()
+            algo = -1
+            if tag in line:
+                algo = 3  # SHA-256
+            elif "{SHA-512}" in line:
+                algo = 4  # SHA-512
+            else:
+                sys.stderr.write("[!] Unknown hash format -> %s\n" % line[0:8])
+                continue
+            line = line[tag_length:]
+            data = line.split('-')
+            try:
+                salt, iterations, h = data
+            except:
+                import traceback
+                traceback.print_exc()
+                continue
+
+            sys.stdout.write("$sspr$%s$%s$%s$%s\n" % (algo, iterations, salt, h))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: %s <File(s)-with-Adobe-AEM-hashes>\n" % sys.argv[0])
+        sys.exit(-1)
+
+    for i in range(1, len(sys.argv)):
+        process_file(sys.argv[i])

--- a/src/opencl_sspr_fmt_plug.c
+++ b/src/opencl_sspr_fmt_plug.c
@@ -369,6 +369,7 @@ struct fmt_main fmt_opencl_sspr = {
 		FMT_CASE | FMT_8_BIT,
 		{
 			"KDF [0:MD5 1:SHA1 2:SHA1_SALT 3:SHA256_SALT 4:SHA512_SALT]",
+			"iteration count",
 		},
 		{ FORMAT_TAG },
 		sspr_tests
@@ -384,6 +385,7 @@ struct fmt_main fmt_opencl_sspr = {
 		sspr_get_salt,
 		{
 			sspr_get_kdf_type,
+			sspr_get_iteration_count,
 		},
 		fmt_default_source,
 		{

--- a/src/sspr_common.h
+++ b/src/sspr_common.h
@@ -6,7 +6,7 @@
 
 #include "formats.h"
 
-#define FORMAT_NAME             "NetIQ SSPR"
+#define FORMAT_NAME             "NetIQ SSPR / Adobe AEM"
 #define FORMAT_TAG              "$sspr$"
 #define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
 #define BINARY_SIZE             64
@@ -25,3 +25,4 @@ extern int sspr_valid(char *ciphertext, struct fmt_main *self);
 extern void *sspr_get_salt(char *ciphertext);
 extern void *sspr_get_binary(char *ciphertext);
 extern unsigned int sspr_get_kdf_type(void *salt);
+extern unsigned int sspr_get_iteration_count(void *salt);

--- a/src/sspr_common_plug.c
+++ b/src/sspr_common_plug.c
@@ -9,6 +9,7 @@
 #include "memdbg.h"
 
 struct fmt_tests sspr_tests[] = {
+	// NetIQ SSPR hashes
 	{"$sspr$1$100000$NONE$64840051a425cbc0b4e2d3750d9e0de3e800de18", "password@12345"},
 	{"$sspr$1$100000$NONE$5cd2aeb3adf2baeca485672f01486775a208a40e", "openwall@12345"},
 	{"$sspr$2$100000$tMR6sNepv6M6nOqOy3SWnAUWo22p0GI7$f0ae3140ce2cf46c13d0b6c4bd4fab65b45b27c0", "openwall@123"},
@@ -20,6 +21,9 @@ struct fmt_tests sspr_tests[] = {
 	{"$sspr$0$100000$NONE$1e6172e71e6af1c15f4c5ca658815835", "abc@12345"},
 	{"$sspr$0$100000$NONE$1117af8ec9f70e8eed192c6c01776b6b", "abc@123"},
 	{"$sspr$2$100000$4YtbuUHaTSHBuE1licTV16KjSZuMMMCn$23b3cf4e1a951b2ed9d5df43632f77092fa93128", "\xe4""bc@123"},  // original password was "äbc@123", application uses a code page
+	// Adobe AEM hashes
+	{"$sspr$3$1000$a9d4b340cb43807b$33b8875ff3f9619e6ae984add262fb6b6f043e8ff9b065f4fb0863021aada275", "admin"},
+	{"$sspr$3$1000$fe90d85cdcd7e79c$ef182cdc47e60b472784e42a6e167d26242648c6b2e063dfd9e27eec9aa38912", "Aa12345678!@"},
 	{NULL}
 };
 
@@ -109,4 +113,11 @@ void *sspr_get_binary(char *ciphertext)
 unsigned int sspr_get_kdf_type(void *salt)
 {
 	return ((struct custom_salt *)salt)->fmt;
+}
+
+unsigned int sspr_get_iteration_count(void *salt)
+{
+	struct custom_salt *ctx = salt;
+
+	return (unsigned int) ctx->iterations;
 }

--- a/src/sspr_fmt_plug.c
+++ b/src/sspr_fmt_plug.c
@@ -190,6 +190,7 @@ struct fmt_main fmt_sspr = {
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
 		{
 			"KDF [0:MD5 1:SHA1 2:SHA1_SALT 3:SHA256_SALT 4:SHA512_SALT]",
+			"iteration count",
 		},
 		{ FORMAT_TAG },
 		sspr_tests
@@ -204,6 +205,7 @@ struct fmt_main fmt_sspr = {
 		sspr_get_salt,
 		{
 			sspr_get_kdf_type,
+			sspr_get_iteration_count,
 		},
 		fmt_default_source,
 		{


### PR DESCRIPTION
I can't benchmark the hash(es) with an iteration count of 1000.

```
✗ ../run/john --test --format=sspr --cost=3,1000 
Benchmarking: sspr, NetIQ SSPR / Adobe AEM [MD5/SHA1/SHA256/SHA512 32/64]... DONE
Speed for cost 1 (KDF [0:MD5 1:SHA1 2:SHA1_SALT 3:SHA256_SALT 4:SHA512_SALT]) of 3, cost 2 (iteration count) of 100000
Warning: "Many salts" test limited: 14/256
Many salts:	53.3 c/s real, 53.3 c/s virtual
Only one salt:	53.8 c/s real, 53.8 c/s virtual
```

Am I invoking the `--cost` parameter correctly?