### PR TITLE
Generate less revealing hashes for Bitcoin wallets

### DIFF
--- a/run/bitcoin2john.py
+++ b/run/bitcoin2john.py
@@ -851,7 +851,7 @@ if __name__ == '__main__':
 
         ckey = k['encrypted_privkey']
         public_key = k['pubkey']
-        cry_master = json_db['mkey']['encrypted_key']
+        cry_master = json_db['mkey']['encrypted_key'][-64:]  # last two aes blocks should be enough
         cry_salt = json_db['mkey']['salt']
 
         sys.stdout.write("$bitcoin$%s$%s$%s$%s$%s$%s$%s$%s$%s\n" %


### PR DESCRIPTION
I have only tested this lightly.

This is related to https://github.com/magnumripper/JohnTheRipper/issues/3139 (Need less revealing *2john "hashes" for cryptocoin wallets & encrypted archives).