### PR TITLE
[GPG] Avoid incorrect processing of very old GPG keys

### DIFF
--- a/src/gpg2john.c
+++ b/src/gpg2john.c
@@ -2570,6 +2570,10 @@ encrypted_Secret_Key(int len, int sha1)
 			MEM_FREE(last_hash);
 			last_hash = mem_alloc(len*2 + 512 + (n_bits + 7) / 4);
 			cp = last_hash;
+			if (m_usage == 1) {
+				puts("[ERROR] We don't support 'Simple string-to-key for IDEA' S2K type yet.");
+				return;
+			}
 			cp += sprintf(cp, "$gpg$*%d*%d*%d*", m_algorithm, len, n_bits);
 			cp += print_hex(m_data, len, cp);
 			cp += sprintf(cp, "*%d*%d*%d*%d*%d*", m_spec, m_usage, m_hashAlgorithm, m_cipherAlgorithm, bs);

--- a/src/gpg_common_plug.c
+++ b/src/gpg_common_plug.c
@@ -271,7 +271,7 @@ int gpg_common_valid(char *ciphertext, struct fmt_main *self, int is_CPU_format)
 		goto err;
 	usage = atoi(p);
 	if (!symmetric_mode) {
-		if (usage != 0 && usage != 254 && usage != 255 && usage != 1)
+		if (usage != 0 && usage != 254 && usage != 255) // && usage != 1)
 			goto err;
 	} else {
 		if (usage != 9 && usage != 18) // https://tools.ietf.org/html/rfc4880


### PR DESCRIPTION
This is related to https://github.com/magnumripper/JohnTheRipper/issues/3273 (Add support for cracking very old GPG keys).