### PR TITLE
Add support for cracking Signal passphrases

### DIFF
--- a/run/signal2john.py
+++ b/run/signal2john.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python
+
+# This software is Copyright (c) 2018, Dhiru Kholia <dhiru.kholia at gmail.com>
+# and it is hereby released to the general public under the following terms:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.
+#
+# Notes,
+#
+# + Modern versions of Signal do not support using a passphrase.
+#
+# + This was tested with Signal 4.13.5 only.
+#
+# + Run against /data/data/org.thoughtcrime.securesms/shared_prefs/SecureSMS-Preferences.xml file.
+#
+# + In modern version of Signal Android app (e.g. 4.19.3), the "Screen lock"
+#   code seems to be stored in plaintext in SecureSMS-Preferences.xml file!
+#
+# See https://github.com/signalapp/Signal-Android/blob/0a569676f7a57144374a24faef566b2ca3233290/src/org/thoughtcrime/securesms/crypto/MasterSecret.java
+# for algorithm details.
+
+import os
+import sys
+import json
+import base64
+import argparse
+from binascii import hexlify
+
+PY3 = sys.version_info[0] == 3
+
+if not PY3:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+
+# Library code starts #
+
+# Copyright (C) 2012 Martin Blech and individual contributors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"Makes working with XML feel like you are working with JSON"
+
+try:
+    from defusedexpat import pyexpat as expat
+except ImportError:
+    from xml.parsers import expat
+from xml.sax.saxutils import XMLGenerator
+from xml.sax.xmlreader import AttributesImpl
+try:  # pragma no cover
+    from cStringIO import StringIO
+except ImportError:  # pragma no cover
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import StringIO
+try:  # pragma no cover
+    from collections import OrderedDict
+except ImportError:  # pragma no cover
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        OrderedDict = dict
+
+try:  # pragma no cover
+    _basestring = basestring
+except NameError:  # pragma no cover
+    _basestring = str
+try:  # pragma no cover
+    _unicode = unicode
+except NameError:  # pragma no cover
+    _unicode = str
+
+__author__ = 'Martin Blech'
+__version__ = '0.11.0'
+__license__ = 'MIT'
+
+
+class ParsingInterrupted(Exception):
+    pass
+
+
+class _DictSAXHandler(object):
+    def __init__(self,
+                 item_depth=0,
+                 item_callback=lambda *args: True,
+                 xml_attribs=True,
+                 attr_prefix='@',
+                 cdata_key='#text',
+                 force_cdata=False,
+                 cdata_separator='',
+                 postprocessor=None,
+                 dict_constructor=OrderedDict,
+                 strip_whitespace=True,
+                 namespace_separator=':',
+                 namespaces=None,
+                 force_list=None):
+        self.path = []
+        self.stack = []
+        self.data = []
+        self.item = None
+        self.item_depth = item_depth
+        self.xml_attribs = xml_attribs
+        self.item_callback = item_callback
+        self.attr_prefix = attr_prefix
+        self.cdata_key = cdata_key
+        self.force_cdata = force_cdata
+        self.cdata_separator = cdata_separator
+        self.postprocessor = postprocessor
+        self.dict_constructor = dict_constructor
+        self.strip_whitespace = strip_whitespace
+        self.namespace_separator = namespace_separator
+        self.namespaces = namespaces
+        self.namespace_declarations = OrderedDict()
+        self.force_list = force_list
+
+    def _build_name(self, full_name):
+        if not self.namespaces:
+            return full_name
+        i = full_name.rfind(self.namespace_separator)
+        if i == -1:
+            return full_name
+        namespace, name = full_name[:i], full_name[i+1:]
+        short_namespace = self.namespaces.get(namespace, namespace)
+        if not short_namespace:
+            return name
+        else:
+            return self.namespace_separator.join((short_namespace, name))
+
+    def _attrs_to_dict(self, attrs):
+        if isinstance(attrs, dict):
+            return attrs
+        return self.dict_constructor(zip(attrs[0::2], attrs[1::2]))
+
+    def startNamespaceDecl(self, prefix, uri):
+        self.namespace_declarations[prefix or ''] = uri
+
+    def startElement(self, full_name, attrs):
+        name = self._build_name(full_name)
+        attrs = self._attrs_to_dict(attrs)
+        if attrs and self.namespace_declarations:
+            attrs['xmlns'] = self.namespace_declarations
+            self.namespace_declarations = OrderedDict()
+        self.path.append((name, attrs or None))
+        if len(self.path) > self.item_depth:
+            self.stack.append((self.item, self.data))
+            if self.xml_attribs:
+                attr_entries = []
+                for key, value in attrs.items():
+                    key = self.attr_prefix+self._build_name(key)
+                    if self.postprocessor:
+                        entry = self.postprocessor(self.path, key, value)
+                    else:
+                        entry = (key, value)
+                    if entry:
+                        attr_entries.append(entry)
+                attrs = self.dict_constructor(attr_entries)
+            else:
+                attrs = None
+            self.item = attrs or None
+            self.data = []
+
+    def endElement(self, full_name):
+        name = self._build_name(full_name)
+        if len(self.path) == self.item_depth:
+            item = self.item
+            if item is None:
+                item = (None if not self.data
+                        else self.cdata_separator.join(self.data))
+
+            should_continue = self.item_callback(self.path, item)
+            if not should_continue:
+                raise ParsingInterrupted()
+        if len(self.stack):
+            data = (None if not self.data
+                    else self.cdata_separator.join(self.data))
+            item = self.item
+            self.item, self.data = self.stack.pop()
+            if self.strip_whitespace and data:
+                data = data.strip() or None
+            if data and self.force_cdata and item is None:
+                item = self.dict_constructor()
+            if item is not None:
+                if data:
+                    self.push_data(item, self.cdata_key, data)
+                self.item = self.push_data(self.item, name, item)
+            else:
+                self.item = self.push_data(self.item, name, data)
+        else:
+            self.item = None
+            self.data = []
+        self.path.pop()
+
+    def characters(self, data):
+        if not self.data:
+            self.data = [data]
+        else:
+            self.data.append(data)
+
+    def push_data(self, item, key, data):
+        if self.postprocessor is not None:
+            result = self.postprocessor(self.path, key, data)
+            if result is None:
+                return item
+            key, data = result
+        if item is None:
+            item = self.dict_constructor()
+        try:
+            value = item[key]
+            if isinstance(value, list):
+                value.append(data)
+            else:
+                item[key] = [value, data]
+        except KeyError:
+            if self._should_force_list(key, data):
+                item[key] = [data]
+            else:
+                item[key] = data
+        return item
+
+    def _should_force_list(self, key, value):
+        if not self.force_list:
+            return False
+        try:
+            return key in self.force_list
+        except TypeError:
+            return self.force_list(self.path[:-1], key, value)
+
+
+def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
+          namespace_separator=':', disable_entities=True, **kwargs):
+    """Parse the given XML input and convert it into a dictionary.
+
+    `xml_input` can either be a `string` or a file-like object.
+
+    If `xml_attribs` is `True`, element attributes are put in the dictionary
+    among regular child elements, using `@` as a prefix to avoid collisions. If
+    set to `False`, they are just ignored.
+
+    Simple example::
+
+        >>> import xmltodict
+        >>> doc = xmltodict.parse(\"\"\"
+        ... <a prop="x">
+        ...   <b>1</b>
+        ...   <b>2</b>
+        ... </a>
+        ... \"\"\")
+        >>> doc['a']['@prop']
+        u'x'
+        >>> doc['a']['b']
+        [u'1', u'2']
+
+    If `item_depth` is `0`, the function returns a dictionary for the root
+    element (default behavior). Otherwise, it calls `item_callback` every time
+    an item at the specified depth is found and returns `None` in the end
+    (streaming mode).
+
+    The callback function receives two parameters: the `path` from the document
+    root to the item (name-attribs pairs), and the `item` (dict). If the
+    callback's return value is false-ish, parsing will be stopped with the
+    :class:`ParsingInterrupted` exception.
+
+    Streaming example::
+
+        >>> def handle(path, item):
+        ...     print('path:%s item:%s' % (path, item))
+        ...     return True
+        ...
+        >>> xmltodict.parse(\"\"\"
+        ... <a prop="x">
+        ...   <b>1</b>
+        ...   <b>2</b>
+        ... </a>\"\"\", item_depth=2, item_callback=handle)
+        path:[(u'a', {u'prop': u'x'}), (u'b', None)] item:1
+        path:[(u'a', {u'prop': u'x'}), (u'b', None)] item:2
+
+    The optional argument `postprocessor` is a function that takes `path`,
+    `key` and `value` as positional arguments and returns a new `(key, value)`
+    pair where both `key` and `value` may have changed. Usage example::
+
+        >>> def postprocessor(path, key, value):
+        ...     try:
+        ...         return key + ':int', int(value)
+        ...     except (ValueError, TypeError):
+        ...         return key, value
+        >>> xmltodict.parse('<a><b>1</b><b>2</b><b>x</b></a>',
+        ...                 postprocessor=postprocessor)
+        OrderedDict([(u'a', OrderedDict([(u'b:int', [1, 2]), (u'b', u'x')]))])
+
+    You can pass an alternate version of `expat` (such as `defusedexpat`) by
+    using the `expat` parameter. E.g:
+
+        >>> import defusedexpat
+        >>> xmltodict.parse('<a>hello</a>', expat=defusedexpat.pyexpat)
+        OrderedDict([(u'a', u'hello')])
+
+    You can use the force_list argument to force lists to be created even
+    when there is only a single child of a given level of hierarchy. The
+    force_list argument is a tuple of keys. If the key for a given level
+    of hierarchy is in the force_list argument, that level of hierarchy
+    will have a list as a child (even if there is only one sub-element).
+    The index_keys operation takes precendence over this. This is applied
+    after any user-supplied postprocessor has already run.
+
+        For example, given this input:
+        <servers>
+          <server>
+            <name>host1</name>
+            <os>Linux</os>
+            <interfaces>
+              <interface>
+                <name>em0</name>
+                <ip_address>10.0.0.1</ip_address>
+              </interface>
+            </interfaces>
+          </server>
+        </servers>
+
+        If called with force_list=('interface',), it will produce
+        this dictionary:
+        {'servers':
+          {'server':
+            {'name': 'host1',
+             'os': 'Linux'},
+             'interfaces':
+              {'interface':
+                [ {'name': 'em0', 'ip_address': '10.0.0.1' } ] } } }
+
+        `force_list` can also be a callable that receives `path`, `key` and
+        `value`. This is helpful in cases where the logic that decides whether
+        a list should be forced is more complex.
+    """
+    handler = _DictSAXHandler(namespace_separator=namespace_separator,
+                              **kwargs)
+    if isinstance(xml_input, _unicode):
+        if not encoding:
+            encoding = 'utf-8'
+        xml_input = xml_input.encode(encoding)
+    if not process_namespaces:
+        namespace_separator = None
+    parser = expat.ParserCreate(
+        encoding,
+        namespace_separator
+    )
+    try:
+        parser.ordered_attributes = True
+    except AttributeError:
+        # Jython's expat does not support ordered_attributes
+        pass
+    parser.StartNamespaceDeclHandler = handler.startNamespaceDecl
+    parser.StartElementHandler = handler.startElement
+    parser.EndElementHandler = handler.endElement
+    parser.CharacterDataHandler = handler.characters
+    parser.buffer_text = True
+    if disable_entities:
+        try:
+            # Attempt to disable DTD in Jython's expat parser (Xerces-J).
+            feature = "http://apache.org/xml/features/disallow-doctype-decl"
+            parser._reader.setFeature(feature, True)
+        except AttributeError:
+            # For CPython / expat parser.
+            # Anything not handled ends up here and entities aren't expanded.
+            parser.DefaultHandler = lambda x: None
+            # Expects an integer return; zero means failure -> expat.ExpatError.
+            parser.ExternalEntityRefHandler = lambda *x: 1
+    if hasattr(xml_input, 'read'):
+        parser.ParseFile(xml_input)
+    else:
+        parser.Parse(xml_input, True)
+    return handler.item
+
+
+def _process_namespace(name, namespaces, ns_sep=':', attr_prefix='@'):
+    if not namespaces:
+        return name
+    try:
+        ns, name = name.rsplit(ns_sep, 1)
+    except ValueError:
+        pass
+    else:
+        ns_res = namespaces.get(ns.strip(attr_prefix))
+        name = '{0}{1}{2}{3}'.format(
+            attr_prefix if ns.startswith(attr_prefix) else '',
+            ns_res, ns_sep, name) if ns_res else name
+    return name
+
+
+def _emit(key, value, content_handler,
+          attr_prefix='@',
+          cdata_key='#text',
+          depth=0,
+          preprocessor=None,
+          pretty=False,
+          newl='\n',
+          indent='\t',
+          namespace_separator=':',
+          namespaces=None,
+          full_document=True):
+    key = _process_namespace(key, namespaces, namespace_separator, attr_prefix)
+    if preprocessor is not None:
+        result = preprocessor(key, value)
+        if result is None:
+            return
+        key, value = result
+    if (not hasattr(value, '__iter__')
+            or isinstance(value, _basestring)
+            or isinstance(value, dict)):
+        value = [value]
+    for index, v in enumerate(value):
+        if full_document and depth == 0 and index > 0:
+            raise ValueError('document with multiple roots')
+        if v is None:
+            v = OrderedDict()
+        elif not isinstance(v, dict):
+            v = _unicode(v)
+        if isinstance(v, _basestring):
+            v = OrderedDict(((cdata_key, v),))
+        cdata = None
+        attrs = OrderedDict()
+        children = []
+        for ik, iv in v.items():
+            if ik == cdata_key:
+                cdata = iv
+                continue
+            if ik.startswith(attr_prefix):
+                ik = _process_namespace(ik, namespaces, namespace_separator,
+                                        attr_prefix)
+                if ik == '@xmlns' and isinstance(iv, dict):
+                    for k, v in iv.items():
+                        attr = 'xmlns{0}'.format(':{0}'.format(k) if k else '')
+                        attrs[attr] = _unicode(v)
+                    continue
+                if not isinstance(iv, _unicode):
+                    iv = _unicode(iv)
+                attrs[ik[len(attr_prefix):]] = iv
+                continue
+            children.append((ik, iv))
+        if pretty:
+            content_handler.ignorableWhitespace(depth * indent)
+        content_handler.startElement(key, AttributesImpl(attrs))
+        if pretty and children:
+            content_handler.ignorableWhitespace(newl)
+        for child_key, child_value in children:
+            _emit(child_key, child_value, content_handler,
+                  attr_prefix, cdata_key, depth+1, preprocessor,
+                  pretty, newl, indent, namespaces=namespaces,
+                  namespace_separator=namespace_separator)
+        if cdata is not None:
+            content_handler.characters(cdata)
+        if pretty and children:
+            content_handler.ignorableWhitespace(depth * indent)
+        content_handler.endElement(key)
+        if pretty and depth:
+            content_handler.ignorableWhitespace(newl)
+
+
+def unparse(input_dict, output=None, encoding='utf-8', full_document=True,
+            short_empty_elements=False,
+            **kwargs):
+    """Emit an XML document for the given `input_dict` (reverse of `parse`).
+
+    The resulting XML document is returned as a string, but if `output` (a
+    file-like object) is specified, it is written there instead.
+
+    Dictionary keys prefixed with `attr_prefix` (default=`'@'`) are interpreted
+    as XML node attributes, whereas keys equal to `cdata_key`
+    (default=`'#text'`) are treated as character data.
+
+    The `pretty` parameter (default=`False`) enables pretty-printing. In this
+    mode, lines are terminated with `'\n'` and indented with `'\t'`, but this
+    can be customized with the `newl` and `indent` parameters.
+
+    """
+    if full_document and len(input_dict) != 1:
+        raise ValueError('Document must have exactly one root.')
+    must_return = False
+    if output is None:
+        output = StringIO()
+        must_return = True
+    if short_empty_elements:
+        content_handler = XMLGenerator(output, encoding, True)
+    else:
+        content_handler = XMLGenerator(output, encoding)
+    if full_document:
+        content_handler.startDocument()
+    for key, value in input_dict.items():
+        _emit(key, value, content_handler, full_document=full_document,
+              **kwargs)
+    if full_document:
+        content_handler.endDocument()
+    if must_return:
+        value = output.getvalue()
+        try:  # pragma no cover
+            value = value.decode(encoding)
+        except AttributeError:  # pragma no cover
+            pass
+        return value
+
+# Library code ends #
+
+
+def extract_hashes_from_xml(xml, fname):
+    p = parse(xml)
+    # print(json.dumps(p, indent=4, sort_keys=True))
+    have_password = p["map"]["boolean"]["@value"]
+    if not have_password:
+        return
+    iterations = p["map"]["int"]["@value"]
+    fields = p["map"]["string"]
+    for field in fields:
+        if field["@name"] == "encryption_salt":
+            encryption_salt = field["#text"]
+        if field["@name"] == "mac_salt":
+            mac_salt = field["#text"]
+        if field["@name"] == "master_secret":
+            master_secret = field["#text"]
+
+    encryption_salt = hexlify(base64.decodestring(encryption_salt))
+    mac_salt = hexlify(base64.decodestring(mac_salt))
+    master_secret = hexlify(base64.decodestring(master_secret))
+    if PY3:
+        encryption_salt = encryption_salt.decode("ascii")
+        mac_salt = mac_salt.decode("ascii")
+        master_secret = master_secret.decode("ascii")
+    # print(encryption_salt, mac_salt, master_secret, iterations)
+    print("%s:$signal$%s$%s$%s$%s$%s$%s" % (os.path.basename(fname), 1, iterations, encryption_salt, mac_salt, master_secret, master_secret[-40:]))
+
+
+def process_file(fname):
+    data = open(fname).read()
+
+    try:
+        idx = data.index(b"<?xml version")
+    except ValueError:
+        return
+
+    xml = data[idx:]
+    extract_hashes_from_xml(xml, fname)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: %s [SecureSMS-Preferences.xml files]\n" % sys.argv[0])
+        sys.exit(-1)
+
+    for i in range(1, len(sys.argv)):
+        process_file(sys.argv[i])

--- a/src/signal_fmt_plug.c
+++ b/src/signal_fmt_plug.c
@@ -178,8 +178,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	const int count = *pcount;
 	int index;
 
-	memset(cracked, 0, sizeof(cracked[0]) * cracked_count);
-
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
@@ -194,7 +192,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				saved_len[index], cur_salt->mac_salt,
 				cur_salt->mac_salt_size, key, keylen);
 		hmac_sha1(key, keylen, cur_salt->master_secret, cur_salt->master_secret_size - 20, hash, 20);
-		cracked[index] = (0 == memcmp(hash, cur_salt->master_secret + cur_salt->master_secret_size - 20, 20));
+		cracked[index] = !memcmp(hash, cur_salt->master_secret + cur_salt->master_secret_size - 20, 20);
 	}
 
 	return count;
@@ -253,7 +251,7 @@ struct fmt_main fmt_signal = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
 		{
 			"iteration count",
 		},

--- a/src/signal_fmt_plug.c
+++ b/src/signal_fmt_plug.c
@@ -1,0 +1,294 @@
+/*
+ * Format for cracking Signal Android app passphrases.
+ *
+ * This software is Copyright (c) 2018, Dhiru Kholia <dhiru.kholia at gmail.com>,
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted.
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_signal;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_signal);
+#else
+
+#include <string.h>
+
+#include "arch.h"
+#include "misc.h"
+#include "memory.h"
+#include "common.h"
+#include "formats.h"
+#include "johnswap.h"
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#define OMP_SCALE               1  // this is a slow format
+
+#include "loader.h"
+#include "pkcs12.h"
+#include "hmac_sha.h"
+#include "memdbg.h"
+
+#define FORMAT_LABEL            "Signal"
+#define FORMAT_NAME             ""
+#define ALGORITHM_NAME          "Signal Android PKCS12 PBE SHA-1 32/" ARCH_BITS_STR
+// I could not get openssl to use passwords > 48 bytes, so we will cut support at this length (JimF).
+#define PLAINTEXT_LENGTH        48
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define SALT_ALIGN              sizeof(int)
+#define BINARY_SIZE             0
+#define BINARY_ALIGN            1
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+#define FORMAT_TAG              "$signal$"
+#define FORMAT_TAG_LENGTH       (sizeof(FORMAT_TAG) - 1)
+
+static struct fmt_tests tests[] = {
+	// Android -> Signal 4.13.5
+	{"$signal$1$6024$011d9eedb6367df21532acc22dcbb9b2$c492a9906443732b82ba846a14fad1eb$3f53a1cdff7417f3e576d390986218fc5808ae3a1470ca6c13b1fb0ca18673f7718e7f18cf633cd42841c6305953dd43a243e7fc6bdc2c4483d018d24792b7507d34b01a$a243e7fc6bdc2c4483d018d24792b7507d34b01a", "openwall"},
+	{"$signal$1$6097$9ce8d884a8efdfb752d1aba4a846b152$33ac657792e920c25de375eda2581833$df06c02b79c500eae098005eb5846d83ce3c64f2ba5518b77f3a3de66e000440c9cc0830381addefed38d4a66c622970bb3449f8f99cbd9d30fedb580987e9e879c31c2c$bb3449f8f99cbd9d30fedb580987e9e879c31c2c", "openwall123"},
+	{NULL}
+};
+
+static struct custom_salt {
+	int iterations;
+	int mac_salt_size;
+	int master_secret_size;
+	unsigned char mac_salt[32];
+	unsigned char master_secret[128];
+	unsigned char mac[20];
+} *cur_salt;
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static int *saved_len;
+static int *cracked, cracked_count;
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+
+	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
+	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));
+	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);
+	cracked_count = self->params.max_keys_per_crypt;
+}
+
+static void done(void)
+{
+	MEM_FREE(cracked);
+	MEM_FREE(saved_key);
+	MEM_FREE(saved_len);
+}
+
+static int valid(char *ciphertext, struct fmt_main *self)
+{
+	char *p = ciphertext, *ctcopy, *keeptr;
+	int extra;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
+		return 0;
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LENGTH;
+	if ((p = strtokm(ctcopy, "$")) == NULL) // version
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if (atoi(p) != 1)
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // iterations
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // encrypted_salt
+		goto bail;
+	if (hexlenl(p, &extra) > 32 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // mac_salt
+		goto bail;
+	if (hexlenl(p, &extra) > 32 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // master_secret
+		goto bail;
+	if (hexlenl(p, &extra) > 128 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // mac
+		goto bail;
+	if (hexlenl(p, &extra) != 20 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+
+	MEM_FREE(keeptr);
+	return 1;
+
+bail:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+static void *get_salt(char *ciphertext)
+{
+	static struct custom_salt cs;
+	int i;
+	char *p = ciphertext, *ctcopy, *keeptr;
+
+	memset(&cs, 0, sizeof(cs));
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LENGTH;
+	p = strtokm(ctcopy, "$");
+	p = strtokm(NULL, "$");
+	cs.iterations = atoi(p);
+	p = strtokm(NULL, "$");
+	p = strtokm(NULL, "$");
+	cs.mac_salt_size = strlen(p) / 2;
+	for (i = 0; i < cs.mac_salt_size; i++)
+		cs.mac_salt[i] = (atoi16[ARCH_INDEX(p[2*i])] << 4) | atoi16[ARCH_INDEX(p[2*i+1])];
+	p = strtokm(NULL, "$");
+	cs.master_secret_size = strlen(p) / 2;
+	for (i = 0; i < cs.master_secret_size; i++)
+		cs.master_secret[i] = (atoi16[ARCH_INDEX(p[2*i])] << 4) | atoi16[ARCH_INDEX(p[2*i+1])];
+
+	MEM_FREE(keeptr);
+
+	return (void *)&cs;
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (struct custom_salt *)salt;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index;
+
+	memset(cracked, 0, sizeof(cracked[0]) * cracked_count);
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index++) {
+		unsigned char key[16];
+		int keylen = 16;
+		unsigned char hash[20];
+
+		pkcs12_pbe_derive_key(1, cur_salt->iterations,
+				MBEDTLS_PKCS12_DERIVE_KEY,
+				(unsigned char*)saved_key[index],
+				saved_len[index], cur_salt->mac_salt,
+				cur_salt->mac_salt_size, key, keylen);
+		hmac_sha1(key, keylen, cur_salt->master_secret, cur_salt->master_secret_size - 20, hash, 20);
+		cracked[index] = (0 == memcmp(hash, cur_salt->master_secret + cur_salt->master_secret_size - 20, 20));
+	}
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (cracked[index])
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return cracked[index];
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+static void set_key(char *key, int index)
+{
+	saved_len[index] =
+		strnzcpyn(saved_key[index], key, sizeof(saved_key[index]));
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+static unsigned int signal_iteration_count(void *salt)
+{
+	struct custom_salt *cs = salt;
+
+	return (unsigned int) cs->iterations;
+}
+
+struct fmt_main fmt_signal = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
+		{
+			"iteration count",
+		},
+		{ FORMAT_TAG },
+		tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		valid,
+		fmt_default_split,
+		fmt_default_binary,
+		get_salt,
+		{
+			signal_iteration_count,
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */


### PR DESCRIPTION
This cracks Signal Android app passphrases.

Notes, 

+  Modern versions of Signal do not support using a passphrase.

+ This was tested with Signal Android app version 4.13.5 only.

+ Run against `/data/data/org.thoughtcrime.securesms/shared_prefs/SecureSMS-Preferences.xml` file.

+ In modern version of Signal Android app (e.g. 4.19.3), the "Screen lock" code seems to be stored in plaintext in SecureSMS-Preferences.xml file