### PR TITLE
docs: add guidelines for contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+## Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
+- If you have questions, please ask them first in the mailing list john-users at lists.openwall.com;
+- Use issues to keep track of ideas, enhancements, tasks, and bugs. NEVER as a support forum;
+
+## Bug Reports
+
+Try to be clear about your environment and what you are doing. If possible, share a sample hash or file that can be used to reproduce.


### PR DESCRIPTION
I'm not 100% sure, but it seems that if we add this file (its content can be improved, I know) the issue window will have a better/clearer header text.

