### PR TITLE
Add support for cracking Telegram Desktop passcodes

### DIFF
--- a/run/telegram2john.py
+++ b/run/telegram2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """Utility to extract "hashes" from Telegram Android app's userconfing.xml file(s)"""
 
@@ -25,8 +25,11 @@
 import os
 import sys
 import base64
+import struct
+import hashlib
 import binascii
 import traceback
+from io import BytesIO
 import xml.etree.ElementTree as ET
 
 PY3 = sys.version_info[0] == 3
@@ -34,6 +37,91 @@ PY3 = sys.version_info[0] == 3
 if not PY3:
     reload(sys)
     sys.setdefaultencoding('utf8')
+
+AuthKeySize = 256
+LocalEncryptIterCount = 4000
+LocalEncryptNoPwdIterCount = 4
+LocalEncryptSaltSize = 32
+
+
+def tdfs_parser(filename):
+    try:
+        f = open(filename, "rb")
+    except IOError:
+        e = sys.exc_info()[1]
+        sys.stderr.write("%s\n" % str(e))
+        return
+
+    magic = f.read(4)
+    if magic != b'TDF$':
+        return False
+
+    version = f.read(4)  # AppVersion = 1003008 for Telegram Desktop 1.3.8
+
+    data = f.read()
+    actual_data = data[:-16]
+    checksum = data[-16:]
+    len_bytes = len(actual_data).to_bytes(4, byteorder='little')
+    calculated_checksum = hashlib.md5(actual_data + len(actual_data).to_bytes(4, byteorder='little') + version + magic).digest()
+    if calculated_checksum != checksum:
+        f.close()
+        return False
+
+    f.close()
+    return actual_data
+
+
+# Derived partly from localstorage.cpp -> readFile()
+def process_tdfs_file(base):
+    """
+    # read settings
+    directory = os.path.join(base, "tdata")
+    f = os.path.join(directory, "settings0")
+    if os.path.exists(f):
+        settings = os.path.join(directory, "settings0")
+    else:
+        settings = os.path.join(directory, "settings1")
+    f = BytesIO(tdfs_parser(settings))
+    length = f.read(4)
+    length = struct.unpack(">I", length)[0]
+    if length != LocalEncryptSaltSize:
+        return False
+    salt = f.read(length)
+    length = f.read(4)
+    length = struct.unpack(">I", length)[0]
+    encrypted_settings = f.read(length)
+    """
+
+    # derive filename
+    s = hashlib.md5(b"data").hexdigest().upper()[:16]
+    user_path = ''.join([s[x:x+2][::-1] for x in range(0, len(s), 2)])  # swap character pairs
+
+    # read encrypted data
+    directory = os.path.join(base, "tdata", user_path)
+    f = os.path.join(directory, "map0")
+    if os.path.exists(f):
+        full_path = os.path.join(directory, "map0")
+    else:
+        full_path = os.path.join(directory, "map1")
+    f = BytesIO(tdfs_parser(full_path))
+    length = f.read(4)
+    length = struct.unpack(">I", length)[0]
+    if length != LocalEncryptSaltSize:
+        return False
+    salt = f.read(length)
+    length = f.read(4)
+    length = struct.unpack(">I", length)[0]
+    encrypted_key = f.read(length)
+
+    salt = binascii.hexlify(salt)
+    encrypted_key = binascii.hexlify(encrypted_key)
+    if PY3:
+        salt = salt.decode("ascii")
+        encrypted_key = encrypted_key.decode("ascii")
+
+    print("%s:$telegram$1*%s*%s*%s" % (full_path, LocalEncryptIterCount, salt, encrypted_key))
+
+    return True
 
 
 def process_xml_file(filename):
@@ -63,9 +151,13 @@ def process_xml_file(filename):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        sys.stderr.write("Usage: %s <userconfing.xml file(s)>\n" %
+        sys.stderr.write("Usage: %s <userconfing.xml file(s) / <path to Telegram data directory>\n" %
+                         sys.argv[0])
+        sys.stderr.write("\nExample: %s ~/.local/share/TelegramDesktop\n" %
                          sys.argv[0])
         sys.exit(-1)
 
     for j in range(1, len(sys.argv)):
-        process_xml_file(sys.argv[j])
+        ret = process_tdfs_file(sys.argv[j])
+        if not ret:
+            process_xml_file(sys.argv[j])

--- a/src/aes_ige.h
+++ b/src/aes_ige.h
@@ -1,0 +1,62 @@
+/* crypto/aes/aes.h */
+/* ====================================================================
+ * Copyright (c) 1998-2002 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <openssl/aes.h>
+
+// #include "aes.h"
+
+/* NB: the IV is _two_ blocks long */
+void JtR_AES_ige_encrypt(const unsigned char *in, unsigned char *out,
+                     size_t length, const AES_KEY *key,
+                     unsigned char *ivec, const int enc);

--- a/src/aes_ige_plug.c
+++ b/src/aes_ige_plug.c
@@ -1,0 +1,194 @@
+/* crypto/aes/aes_ige.c */
+/* ====================================================================
+ * Copyright (c) 2006 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ */
+
+#include <string.h>
+
+#include <openssl/aes.h>
+
+#define N_WORDS (AES_BLOCK_SIZE / sizeof(unsigned long))
+typedef struct {
+    unsigned long data[N_WORDS];
+} aes_block_t;
+
+/* XXX: probably some better way to do this */
+#if defined(__i386__) || defined(__x86_64__)
+# define UNALIGNED_MEMOPS_ARE_FAST 1
+#else
+# define UNALIGNED_MEMOPS_ARE_FAST 0
+#endif
+
+#if UNALIGNED_MEMOPS_ARE_FAST
+# define load_block(d, s)        (d) = *(const aes_block_t *)(s)
+# define store_block(d, s)       *(aes_block_t *)(d) = (s)
+#else
+# define load_block(d, s)        memcpy((d).data, (s), AES_BLOCK_SIZE)
+# define store_block(d, s)       memcpy((d), (s).data, AES_BLOCK_SIZE)
+#endif
+
+/* N.B. The IV for this mode is _twice_ the block size */
+
+void JtR_AES_ige_encrypt(const unsigned char *in, unsigned char *out,
+                     size_t length, const AES_KEY *key,
+                     unsigned char *ivec, const int enc)
+{
+    size_t n;
+    size_t len = length;
+
+    len = length / AES_BLOCK_SIZE;
+
+    if (AES_ENCRYPT == enc) {
+        if (in != out &&
+            (UNALIGNED_MEMOPS_ARE_FAST
+             || ((size_t)in | (size_t)out | (size_t)ivec) % sizeof(long) ==
+             0)) {
+            aes_block_t *ivp = (aes_block_t *) ivec;
+            aes_block_t *iv2p = (aes_block_t *) (ivec + AES_BLOCK_SIZE);
+
+            while (len) {
+                aes_block_t *inp = (aes_block_t *) in;
+                aes_block_t *outp = (aes_block_t *) out;
+
+                for (n = 0; n < N_WORDS; ++n)
+                    outp->data[n] = inp->data[n] ^ ivp->data[n];
+                AES_encrypt((unsigned char *)outp->data,
+                            (unsigned char *)outp->data, key);
+                for (n = 0; n < N_WORDS; ++n)
+                    outp->data[n] ^= iv2p->data[n];
+                ivp = outp;
+                iv2p = inp;
+                --len;
+                in += AES_BLOCK_SIZE;
+                out += AES_BLOCK_SIZE;
+            }
+            memcpy(ivec, ivp->data, AES_BLOCK_SIZE);
+            memcpy(ivec + AES_BLOCK_SIZE, iv2p->data, AES_BLOCK_SIZE);
+        } else {
+            aes_block_t tmp, tmp2;
+            aes_block_t iv;
+            aes_block_t iv2;
+
+            load_block(iv, ivec);
+            load_block(iv2, ivec + AES_BLOCK_SIZE);
+
+            while (len) {
+                load_block(tmp, in);
+                for (n = 0; n < N_WORDS; ++n)
+                    tmp2.data[n] = tmp.data[n] ^ iv.data[n];
+                AES_encrypt((unsigned char *)tmp2.data,
+                            (unsigned char *)tmp2.data, key);
+                for (n = 0; n < N_WORDS; ++n)
+                    tmp2.data[n] ^= iv2.data[n];
+                store_block(out, tmp2);
+                iv = tmp2;
+                iv2 = tmp;
+                --len;
+                in += AES_BLOCK_SIZE;
+                out += AES_BLOCK_SIZE;
+            }
+            memcpy(ivec, iv.data, AES_BLOCK_SIZE);
+            memcpy(ivec + AES_BLOCK_SIZE, iv2.data, AES_BLOCK_SIZE);
+        }
+    } else {
+        if (in != out &&
+            (UNALIGNED_MEMOPS_ARE_FAST
+             || ((size_t)in | (size_t)out | (size_t)ivec) % sizeof(long) ==
+             0)) {
+            aes_block_t *ivp = (aes_block_t *) ivec;
+            aes_block_t *iv2p = (aes_block_t *) (ivec + AES_BLOCK_SIZE);
+
+            while (len) {
+                aes_block_t tmp;
+                aes_block_t *inp = (aes_block_t *) in;
+                aes_block_t *outp = (aes_block_t *) out;
+
+                for (n = 0; n < N_WORDS; ++n)
+                    tmp.data[n] = inp->data[n] ^ iv2p->data[n];
+                AES_decrypt((unsigned char *)tmp.data,
+                            (unsigned char *)outp->data, key);
+                for (n = 0; n < N_WORDS; ++n)
+                    outp->data[n] ^= ivp->data[n];
+                ivp = inp;
+                iv2p = outp;
+                --len;
+                in += AES_BLOCK_SIZE;
+                out += AES_BLOCK_SIZE;
+            }
+            memcpy(ivec, ivp->data, AES_BLOCK_SIZE);
+            memcpy(ivec + AES_BLOCK_SIZE, iv2p->data, AES_BLOCK_SIZE);
+        } else {
+            aes_block_t tmp, tmp2;
+            aes_block_t iv;
+            aes_block_t iv2;
+
+            load_block(iv, ivec);
+            load_block(iv2, ivec + AES_BLOCK_SIZE);
+
+            while (len) {
+                load_block(tmp, in);
+                tmp2 = tmp;
+                for (n = 0; n < N_WORDS; ++n)
+                    tmp.data[n] ^= iv2.data[n];
+                AES_decrypt((unsigned char *)tmp.data,
+                            (unsigned char *)tmp.data, key);
+                for (n = 0; n < N_WORDS; ++n)
+                    tmp.data[n] ^= iv.data[n];
+                store_block(out, tmp);
+                iv = tmp2;
+                iv2 = tmp;
+                --len;
+                in += AES_BLOCK_SIZE;
+                out += AES_BLOCK_SIZE;
+            }
+            memcpy(ivec, iv.data, AES_BLOCK_SIZE);
+            memcpy(ivec + AES_BLOCK_SIZE, iv2.data, AES_BLOCK_SIZE);
+        }
+    }
+}

--- a/src/telegram_common.h
+++ b/src/telegram_common.h
@@ -1,0 +1,34 @@
+/*
+ * Common code for the Telegram Desktop format.
+ *
+ * This file takes replicated but common code, shared between the CPU
+ * and the GPU formats, and places it into one common location.
+ */
+
+#include "common.h"
+#include "formats.h"
+#include "jumbo.h"
+#include "memdbg.h"
+
+#define FORMAT_NAME             ""
+#define FORMAT_TAG              "$telegram$"
+#define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
+
+#define SALTLEN                 32
+#define ENCRYPTED_BLOB_LEN      512
+
+struct custom_salt {
+	uint32_t iterations;
+	unsigned char salt[SALTLEN];
+	uint32_t salt_length;
+	unsigned char encrypted_blob[ENCRYPTED_BLOB_LEN];
+	uint32_t encrypted_blob_length;
+};
+
+extern struct fmt_tests telegram_tests[];
+
+int telegram_valid(char *ciphertext, struct fmt_main *self);
+
+void *telegram_get_salt(char *ciphertext);
+
+unsigned int telegram_iteration_count(void *salt);

--- a/src/telegram_common_plug.c
+++ b/src/telegram_common_plug.c
@@ -1,0 +1,92 @@
+/*
+ * Common code for the Telegram Desktop format.
+ *
+ * This file takes replicated but common code, shared between the CPU
+ * and the GPU formats, and places it into one common location.
+ */
+
+#include "arch.h"
+#include "telegram_common.h"
+#include "jumbo.h"
+#include "memdbg.h"
+
+struct fmt_tests telegram_tests[] = {
+	// Telegram Desktop 1.3.9 on Ubuntu 18.04 LTS
+	{"$telegram$1*4000*e693c27ff92fe83a5a247cce198a8d6a0f3a89ffedc6bcddbc39586bb1bcb50b*d6fb7ebda06a23a9c42fc57c39e2c3128da4ee1ff394f17c2fc4290229e13d1c9e45c42ef1aee64903e5904c28cffd49498358fee96eb01888f2251715b7a5e71fa130918f46da5a2117e742ad7727700e924411138bb8d4359662da0ebd4f4357d96d1aa62955e44d4acf2e2ac6e0ce057f48fe24209090fd35eeac8a905aca649cafb2aade1ef7a96a7ab44a22bd7961e79a9291b7fea8749dd415f2fcd73d0293cdb533554f396625f669315c2400ebf6f1f30e08063e88b59b2d5832a197b165cdc6b0dc9d5bfa6d5e278a79fa101e10a98c6662cc3d623aa64daada76f340a657c2cbaddfa46e35c60ecb49e8f1f57bc170b8064b70aa2b22bb326915a8121922e06e7839e62075ee045b8c82751defcba0e8fb75c32f8bbbdb8b673258", "openwall123"},
+	{"$telegram$1*4000*e693c27ff92fe83a5a247cce198a8d6a0f3a89ffedc6bcddbc39586bb1bcb50b*7c04a5becb2564fe4400c124f5bb5f1896117327d8a21f610bd431171f606fa6e064c088aacc59d8eae4e6dce539abdba5ea552f5855412c26284bc851465d6b31949b276f4890fc212d63d73e2ba132d6098688f2a6408b9d9d69c3db4bcd13dcc3a5f80a7926bb11eb2c99c7f02b5d9fd1ced974d18ed9d667deae4be8df6a4a97ed8fae1da90d5131a7536535a9bfa8094ca7f7465deabef00ab4c715f151d016a879197b328c74dfad5b1f854217c741cf3e0297c63c3fb4d5d672d1e31d797b2c01cb8a254f80a37b6c9a011d864c21c4145091f22839a52b6daf23ed2f350f1deb275f1b0b4146285ada0f0b168ce54234854b19ec6657ad0a92ffb0f3b86547c8b8cc3655a29797c398721e740ed606a71018d16545c78ee240ff3635", "öye"},
+	{NULL}
+};
+
+int telegram_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *keeptr, *p;
+	int value, extra;
+
+	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH) != 0)
+		return 0;
+
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+
+	ctcopy += TAG_LENGTH;
+	if ((p = strtokm(ctcopy, "*")) == NULL)  // version / type
+		goto err;
+	if (!isdec(p))
+		goto err;
+	value = atoi(p);
+	if (value != 1)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)  // rounds
+		goto err;
+	if (!isdec(p))
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)  // salt
+		goto err;
+	if (hexlenl(p, &extra) > SALTLEN * 2 || extra)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)  // encrypted_blob
+		goto err;
+	if (hexlenl(p, &extra) > ENCRYPTED_BLOB_LEN * 2 || extra)
+		goto err;
+
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *telegram_get_salt(char *ciphertext)
+{
+	static struct custom_salt cs;
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	char *p;
+	int i;
+
+	memset(&cs, 0, sizeof(struct custom_salt));
+	ctcopy += TAG_LENGTH;
+	p = strtokm(ctcopy, "*");
+	p = strtokm(NULL, "*");
+	cs.iterations = atoi(p);
+	p = strtokm(NULL, "*");
+	cs.salt_length = strlen(p) / 2;
+	for (i = 0; i < cs.salt_length; i++)
+		cs.salt[i] = (atoi16[ARCH_INDEX(p[2 * i])] << 4) | atoi16[ARCH_INDEX(p[2 * i + 1])];
+	p = strtokm(NULL, "*");
+	cs.encrypted_blob_length = strlen(p) / 2;
+	for (i = 0; i < cs.encrypted_blob_length; i++)
+		cs.encrypted_blob[i] = (atoi16[ARCH_INDEX(p[2 * i])] << 4) | atoi16[ARCH_INDEX(p[2 * i + 1])];
+
+	MEM_FREE(keeptr);
+
+	return &cs;
+}
+
+unsigned int telegram_iteration_count(void *salt)
+{
+	struct custom_salt *cs = (struct custom_salt*)salt;
+
+	return cs->iterations;
+}

--- a/src/telegram_fmt_plug.c
+++ b/src/telegram_fmt_plug.c
@@ -1,0 +1,291 @@
+/*
+ * Format for cracking Telegram Desktop passcodes.
+ *
+ * This software is Copyright (c) 2018, Dhiru Kholia <dhiru [at] openwall.com>,
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * All credit goes to "TelegramDesktopLocalStorage" project by Miha Zupan for
+ * making this work possible.
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_telegram;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_telegram);
+#else
+
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#define OMP_SCALE               1  // tuned on Intel Xeon E5-2670
+
+#include "formats.h"
+#include "misc.h"
+#include "common.h"
+#include "params.h"
+#include "options.h"
+#include "sha.h"
+#include "aes_ige.h"
+#include "pbkdf2_hmac_sha1.h"
+#include "telegram_common.h"
+#include "memdbg.h"
+
+#define FORMAT_LABEL            "telegram"
+#define FORMAT_NAME             ""
+#define FORMAT_TAG              "$telegram$"
+#define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
+#ifdef SIMD_COEF_64
+#define ALGORITHM_NAME          "PBKDF2-SHA1 " SHA1_ALGORITHM_NAME " AES"
+#else
+#define ALGORITHM_NAME          "PBKDF2-SHA1 32/" ARCH_BITS_STR " AES"
+#endif
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        0
+#define PLAINTEXT_LENGTH        125
+#define BINARY_SIZE             0
+#define BINARY_ALIGN            1
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define SALT_ALIGN              sizeof(uint64_t)
+#ifdef SIMD_COEF_32
+#define MIN_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA1
+#define MAX_KEYS_PER_CRYPT      (SSE_GROUP_SZ_SHA1 * 4)
+#else
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      4
+#endif
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static int *saved_len;
+static int any_cracked, *cracked;
+static size_t cracked_size;
+
+static struct custom_salt *cur_salt;
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
+	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));
+	cracked_size = sizeof(*cracked) * self->params.max_keys_per_crypt;
+	any_cracked = 0;
+	cracked = mem_calloc(cracked_size, 1);
+}
+
+static void done(void)
+{
+	MEM_FREE(saved_key);
+	MEM_FREE(saved_len);
+	MEM_FREE(cracked);
+}
+
+static int check_password(unsigned char *authkey, struct custom_salt *cs)
+{
+	AES_KEY aeskey;
+	unsigned char data_a[48];
+	unsigned char data_b[48];
+	unsigned char data_c[48];
+	unsigned char data_d[48];
+	unsigned char sha1_a[48];
+	unsigned char sha1_b[48];
+	unsigned char sha1_c[48];
+	unsigned char sha1_d[48];
+	unsigned char message_key[16];
+	unsigned char aes_key[32];
+	unsigned char aes_iv[32];
+	unsigned char encrypted_data[ENCRYPTED_BLOB_LEN];
+	unsigned char decrypted_data[ENCRYPTED_BLOB_LEN];
+	int encrypted_data_length = cs->encrypted_blob_length - 16;
+	SHA_CTX ctx;
+
+	// setup buffers
+	memcpy(message_key, cs->encrypted_blob, 16);
+	memcpy(encrypted_data, cs->encrypted_blob + 16, encrypted_data_length);
+
+	memcpy(data_a, message_key, 16);
+	memcpy(data_b + 16, message_key, 16);
+	memcpy(data_c + 32, message_key, 16);
+	memcpy(data_d, message_key, 16);
+
+	memcpy(data_a + 16, authkey + 8, 32);
+	memcpy(data_b, authkey + 40, 16);
+	memcpy(data_b + 32, authkey + 56, 16);
+	memcpy(data_c, authkey + 72, 32);
+	memcpy(data_d + 16, authkey + 104, 32);
+
+	// kdf
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, data_a, 48);
+	SHA1_Final(sha1_a, &ctx);
+
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, data_b, 48);
+	SHA1_Final(sha1_b, &ctx);
+
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, data_c, 48);
+	SHA1_Final(sha1_c, &ctx);
+
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, data_d, 48);
+	SHA1_Final(sha1_d, &ctx);
+
+	memcpy(aes_key, sha1_a, 8);
+	memcpy(aes_key + 8, sha1_b + 8, 12);
+	memcpy(aes_key + 20, sha1_c + 4, 12);
+
+	memcpy(aes_iv, sha1_a + 8, 12);
+	memcpy(aes_iv + 12, sha1_b, 8);
+	memcpy(aes_iv + 20, sha1_c + 16, 4);
+	memcpy(aes_iv + 24, sha1_d, 8);
+
+	// decrypt
+	AES_set_decrypt_key(aes_key, 256, &aeskey);
+	JtR_AES_ige_encrypt(encrypted_data, decrypted_data, encrypted_data_length, &aeskey, aes_iv, AES_DECRYPT);
+
+	// verify
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, decrypted_data, encrypted_data_length);
+	SHA1_Final(sha1_a, &ctx);
+
+	return !memcmp(sha1_a, message_key, 16);
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (struct custom_salt *)salt;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index;
+
+	if (any_cracked) {
+		memset(cracked, 0, cracked_size);
+		any_cracked = 0;
+	}
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index += MIN_KEYS_PER_CRYPT) {
+		unsigned char pkey[MIN_KEYS_PER_CRYPT][256]; /* 2048 bits, yes */
+		int i;
+#ifdef SIMD_COEF_32
+		int len[MIN_KEYS_PER_CRYPT];
+		unsigned char *pin[MIN_KEYS_PER_CRYPT], *pout[MIN_KEYS_PER_CRYPT];
+		for (i = 0; i < MIN_KEYS_PER_CRYPT; ++i) {
+			len[i] = strlen(saved_key[i+index]);
+			pin[i] = (unsigned char*)saved_key[i+index];
+			pout[i] = pkey[i];
+		}
+		pbkdf2_sha1_sse((const unsigned char **)pin, len, cur_salt->salt, cur_salt->salt_length, cur_salt->iterations, pout, 136 /* 256 */, 0);
+#else
+		for (i = 0; i < MIN_KEYS_PER_CRYPT; i++) {
+			pbkdf2_sha1((unsigned char *)saved_key[index+i],
+					strlen(saved_key[index+i]),
+					cur_salt->salt, cur_salt->salt_length, cur_salt->iterations,
+					pkey[i], 136, 0);
+		}
+#endif
+
+		for (i = 0; i < MIN_KEYS_PER_CRYPT; i++) {
+			if (check_password(pkey[i], cur_salt)) {
+				cracked[index+i] = 1;
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+				any_cracked |= 1;
+			} else {
+				cracked[index+i] = 0;
+			}
+		}
+	}
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	return any_cracked;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return cracked[index];
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+static void set_key(char *key, int index)
+{
+	saved_len[index] = strnzcpyn(saved_key[index], key, PLAINTEXT_LENGTH + 1);
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+struct fmt_main fmt_telegram = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		{
+			"iteration count",
+		},
+		{ FORMAT_TAG },
+		telegram_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		telegram_valid,
+		fmt_default_split,
+		fmt_default_binary,
+		telegram_get_salt,
+		{
+			telegram_iteration_count,
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */


### PR DESCRIPTION
TODO: OpenMP tuning stuff

Speed,

```
$ ../run/john --test --format=telegram  # i3-4005U CPU
Will run 4 OpenMP threads
Benchmarking: telegram [PBKDF2-SHA1 256/256 AVX2 8x AES]... (4xOMP) DONE
Speed for cost 1 (iteration count) of 4000
Warning: "Many salts" test limited: 2/256
Many salts:	867 c/s real, 230 c/s virtual
Only one salt:	898 c/s real, 227 c/s virtual
```

CC @MihaZupan.

This fixes #3280.