### PR TITLE
Many OpenCL formats: Use new scheme of LWS=NULL

### DIFF
--- a/src/opencl/md4_kernel.cl
+++ b/src/opencl/md4_kernel.cl
@@ -295,9 +295,10 @@ __kernel void md4(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	/* We must allocate for the possibility of non-log2 LWS */
+	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 4) * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
+	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS + lws - 1) / lws); i++)
 		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
 
 	barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/opencl/md5_kernel.cl
+++ b/src/opencl/md5_kernel.cl
@@ -319,9 +319,10 @@ __kernel void md5(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	/* We must allocate for the possibility of non-log2 LWS */
+	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 4) * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
+	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS + lws - 1) / lws); i++)
 		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
 
 	barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/opencl/nt_kernel.cl
+++ b/src/opencl/nt_kernel.cl
@@ -381,10 +381,11 @@ __kernel void nt(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	/* We must allocate for the possibility of non-log2 LWS */
+	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 4) * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
-		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
+	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS + lws - 1) / lws); i++)
+		s_bitmaps[i * lws + lid] = bitmaps[i * lws + lid];
 
 	barrier(CLK_LOCAL_MEM_FENCE);
 #endif

--- a/src/opencl/salted_sha_kernel.cl
+++ b/src/opencl/salted_sha_kernel.cl
@@ -208,9 +208,10 @@ void sha1(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	/* We must allocate for the possibility of non-log2 LWS */
+	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 4) * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
+	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS + lws - 1) / lws); i++)
 		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
 
 	barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/opencl/sha1_kernel.cl
+++ b/src/opencl/sha1_kernel.cl
@@ -186,9 +186,10 @@ __kernel void sha1(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	/* We must allocate for the possibility of non-log2 LWS */
+	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 4) * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
+	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS + lws - 1) / lws); i++)
 		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
 
 	barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/opencl_7z_fmt_plug.c
+++ b/src/opencl_7z_fmt_plug.c
@@ -647,10 +647,11 @@ exit_good:
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 	int index;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	//fprintf(stderr, "%s(%d) lws %zu gws %zu\n", __FUNCTION__, count, local_work_size, global_work_size);
+	global_work_size = count;
 
 	if (any_cracked) {
 		memset(cracked, 0, cracked_size);

--- a/src/opencl_agilekeychain_fmt_plug.c
+++ b/src/opencl_agilekeychain_fmt_plug.c
@@ -332,9 +332,9 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	/// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
@@ -343,7 +343,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	/// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 	        multi_profilingEvent[1]), "Run kernel");
 
 	/// Read the result back

--- a/src/opencl_bitwarden_fmt_plug.c
+++ b/src/opencl_bitwarden_fmt_plug.c
@@ -222,35 +222,34 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = (host_salt->salt.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = (host_salt->salt.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+		CL_FALSE, 0, gws * sizeof(pass_t), host_pass, 0,
 		NULL, multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], split_kernel,
-			1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
+			1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
 	}
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL,
+		1, NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run final kernel");
 
 	// Run Bitwarden decrypt/compare kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], decrypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[4]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[4]), "Run kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_cracked,

--- a/src/opencl_blockchain_fmt_plug.c
+++ b/src/opencl_blockchain_fmt_plug.c
@@ -240,9 +240,9 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	/// Copy data to gpu
 	if (ocl_autotune_running || new_keys) {
@@ -254,7 +254,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	/// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 	        multi_profilingEvent[1]), "Run kernel");
 
 	/// Read the result back

--- a/src/opencl_electrum_modern_fmt_plug.c
+++ b/src/opencl_electrum_modern_fmt_plug.c
@@ -349,28 +349,27 @@ static const char *group_order = "fffffffffffffffffffffffffffffffebaaedce6af48a0
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int index;
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, index;
 	int loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		global_work_size * sizeof(pass_t), host_pass, 0, NULL,
+		gws * sizeof(pass_t), host_pass, 0, NULL,
 		multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-				NULL, &global_work_size, lws, 0, NULL,
+				NULL, &gws, lws, 0, NULL,
 				multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 					split_kernel, 1, NULL,
-					&global_work_size, lws, 0, NULL,
+					&gws, lws, 0, NULL,
 					multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
@@ -378,7 +377,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
-				global_work_size * sizeof(crack_t), host_crack,
+				gws * sizeof(crack_t), host_crack,
 				0, NULL, multi_profilingEvent[3]), "Copy result back");
 
 	if (!ocl_autotune_running) {

--- a/src/opencl_ethereum_fmt_plug.c
+++ b/src/opencl_ethereum_fmt_plug.c
@@ -269,35 +269,34 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = (host_salt->pbkdf2.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = (host_salt->pbkdf2.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+		CL_FALSE, 0, gws * sizeof(pass_t), host_pass, 0,
 		NULL, multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], split_kernel,
-			1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
+			1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
 	}
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL,
+		1, NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run final kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out,
-		CL_TRUE, 0, global_work_size * sizeof(hash_t), host_crack, 0,
+		CL_TRUE, 0, gws * sizeof(hash_t), host_crack, 0,
 		NULL, multi_profilingEvent[4]), "Copy result back");
 
 	return count;

--- a/src/opencl_fvde_fmt_plug.c
+++ b/src/opencl_fvde_fmt_plug.c
@@ -222,35 +222,34 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = (host_salt->salt.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = (host_salt->salt.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+		CL_FALSE, 0, gws * sizeof(pass_t), host_pass, 0,
 		NULL, multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], split_kernel,
-			1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
+			1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
 	}
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL,
+		1, NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run final kernel");
 
 	// Run FVDE decrypt/compare kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], decrypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[4]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[4]), "Run kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_cracked,

--- a/src/opencl_gpg_fmt_plug.c
+++ b/src/opencl_gpg_fmt_plug.c
@@ -273,10 +273,10 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 	int index = 0;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
 
 	if (any_cracked) {
 		memset(cracked, 0, cracked_size);
@@ -292,17 +292,17 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	if (gpg_common_cur_salt->hash_algorithm == HASH_SHA1) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 					crypt_kernel, 1, NULL,
-					&global_work_size, lws, 0, NULL,
+					&gws, lws, 0, NULL,
 					multi_profilingEvent[1]), "Run kernel");
 	} else if (gpg_common_cur_salt->hash_algorithm == HASH_SHA256) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 					crypt_kernel_sha256, 1, NULL,
-					&global_work_size, lws, 0, NULL,
+					&gws, lws, 0, NULL,
 					multi_profilingEvent[1]), "Run kernel");
 	} else if (gpg_common_cur_salt->hash_algorithm == HASH_SHA512) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 					crypt_kernel_sha512, 1, NULL,
-					&global_work_size, lws, 0, NULL,
+					&gws, lws, 0, NULL,
 					multi_profilingEvent[1]), "Run kernel");
 	}
 

--- a/src/opencl_hash_check_128_plug.c
+++ b/src/opencl_hash_check_128_plug.c
@@ -221,12 +221,11 @@ char* ocl_hc_128_select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 16384 ||
+			max_local_mem_sz_bytes < 32768 ||
 			cpu(device_info[gpu_id]))
 			bitmap_size_bits = 256 * 1024;
 
 		else {
-			bitmap_size_bits = 32 * 1024;
 			cmp_steps = 4;
 			use_local = 1;
 		}
@@ -238,12 +237,12 @@ char* ocl_hc_128_select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 32768 ||
+			(platform_apple(platform_id) && gpu_nvidia(device_info[gpu_id])) ||
+			max_local_mem_sz_bytes < 65536 ||
 			cpu(device_info[gpu_id]))
 			bitmap_size_bits = 256 * 1024;
 
 		else {
-			bitmap_size_bits = 64 * 1024;
 			cmp_steps = 4;
 			use_local = 1;
 		}
@@ -254,7 +253,7 @@ char* ocl_hc_128_select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 1024 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 32768)
+			max_local_mem_sz_bytes < 128 * 1024)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_vliw4(device_info[gpu_id]) ||
@@ -264,7 +263,6 @@ char* ocl_hc_128_select_bitmap(unsigned int num_ld_hashes)
 		}
 
 		else {
-			bitmap_size_bits = 32 * 1024;
 			cmp_steps = 8;
 			use_local = 1;
 		}
@@ -309,6 +307,22 @@ char* ocl_hc_128_select_bitmap(unsigned int num_ld_hashes)
 		cmp_steps = 1;
 	}
 
+	if (use_local) {
+		/*
+		 * bitmap_size_bits must be even log2.  We can't count on allocating
+		 * ALL local memory so need to settle for, worst case, half of it.
+		 */
+		bitmap_size_bits = 1;
+		while ((bitmap_size_bits << 1) < max_local_mem_sz_bytes)
+			bitmap_size_bits <<= 1;
+
+		/* Limit to usable local mem size */
+		while ((bitmap_size_bits >> 1) * cmp_steps > bitmap_size_bits)
+			cmp_steps--;
+
+		//fprintf(stderr, "\nPicked bitmap size %u steps %u max mem usage %zu of %zu\n", (uint32_t)bitmap_size_bits, (uint32_t)cmp_steps, (bitmap_size_bits >> 3) * cmp_steps * sizeof(int), get_local_memory_size(gpu_id));
+	}
+
 	if (cmp_steps == 1)
 		prepare_bitmap_1(bitmap_size_bits, &bitmaps);
 
@@ -317,13 +331,6 @@ char* ocl_hc_128_select_bitmap(unsigned int num_ld_hashes)
 
 	else
 		prepare_bitmap_8(bitmap_size_bits, &bitmaps);
-
-	/*
-	 * Much better speed seen on Macbook Pro with GT 650M. Not sure why -
-	 * or what we should actually test for.
-	 */
-	if (platform_apple(platform_id) && gpu_nvidia(device_info[gpu_id]))
-		use_local = 0;
 
 	sprintf(kernel_params,
 		"-D SELECT_CMP_STEPS=%u"

--- a/src/opencl_keepass_fmt_plug.c
+++ b/src/opencl_keepass_fmt_plug.c
@@ -244,10 +244,10 @@ static void set_salt(void *salt)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 	int i;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
@@ -257,13 +257,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	// Run kernels
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 		kernel_init, 1, NULL,
-		&global_work_size, lws, 0, NULL,
+		&gws, lws, 0, NULL,
 		multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : LOOP_COUNT); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 			kernel_loop, 1, NULL,
-			&global_work_size, lws, 0, NULL,
+			&gws, lws, 0, NULL,
 			multi_profilingEvent[2]), "Run kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "Error running loop kernel");
 		opencl_process_event();
@@ -271,7 +271,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 		kernel_final, 1, NULL,
-		&global_work_size, lws, 0, NULL,
+		&gws, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run kernel");
 
 	// Read the result back

--- a/src/opencl_keychain_fmt_plug.c
+++ b/src/opencl_keychain_fmt_plug.c
@@ -305,9 +305,9 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	/// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
@@ -316,7 +316,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	/// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 	        multi_profilingEvent[1]), "Run kernel");
 
 	/// Read the result back

--- a/src/opencl_lastpass_fmt_plug.c
+++ b/src/opencl_lastpass_fmt_plug.c
@@ -198,38 +198,37 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	if (new_keys || ocl_autotune_running) {
 		// Copy data to gpu
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+			CL_FALSE, 0, gws * sizeof(pass_t), host_pass, 0,
 			NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], split_kernel,
-			1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
+			1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
 	}
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL,
+		1, NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run final kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out,
-		CL_TRUE, 0, global_work_size * sizeof(*crypt_out), crypt_out, 0,
+		CL_TRUE, 0, gws * sizeof(*crypt_out), crypt_out, 0,
 		NULL, multi_profilingEvent[4]), "Copy result back");
 
 	return count;

--- a/src/opencl_md5crypt_fmt_plug.c
+++ b/src/opencl_md5crypt_fmt_plug.c
@@ -354,9 +354,10 @@ static void *get_binary(char *ciphertext)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	global_work_size = count;
 
 	///Copy data to GPU memory
 	if (new_keys)

--- a/src/opencl_mysqlsha1_fmt_plug.c
+++ b/src/opencl_mysqlsha1_fmt_plug.c
@@ -580,7 +580,8 @@ static void prepare_bitmap_1(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 }
 
 static char* select_bitmap(unsigned int num_ld_hashes)
-{	static char kernel_params[200];
+{
+	static char kernel_params[200];
 	cl_ulong max_local_mem_sz_bytes = 0;
 	unsigned int cmp_steps = 2, use_local = 0;
 
@@ -594,12 +595,11 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 16384 ||
+			max_local_mem_sz_bytes < 32768 ||
 			cpu(device_info[gpu_id]))
 			bitmap_size_bits = 256 * 1024;
 
 		else {
-			bitmap_size_bits = 32 * 1024;
 			cmp_steps = 4;
 			use_local = 1;
 		}
@@ -611,12 +611,12 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 32768 ||
+			(platform_apple(platform_id) && gpu_nvidia(device_info[gpu_id])) ||
+			max_local_mem_sz_bytes < 65536 ||
 			cpu(device_info[gpu_id]))
 			bitmap_size_bits = 256 * 1024;
 
 		else {
-			bitmap_size_bits = 64 * 1024;
 			cmp_steps = 4;
 			use_local = 1;
 		}
@@ -627,7 +627,7 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 1024 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 32768)
+			max_local_mem_sz_bytes < 128 * 1024)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_vliw4(device_info[gpu_id]) ||
@@ -637,7 +637,6 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		}
 
 		else {
-			bitmap_size_bits = 32 * 1024;
 			cmp_steps = 8;
 			use_local = 1;
 		}
@@ -682,6 +681,22 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		cmp_steps = 1;
 	}
 
+	if (use_local) {
+		/*
+		 * bitmap_size_bits must be even log2.  We can't count on allocating
+		 * ALL local memory so need to settle for, worst case, half of it.
+		 */
+		bitmap_size_bits = 1;
+		while ((bitmap_size_bits << 1) < max_local_mem_sz_bytes)
+			bitmap_size_bits <<= 1;
+
+		/* Limit to usable local mem size */
+		while ((bitmap_size_bits >> 1) * cmp_steps > bitmap_size_bits)
+			cmp_steps--;
+
+		//fprintf(stderr, "\nPicked bitmap size %u steps %u max mem usage %zu of %zu\n", (uint32_t)bitmap_size_bits, (uint32_t)cmp_steps, (bitmap_size_bits >> 3) * cmp_steps * sizeof(int), get_local_memory_size(gpu_id));
+	}
+
 	if (cmp_steps == 1)
 		prepare_bitmap_1(bitmap_size_bits, &bitmaps);
 
@@ -692,8 +707,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		prepare_bitmap_8(bitmap_size_bits, &bitmaps);
 
 	sprintf(kernel_params,
-		"-DSELECT_CMP_STEPS=%u"
-		" -DBITMAP_SIZE_BITS_LESS_ONE="LLu" -DUSE_LOCAL_BITMAPS=%u",
+		"-D SELECT_CMP_STEPS=%u"
+		" -D BITMAP_SIZE_BITS_LESS_ONE="LLu" -D USE_LOCAL_BITMAPS=%u",
 		cmp_steps, (unsigned long long)bitmap_size_bits - 1, use_local);
 
 	bitmap_size_bits *= cmp_steps;
@@ -704,12 +719,10 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand%d\n", __FUNCTION__, count, local_work_size, global_work_size, key_idx, mask_int_cand.num_int_cand);
+	global_work_size = count;
 
 	// copy keys to the device
 	if (key_idx)

--- a/src/opencl_notes_fmt_plug.c
+++ b/src/opencl_notes_fmt_plug.c
@@ -222,35 +222,34 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = (host_salt->salt.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = (host_salt->salt.rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+		CL_FALSE, 0, gws * sizeof(pass_t), host_pass, 0,
 		NULL, multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], split_kernel,
-			1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
+			1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
 	}
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL,
+		1, NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run final kernel");
 
 	// Run FVDE decrypt/compare kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], decrypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[4]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[4]), "Run kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_cracked,

--- a/src/opencl_odf_fmt_plug.c
+++ b/src/opencl_odf_fmt_plug.c
@@ -208,9 +208,9 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
@@ -219,7 +219,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[1]), "Run kernel");
 
 	// Read the result back

--- a/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
@@ -213,40 +213,34 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-#if 0
-	printf("crypt_all(%d)\n", count);
-	printf("LWS = %d, GWS = %d\n", (int)local_work_size, (int)global_work_size);
-#endif
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+		CL_FALSE, 0, gws * sizeof(pass_t), host_pass, 0,
 		NULL, multi_profilingEvent[0]), "Copy data to gpu");
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
+		1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], split_kernel,
-			1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
+			1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
 	}
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL,
+		1, NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run final kernel");
 
 	// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out,
-		CL_TRUE, 0, global_work_size * sizeof(crack_t), host_crack, 0,
+		CL_TRUE, 0, gws * sizeof(crack_t), host_crack, 0,
 		NULL, multi_profilingEvent[4]), "Copy result back");
 
 	return count;

--- a/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
@@ -248,39 +248,33 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-#if 0
-	printf("crypt_all(%d)\n", count);
-	printf("LWS = %d, GWS = %d, loops=%d\n",(int)local_work_size, (int)global_work_size, loops);
-#endif
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = (host_salt->rounds + HASH_LOOPS - 1) / HASH_LOOPS;
 
 	/// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		global_work_size * sizeof(pass_t), host_pass, 0, NUUL,
+		gws * sizeof(pass_t), host_pass, 0, NUUL,
 		multi_profilingEvent[0]), "Copy data to gpu");
 
 	/// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NUUL, &global_work_size, lws, 0, NULL,
+		NUUL, &gws, lws, 0, NULL,
 		multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 		        split_kernel,
-			1, NULL, &global_work_size, lws, 0, NULL,
+			1, NULL, &gws, lws, 0, NULL,
 			multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
 	}
 	/// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
-		global_work_size * sizeof(crack_t), host_crack, 0, NUUL,
+		gws * sizeof(crack_t), host_crack, 0, NUUL,
 		 multi_profilingEvent[3]), "Copy result back");
 
 	return count;

--- a/src/opencl_pfx_fmt_plug.c
+++ b/src/opencl_pfx_fmt_plug.c
@@ -292,9 +292,9 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
@@ -303,7 +303,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[1]),
 		"Run kernel");
 

--- a/src/opencl_pwsafe_fmt_plug.c
+++ b/src/opencl_pwsafe_fmt_plug.c
@@ -300,10 +300,11 @@ static void set_salt(void *salt)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 	int i = 0;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	global_work_size = count;
 
 	///Copy data to GPU memory
 		BENCH_CLERROR(clEnqueueWriteBuffer

--- a/src/opencl_rar5_fmt_plug.c
+++ b/src/opencl_rar5_fmt_plug.c
@@ -215,44 +215,38 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	int loops = host_salt->rounds / HASH_LOOPS;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i, loops = host_salt->rounds / HASH_LOOPS;
 
 	loops += host_salt->rounds % HASH_LOOPS > 0;
 
-#if 0
-	printf("crypt_all(%d)\n", count);
-	printf("LWS = %d, GWS = %d\n", (int)local_work_size, (int)global_work_size);
-#endif
-
 	/// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+		CL_FALSE, 0, gws * sizeof(pass_t), host_pass, 0,
 		NULL, multi_profilingEvent[0]), "Copy data to gpu");
 
 	/// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL,
+		1, NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[1]), "Run kernel");
 
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], split_kernel,
-			1, NULL, &global_work_size, lws, 0, NULL,
+			1, NULL, &gws, lws, 0, NULL,
 			multi_profilingEvent[2]), "Run split kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 		opencl_process_event();
 	}
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel,
-		1, NULL, &global_work_size, lws, 0, NULL,
+		1, NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run final kernel");
 
 	/// Read the result back
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out,
-		CL_TRUE, 0, global_work_size * sizeof(crack_t), host_crack, 0,
+		CL_TRUE, 0, gws * sizeof(crack_t), host_crack, 0,
 		NULL, multi_profilingEvent[4]), "Copy result back");
 
 	return count;

--- a/src/opencl_rar_fmt_plug.c
+++ b/src/opencl_rar_fmt_plug.c
@@ -320,9 +320,10 @@ static void reset(struct db_main *db)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 	int k;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-	size_t gws = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
 
 	if (ocl_autotune_running || new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_key, CL_FALSE, 0, UNICODE_LENGTH * gws, saved_key, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer saved_key");

--- a/src/opencl_rawmd5_fmt_plug.c
+++ b/src/opencl_rawmd5_fmt_plug.c
@@ -402,12 +402,10 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand%d\n", __FUNCTION__, count, local_work_size, global_work_size, key_idx, mask_int_cand.num_int_cand);
+	global_work_size = count;
 
 	// copy keys to the device
 	if (key_idx)

--- a/src/opencl_rawsha512_fmt_plug.c
+++ b/src/opencl_rawsha512_fmt_plug.c
@@ -108,7 +108,7 @@ static void create_clobj(size_t gws, struct fmt_main *self)
 	gkey = mem_calloc(gws, sizeof(sha512_key));
 	ghash = mem_calloc(gws, sizeof(sha512_hash));
 
-	///Allocate memory on the GPU
+	// Allocate memory on the GPU
 	mem_in =
 		clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, insize, NULL,
 		&ret_code);
@@ -126,11 +126,11 @@ static void create_clobj(size_t gws, struct fmt_main *self)
 		&ret_code);
 	HANDLE_CLERROR(ret_code,"Error while allocating memory for cmp_all result");
 
-	///Assign crypt kernel parameters
+	// Assign crypt kernel parameters
 	clSetKernelArg(crypt_kernel, 0, sizeof(mem_in), &mem_in);
 	clSetKernelArg(crypt_kernel, 1, sizeof(mem_out), &mem_out);
 
-	///Assign cmp kernel parameters
+	// Assign cmp kernel parameters
 	clSetKernelArg(cmp_kernel, 0, sizeof(mem_binary), &mem_binary);
 	clSetKernelArg(cmp_kernel, 1, sizeof(mem_out), &mem_out);
 	clSetKernelArg(cmp_kernel, 2, sizeof(mem_cmp), &mem_cmp);
@@ -192,7 +192,7 @@ static void done(void)
 inline static void copy_hash_back()
 {
     if (!hash_copy_back) {
-        HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,outsize, ghash, 0, NULL, NULL), "Copy data back");
+        HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0, outsize, ghash, 0, NULL, NULL), "Copy data back");
         hash_copy_back = 1;
     }
 }
@@ -298,23 +298,24 @@ static int get_hash_6(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	global_work_size = count;
 
-	///Copy data to GPU memory
+	// Copy data to GPU memory
 	if (sha512_key_changed || ocl_autotune_running) {
 		BENCH_CLERROR(clEnqueueWriteBuffer
 		    (queue[gpu_id], mem_in, CL_FALSE, 0, insize, gkey, 0, NULL,
 			multi_profilingEvent[0]), "Copy memin");
 	}
 
-	///Run kernel
+	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel
 	    (queue[gpu_id], crypt_kernel, 1, NULL, &global_work_size, lws,
 		0, NULL, multi_profilingEvent[1]), "Set ND range");
 
-	/// Reset key to unchanged and hashes uncopy to host
+	// Reset key to unchanged and hashes uncopy to host
 	sha512_key_changed = 0;
     hash_copy_back = 0;
 
@@ -324,16 +325,19 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 static int cmp_all(void *binary, int count)
 {
 	uint32_t result;
-	///Copy binary to GPU memory
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
+
+	// Copy binary to GPU memory
 	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_binary, CL_FALSE,
 		0, sizeof(uint64_t), ((uint64_t*)binary)+3, 0, NULL, NULL), "Copy mem_binary");
 
-	///Run kernel
+	// Run kernel
 	HANDLE_CLERROR(clEnqueueNDRangeKernel
-	    (queue[gpu_id], cmp_kernel, 1, NULL, &global_work_size, &local_work_size,
+	    (queue[gpu_id], cmp_kernel, 1, NULL, &global_work_size, lws,
 		0, NULL, NULL), "Set ND range");
 
-	/// Copy result out
+	// Copy result out
 	HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_cmp, CL_TRUE, 0,
 		sizeof(uint32_t), &result, 0, NULL, NULL), "Copy data back");
 

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -585,7 +585,8 @@ static void prepare_bitmap_1(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 }
 
 static char* select_bitmap(unsigned int num_ld_hashes)
-{	static char kernel_params[200];
+{
+	static char kernel_params[200];
 	cl_ulong max_local_mem_sz_bytes = 0;
 	unsigned int cmp_steps = 2, use_local = 0;
 
@@ -599,12 +600,11 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 16384 ||
+			max_local_mem_sz_bytes < 32768 ||
 			cpu(device_info[gpu_id]))
 			bitmap_size_bits = 256 * 1024;
 
 		else {
-			bitmap_size_bits = 32 * 1024;
 			cmp_steps = 4;
 			use_local = 1;
 		}
@@ -616,12 +616,12 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 32768 ||
+			(platform_apple(platform_id) && gpu_nvidia(device_info[gpu_id])) ||
+			max_local_mem_sz_bytes < 65536 ||
 			cpu(device_info[gpu_id]))
 			bitmap_size_bits = 256 * 1024;
 
 		else {
-			bitmap_size_bits = 64 * 1024;
 			cmp_steps = 4;
 			use_local = 1;
 		}
@@ -632,7 +632,7 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 1024 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 32768)
+			max_local_mem_sz_bytes < 128 * 1024)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_vliw4(device_info[gpu_id]) ||
@@ -642,7 +642,6 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		}
 
 		else {
-			bitmap_size_bits = 32 * 1024;
 			cmp_steps = 8;
 			use_local = 1;
 		}
@@ -687,6 +686,22 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		cmp_steps = 1;
 	}
 
+	if (use_local) {
+		/*
+		 * bitmap_size_bits must be even log2.  We can't count on allocating
+		 * ALL local memory so need to settle for, worst case, half of it.
+		 */
+		bitmap_size_bits = 1;
+		while ((bitmap_size_bits << 1) < max_local_mem_sz_bytes)
+			bitmap_size_bits <<= 1;
+
+		/* Limit to usable local mem size */
+		while ((bitmap_size_bits >> 1) * cmp_steps > bitmap_size_bits)
+			cmp_steps--;
+
+		//fprintf(stderr, "\nPicked bitmap size %u steps %u max mem usage %zu of %zu\n", (uint32_t)bitmap_size_bits, (uint32_t)cmp_steps, (bitmap_size_bits >> 3) * cmp_steps * sizeof(int), get_local_memory_size(gpu_id));
+	}
+
 	if (cmp_steps == 1)
 		prepare_bitmap_1(bitmap_size_bits, &bitmaps);
 
@@ -709,12 +724,10 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand%d\n", __FUNCTION__, count, local_work_size, global_work_size, key_idx, mask_int_cand.num_int_cand);
+	global_work_size = count;
 
 	if (keys_changed) {
 	// copy keys to the device

--- a/src/opencl_sl3_fmt_plug.c
+++ b/src/opencl_sl3_fmt_plug.c
@@ -541,7 +541,8 @@ static void prepare_bitmap_1(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 }
 
 static char* select_bitmap(unsigned int num_ld_hashes)
-{	static char kernel_params[200];
+{
+	static char kernel_params[200];
 	cl_ulong max_local_mem_sz_bytes = 0;
 	unsigned int cmp_steps = 2, use_local = 0;
 
@@ -555,12 +556,11 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 16384 ||
+			max_local_mem_sz_bytes < 32768 ||
 			cpu(device_info[gpu_id]))
 			bitmap_size_bits = 256 * 1024;
 
 		else {
-			bitmap_size_bits = 32 * 1024;
 			cmp_steps = 4;
 			use_local = 1;
 		}
@@ -572,12 +572,12 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 32768 ||
+			(platform_apple(platform_id) && gpu_nvidia(device_info[gpu_id])) ||
+			max_local_mem_sz_bytes < 65536 ||
 			cpu(device_info[gpu_id]))
 			bitmap_size_bits = 256 * 1024;
 
 		else {
-			bitmap_size_bits = 64 * 1024;
 			cmp_steps = 4;
 			use_local = 1;
 		}
@@ -588,7 +588,7 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 			bitmap_size_bits = 1024 * 1024;
 
 		else if (amd_gcn_11(device_info[gpu_id]) ||
-			max_local_mem_sz_bytes < 32768)
+			max_local_mem_sz_bytes < 128 * 1024)
 			bitmap_size_bits = 512 * 1024;
 
 		else if (amd_vliw4(device_info[gpu_id]) ||
@@ -598,7 +598,6 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		}
 
 		else {
-			bitmap_size_bits = 32 * 1024;
 			cmp_steps = 8;
 			use_local = 1;
 		}
@@ -643,6 +642,22 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		cmp_steps = 1;
 	}
 
+	if (use_local) {
+		/*
+		 * bitmap_size_bits must be even log2.  We can't count on allocating
+		 * ALL local memory so need to settle for, worst case, half of it.
+		 */
+		bitmap_size_bits = 1;
+		while ((bitmap_size_bits << 1) < max_local_mem_sz_bytes)
+			bitmap_size_bits <<= 1;
+
+		/* Limit to usable local mem size */
+		while ((bitmap_size_bits >> 1) * cmp_steps > bitmap_size_bits)
+			cmp_steps--;
+
+		//fprintf(stderr, "\nPicked bitmap size %u steps %u max mem usage %zu of %zu\n", (uint32_t)bitmap_size_bits, (uint32_t)cmp_steps, (bitmap_size_bits >> 3) * cmp_steps * sizeof(int), get_local_memory_size(gpu_id));
+	}
+
 	if (cmp_steps == 1)
 		prepare_bitmap_1(bitmap_size_bits, &bitmaps);
 
@@ -665,12 +680,10 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand%d\n", __FUNCTION__, count, local_work_size, global_work_size, key_idx, mask_int_cand.num_int_cand);
+	global_work_size = count;
 
 	if (keys_changed) {
 	// copy keys to the device

--- a/src/opencl_sspr_fmt_plug.c
+++ b/src/opencl_sspr_fmt_plug.c
@@ -296,11 +296,11 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 	int i;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
 	int krnl = cur_salt->fmt;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
 
 	// Copy data to gpu
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
@@ -310,14 +310,14 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	// Run 1st kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 		sspr_kernel[krnl], 1, NULL,
-		&global_work_size, lws, 0, NULL,
+		&gws, lws, 0, NULL,
 		multi_profilingEvent[1]), "Run init kernel");
 
 	// Run loop kernel
 	for (i = 0; i < (ocl_autotune_running ? 1 : LOOP_COUNT); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 			loop_kernel[krnl], 1, NULL,
-			&global_work_size, lws, 0, NULL,
+			&gws, lws, 0, NULL,
 			multi_profilingEvent[2]), "Run loop kernel");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "Error running loop kernel");
 		opencl_process_event();

--- a/src/opencl_strip_fmt_plug.c
+++ b/src/opencl_strip_fmt_plug.c
@@ -297,12 +297,13 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	if (new_keys || ocl_autotune_running) {
 		/// Copy data to gpu
+		insize = sizeof(pbkdf2_password) * gws;
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
 			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
 		        "Copy data to gpu");
@@ -311,10 +312,11 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	/// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 	        multi_profilingEvent[1]), "Run kernel");
 
 	/// Read the result back
+	outsize = sizeof(strip_out) * gws;
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
 		outsize, outbuffer, 0, NULL, multi_profilingEvent[2]), "Copy result back");
 

--- a/src/opencl_tc_fmt_plug.c
+++ b/src/opencl_tc_fmt_plug.c
@@ -414,11 +414,11 @@ static int apply_keyfiles(unsigned char *pass, size_t pass_memsz, int nkeyfiles)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	int i;
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+	int i;
 
 	if (psalt->nkeyfiles) {
 		for (i = 0; i < count; i++) {
@@ -434,7 +434,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	/// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 	        multi_profilingEvent[1]), "Run kernel");
 
 	/// Read the result back

--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -344,9 +344,9 @@ static char *get_key(int index)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_MULTIPLE_OR_BIGGER(count, local_work_size);
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
 
 	if (saved_salt->v.type) {
 		// This salt passed valid() but failed get_salt().
@@ -356,17 +356,19 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	}
 
 	/// Copy data to gpu
+	insize = sizeof(zip_password) * gws;
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
 		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
 		"Copy data to gpu");
 
 	/// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
-		NULL, &global_work_size, lws, 0, NULL,
+		NULL, &gws, lws, 0, NULL,
 		multi_profilingEvent[1]),
 		"Run kernel");
 
 	/// Read the result back
+	outsize = sizeof(zip_hash) * gws;
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
 		outsize, outbuffer, 0, NULL, multi_profilingEvent[2]),
 		"Copy result back");


### PR DESCRIPTION
...for less-than-full batches instead of rounding GWS up to LWS multiple.  See #3223.