### PR TITLE
Use new scheme of LWS=NULL for less-than-full batches instead of rounding GWS up to LWS multiple.

### DIFF
--- a/src/opencl_geli_fmt_plug.c
+++ b/src/opencl_geli_fmt_plug.c
@@ -285,28 +285,27 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = (host_salt->pbkdf2.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = (host_salt->pbkdf2.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-				global_work_size * sizeof(pass_t), host_pass,
+				gws * sizeof(pass_t), host_pass,
 				0, NULL, multi_profilingEvent[0]),
 				"Copy data to gpu");
 
 	// Run standard PBKDF2 kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-				NULL, &global_work_size, lws, 0, NULL,
+				NULL, &gws, lws, 0, NULL,
 				multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 					split_kernel, 1, NULL,
-					&global_work_size, lws, 0, NULL,
+					&gws, lws, 0, NULL,
 					multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
@@ -314,12 +313,12 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	// Run GELI post-processing kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel, 1,
-				NULL, &global_work_size, lws, 0, NULL,
+				NULL, &gws, lws, 0, NULL,
 				multi_profilingEvent[3]), "Run kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
-				global_work_size * sizeof(out_t), host_crack,
+				gws * sizeof(out_t), host_crack,
 				0, NULL, multi_profilingEvent[4]), "Copy result back");
 
 	return count;

--- a/src/opencl_keystore_fmt_plug.c
+++ b/src/opencl_keystore_fmt_plug.c
@@ -310,7 +310,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
 	size_t gws = count;
-	size_t *lws = (local_work_size && !(gws % local_work_size)) ? &local_work_size : NULL;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	if (new_keys || ocl_autotune_running) {
 		if (key_idx)

--- a/src/opencl_keystore_fmt_plug.c
+++ b/src/opencl_keystore_fmt_plug.c
@@ -335,9 +335,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		sizeof(keystore_hash) * gws, outbuffer, 0, NULL,
 		multi_profilingEvent[3]), "Copy result back");
 
-	// Await completion of all the above
-	BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish error");
-
 	return count;
 }
 

--- a/src/opencl_krb5pa-md5_fmt_plug.c
+++ b/src/opencl_krb5pa-md5_fmt_plug.c
@@ -832,11 +832,9 @@ static void prepare_table(struct db_main *db)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-	size_t gws = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand %d\n", __FUNCTION__, count, local_work_size, gws, key_idx, mask_int_cand.num_int_cand);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	// copy keys to the device
 	if (set_new_keys || ocl_autotune_running) {

--- a/src/opencl_krb5pa-sha1_fmt_plug.c
+++ b/src/opencl_krb5pa-sha1_fmt_plug.c
@@ -526,7 +526,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	}
 
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], pa_sha1_final, 1, NULL, &scalar_gws, lws, 0, NULL, multi_profilingEvent[4]), "Run final kernel (SHA1)");
-	BENCH_CLERROR(clFinish(queue[gpu_id]), "Failed running final kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0, sizeof(krb5pa_out) * scalar_gws, output, 0, NULL, multi_profilingEvent[5]), "Copy result back");

--- a/src/opencl_lotus5_fmt_plug.c
+++ b/src/opencl_lotus5_fmt_plug.c
@@ -249,7 +249,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 					      crypt_kernel, 1,
 					      NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]),
 					      "Failed to enqueue kernel lotus5.");
-	BENCH_CLERROR(clFinish(queue[gpu_id]), "Shit hit fan");
 
 	mem_cpy_sz = count * BINARY_SIZE;
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id],

--- a/src/opencl_ntlmv2_fmt_plug.c
+++ b/src/opencl_ntlmv2_fmt_plug.c
@@ -588,7 +588,6 @@ static void *get_salt(char *ciphertext)
 static void clear_keys(void)
 {
 	key_idx = 0;
-	set_new_keys = 1;
 }
 
 static void set_key(char *_key, int index)
@@ -873,11 +872,9 @@ static void prepare_table(struct db_main *db)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-	size_t gws = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand %d\n", __FUNCTION__, count, local_work_size, gws, key_idx, mask_int_cand.num_int_cand);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	// copy keys to the device
 	if (set_new_keys || ocl_autotune_running) {

--- a/src/opencl_o5logon_fmt_plug.c
+++ b/src/opencl_o5logon_fmt_plug.c
@@ -269,12 +269,9 @@ static void set_salt(void *salt)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t gws;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	gws = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu"\n", __FUNCTION__, count, local_work_size, global_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	if (key_idx)
 		BENCH_CLERROR(

--- a/src/opencl_pgpdisk_fmt_plug.c
+++ b/src/opencl_pgpdisk_fmt_plug.c
@@ -253,37 +253,37 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+		sizeof(pgpdisk_password) * gws, inbuffer, 0, NULL,
+	    multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	if (cur_salt->algorithm == 3) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], cast_kernel, 1,
-			NULL, &global_work_size, lws, 0, NULL,
+			NULL, &gws, lws, 0, NULL,
 			multi_profilingEvent[1]),
 			"Run kernel");
 	} else if (cur_salt->algorithm == 4) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], twofish_kernel, 1,
-			NULL, &global_work_size, lws, 0, NULL,
+			NULL, &gws, lws, 0, NULL,
 			multi_profilingEvent[1]),
 			"Run kernel");
 	} else /* if (cur_salt->algorithm >= 5) */ {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], aes_kernel, 1,
-			NULL, &global_work_size, lws, 0, NULL,
+			NULL, &gws, lws, 0, NULL,
 			multi_profilingEvent[1]),
 			"Run kernel");
 	}
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
-		outsize, outbuffer, 0, NULL, multi_profilingEvent[2]),
-		"Copy result back");
+		sizeof(pgpdisk_hash) * gws, outbuffer, 0, NULL,
+	    multi_profilingEvent[2]), "Copy result back");
 
 	return count;
 }

--- a/src/opencl_pgpsda_fmt_plug.c
+++ b/src/opencl_pgpsda_fmt_plug.c
@@ -219,24 +219,24 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+		sizeof(pgpsda_password) * gws, inbuffer, 0, NULL,
+	    multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[1]),
 		"Run kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
-		outsize, outbuffer, 0, NULL, multi_profilingEvent[2]),
+		sizeof(pgpsda_hash) * gws, outbuffer, 0, NULL, multi_profilingEvent[2]),
 		"Copy result back");
 
 	return count;

--- a/src/opencl_pgpwde_fmt_plug.c
+++ b/src/opencl_pgpwde_fmt_plug.c
@@ -206,24 +206,24 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+		sizeof(pgpwde_password) * gws, inbuffer, 0, NULL,
+	    multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[1]),
 		"Run kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
-		outsize, outbuffer, 0, NULL, multi_profilingEvent[2]),
+		sizeof(pgpwde_hash) * gws, outbuffer, 0, NULL, multi_profilingEvent[2]),
 		"Copy result back");
 
 	return count;


### PR DESCRIPTION
See #3223.