### PR TITLE
Add OpenCL support for cracking SAP's PSE files

### DIFF
--- a/src/opencl/sap_pse_kernel.cl
+++ b/src/opencl/sap_pse_kernel.cl
@@ -1,0 +1,107 @@
+/*
+ * This software is Copyright (c) 2018 Dhiru Kholia <kholia at kth dot se>,
+ * Copyright (c) 2017 magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#include "opencl_device_info.h"
+#include "opencl_misc.h"
+#include "opencl_pkcs12.h"
+#include "opencl_des.h"
+
+#ifndef PLAINTEXT_LENGTH
+#error PLAINTEXT_LENGTH must be defined
+#endif
+
+// input
+typedef struct {
+	uint32_t length;
+	uint32_t v[PLAINTEXT_LENGTH / 4];
+} sappse_password;
+
+// input
+typedef struct {
+	uint32_t iterations;
+	uint32_t salt_size;
+	uint32_t encrypted_pin_size;
+	uint32_t salt[32 / 4];
+	uchar encrypted_pin[32];
+} sappse_salt;
+
+// output
+typedef struct {
+	uint cracked;
+} sappse_out;
+
+inline int sappse_crypt(__global const uint *password, uint32_t password_length,
+                      __constant sappse_salt *salt, __global sappse_out *out)
+{
+	uint i;
+	uint32_t csalt[20 / 4];
+
+	union {
+		uint32_t chunks[PLAINTEXT_LENGTH / 4];
+		uchar bytes[PLAINTEXT_LENGTH];
+	} pass;
+
+	union {
+		uint32_t chunks[32 / 4];
+		uchar bytes[24];
+	} key;
+
+	union {
+		uint32_t chunks[16 / 4];
+		uchar bytes[8];
+	} iv;
+
+	for (i = 0; i < (password_length + 3) / 4; i++)
+		pass.chunks[i] = password[i];
+
+	for (i = 0; i < (salt->salt_size + 3) / 4; i++)
+		csalt[i] = salt->salt[i];
+
+	// derive key
+	pkcs12_pbe_derive_key(salt->iterations, 1, pass.chunks, password_length,
+	                      csalt, salt->salt_size, key.chunks, 24);
+
+	// derive iv
+	for (i = 0; i < (salt->salt_size + 3) / 4; i++)
+		csalt[i] = salt->salt[i];
+
+	pkcs12_pbe_derive_key(salt->iterations, 2, pass.chunks, password_length,
+	                      csalt, salt->salt_size, iv.chunks, 8);
+
+	// prepare des input
+	uint padbyte = 8 - (password_length % 8);
+	if (padbyte < 8 && padbyte > 0) {
+		for (i = 0; i < padbyte; i++) {
+			pass.bytes[password_length + i] = padbyte;
+		}
+	}
+
+	// encrypt
+	uchar temp1[16];
+	des3_context ks;
+	des3_set3key_enc(&ks, key.bytes);
+	des3_crypt_cbc(&ks, DES_ENCRYPT, 8, iv.bytes, __private, pass.bytes, temp1);
+
+	for (i = 0; i < 8; i++) {
+		if (temp1[i] != salt->encrypted_pin[i]) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+__kernel void sappse(__global const sappse_password *inbuffer,
+		__global sappse_out *out,
+		__constant sappse_salt *salt)
+{
+	uint idx = get_global_id(0);
+
+	out[idx].cracked = sappse_crypt(inbuffer[idx].v, inbuffer[idx].length, salt, out);
+}

--- a/src/opencl_sappse_fmt_plug.c
+++ b/src/opencl_sappse_fmt_plug.c
@@ -1,0 +1,311 @@
+/*
+ * This software is Copyright (c) 2018 Dhiru Kholia <kholia at kth dot se> and
+ * it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * Based on opencl_pfx_fmt_plug.c file, and other files which are,
+ *
+ * Copyright (c) 2012 Lukas Odzioba <ukasz@openwall.net>, Copyright (c) JimF,
+ * and Copyright (c) magnum.
+ */
+
+#ifdef HAVE_OPENCL
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_opencl_sappse;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_opencl_sappse);
+#else
+
+#include <stdint.h>
+#include <string.h>
+
+#include "misc.h"
+#include "arch.h"
+#include "params.h"
+#include "common.h"
+#include "formats.h"
+#include "opencl_common.h"
+#include "options.h"
+#include "sap_pse_common.h"
+
+#define FORMAT_LABEL            "sappse-opencl"
+#define FORMAT_NAME             "SAP PSE - PKCS12 PBE"
+#define ALGORITHM_NAME          "SHA1 OpenCL"
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define BINARY_ALIGN            sizeof(uint32_t)
+#define SALT_SIZE               sizeof(*cur_salt)
+#define SALT_ALIGN              sizeof(int)
+#define PLAINTEXT_LENGTH        32
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+
+// input
+typedef struct {
+	uint32_t length;
+	uint32_t v[PLAINTEXT_LENGTH / 4];
+} sappse_password;
+
+typedef struct {
+	uint32_t cracked;
+} sappse_out;
+
+// input
+typedef struct {
+	uint32_t iterations;
+	uint32_t salt_size;
+	uint32_t encrypted_pin_size;
+	uint32_t salt[32 / 4];
+	unsigned char encrypted_pin[32];
+} sappse_salt;
+
+static sappse_out *output;
+static struct custom_salt *cur_salt;
+static cl_int cl_error;
+static sappse_password *inbuffer;
+static sappse_salt currentsalt;
+static cl_mem mem_in, mem_out, mem_setting;
+static struct fmt_main *self;
+
+size_t insize, outsize, settingsize, cracked_size;
+
+#define STEP			0
+#define SEED			256
+
+// This file contains auto-tuning routine(s). Has to be included after formats definitions.
+#include "opencl_autotune.h"
+#include "memdbg.h"
+
+static const char *warn[] = {
+	"xfer: ",  ", crypt: ",  ", xfer: "
+};
+
+/* ------- Helper functions ------- */
+static size_t get_task_max_work_group_size()
+{
+	return autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel);
+}
+
+static void create_clobj(size_t gws, struct fmt_main *self)
+{
+	insize = sizeof(sappse_password) * gws;
+	outsize = sizeof(sappse_out) * gws;
+	settingsize = sizeof(sappse_salt);
+
+	inbuffer = mem_calloc(1, insize);
+	output = mem_alloc(outsize);
+
+	// Allocate memory
+	mem_in =
+	    clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, insize, NULL,
+	    &cl_error);
+	HANDLE_CLERROR(cl_error, "Error allocating mem in");
+	mem_out =
+	    clCreateBuffer(context[gpu_id], CL_MEM_WRITE_ONLY, outsize, NULL,
+	    &cl_error);
+	HANDLE_CLERROR(cl_error, "Error allocating mem out");
+	mem_setting =
+	    clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, settingsize,
+	    NULL, &cl_error);
+	HANDLE_CLERROR(cl_error, "Error allocating mem setting");
+
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 0, sizeof(mem_in),
+		&mem_in), "Error while setting mem_in kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 1, sizeof(mem_out),
+		&mem_out), "Error while setting mem_out kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 2, sizeof(mem_setting),
+		&mem_setting), "Error while setting mem_salt kernel argument");
+}
+
+static void release_clobj(void)
+{
+	if (output) {
+		HANDLE_CLERROR(clReleaseMemObject(mem_in), "Release mem in");
+		HANDLE_CLERROR(clReleaseMemObject(mem_setting), "Release mem setting");
+		HANDLE_CLERROR(clReleaseMemObject(mem_out), "Release mem out");
+
+		MEM_FREE(inbuffer);
+		MEM_FREE(output);
+	}
+}
+
+static void init(struct fmt_main *_self)
+{
+	self = _self;
+	opencl_prepare_dev(gpu_id);
+}
+
+static void reset(struct db_main *db)
+{
+	if (!autotuned) {
+		char build_opts[64];
+
+		snprintf(build_opts, sizeof(build_opts),
+		         "-DPLAINTEXT_LENGTH=%d", PLAINTEXT_LENGTH);
+		opencl_init("$JOHN/kernels/sap_pse_kernel.cl",
+		            gpu_id, build_opts);
+
+		crypt_kernel = clCreateKernel(program[gpu_id], "sappse", &cl_error);
+		HANDLE_CLERROR(cl_error, "Error creating kernel");
+
+		// Initialize openCL tuning (library) for this format.
+		opencl_init_auto_setup(SEED, 0, NULL, warn, 1, self,
+		                       create_clobj, release_clobj,
+		                       sizeof(sappse_password), 0, db);
+
+		// Auto tune execution from shared/included code.
+		autotune_run(self, 1, 0, 200);
+	}
+}
+
+static void done(void)
+{
+	if (autotuned) {
+		release_clobj();
+
+		HANDLE_CLERROR(clReleaseKernel(crypt_kernel), "Release kernel");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program");
+
+		autotuned--;
+	}
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (struct custom_salt*)salt;
+
+	currentsalt.salt_size = cur_salt->salt_size;
+	currentsalt.iterations = cur_salt->iterations;
+	currentsalt.encrypted_pin_size = cur_salt->encrypted_pin_size;
+	memcpy((char*)currentsalt.salt, cur_salt->salt, currentsalt.salt_size);
+	memcpy((char*)currentsalt.encrypted_pin, cur_salt->encrypted_pin, currentsalt.encrypted_pin_size);
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_setting,
+		CL_FALSE, 0, settingsize, &currentsalt, 0, NULL, NULL),
+	    "Copy setting to gpu");
+}
+
+static void sappse_set_key(char *key, int index)
+{
+	uint32_t length = strlen(key);
+
+	if (length > PLAINTEXT_LENGTH)
+		length = PLAINTEXT_LENGTH;
+	inbuffer[index].length = length;
+	memcpy(inbuffer[index].v, key, length);
+}
+
+static char *get_key(int index)
+{
+	static char ret[PLAINTEXT_LENGTH + 1];
+	uint32_t length = inbuffer[index].length;
+
+	memcpy(ret, inbuffer[index].v, length);
+	ret[length] = '\0';
+
+	return ret;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	size_t gws = count;
+	size_t *lws = (local_work_size && !(gws % local_work_size)) ?
+		&local_work_size : NULL;
+
+	// Copy data to gpu
+	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+		"Copy data to gpu");
+
+	// Run kernel
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
+		NULL, &gws, lws, 0, NULL,
+		multi_profilingEvent[1]),
+		"Run kernel");
+
+	// Read the result back
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0, outsize, output, 0, NULL, multi_profilingEvent[5]), "Copy result back");
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (output[index].cracked)
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return output[index].cracked;
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main fmt_opencl_sappse = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT,
+		{
+			"iteration count",
+		},
+		{ FORMAT_TAG },
+		sappse_tests
+	}, {
+		init,
+		done,
+		reset,
+		fmt_default_prepare,
+		sappse_common_valid,
+		fmt_default_split,
+		fmt_default_binary,
+		sappse_common_get_salt,
+		{
+			sappse_iteration_count,
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		sappse_set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */
+
+#endif /* HAVE_OPENCL */

--- a/src/sap_pse_common.h
+++ b/src/sap_pse_common.h
@@ -1,0 +1,25 @@
+#include <string.h>
+
+#include "formats.h"
+#include "arch.h"
+#include "memory.h"
+#include "common.h"
+#include "loader.h"
+
+#define BINARY_SIZE             0
+#define FORMAT_TAG              "$pse$"
+#define FORMAT_TAG_LENGTH       (sizeof(FORMAT_TAG) - 1)
+
+struct custom_salt {
+        int iterations;
+        int salt_size;
+        int encrypted_pin_size;
+        unsigned char salt[32];
+        unsigned char encrypted_pin[128];
+};
+
+extern struct fmt_tests sappse_tests[];
+
+void *sappse_common_get_salt(char *ciphertext);
+int sappse_common_valid(char *ciphertext, struct fmt_main *self);
+unsigned int sappse_iteration_count(void *salt);

--- a/src/sap_pse_common_plug.c
+++ b/src/sap_pse_common_plug.c
@@ -1,0 +1,108 @@
+#include "sap_pse_common.h"
+
+struct fmt_tests sappse_tests[] =
+{
+	{"$pse$1$2048$8$0000000000000000$0$$8$826a5c4189e18b67", "1234"},
+	{"$pse$1$2048$8$0000000000000000$0$$16$4e25e64000fa09dc32b2310a215d246e", "12345678"},
+	{"$pse$1$2048$8$0000000000000000$0$$16$70172e6c0eb85edc6344852fb5fd24f3", "1234567890"},
+	{"$pse$1$10000$8$0000000000000000$0$$16$4b23ac258610078d0ca66620010850b8", "password"},
+	{"$pse$1$10000$8$77cb6908be860865$0$$16$24ee62740976ada0e7a41ade3552ee42", "1234567980"},
+	{NULL}
+};
+
+int sappse_common_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *p = ciphertext, *ctcopy, *keeptr;
+	int extra;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
+		return 0;
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LENGTH;
+	if ((p = strtokm(ctcopy, "$")) == NULL) // version
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if (atoi(p) != 1)
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // iterations
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // salt size
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // salt
+		goto bail;
+	if (hexlenl(p, &extra) > 32 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // iv size
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // iv
+		goto bail;
+	if (hexlenl(p, &extra) > 32 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // encrypted_pin_length
+		goto bail;
+	if (!isdec(p))
+		goto bail;
+	if ((p = strtokm(NULL, "$")) == NULL) // encrypted_pin
+		goto bail;
+	if (hexlenl(p, &extra) > 128 * 2 || extra)
+		goto bail;
+	if (!ishexlc(p))
+		goto bail;
+
+	MEM_FREE(keeptr);
+	return 1;
+
+bail:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *sappse_common_get_salt(char *ciphertext)
+{
+	static struct custom_salt cs;
+	int i;
+	char *p = ciphertext, *ctcopy, *keeptr;
+
+	memset(&cs, 0, sizeof(cs));
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LENGTH;
+	p = strtokm(ctcopy, "$");
+	p = strtokm(NULL, "$");
+	cs.iterations = atoi(p);
+	p = strtokm(NULL, "$");
+	cs.salt_size = atoi(p);
+	p = strtokm(NULL, "$");
+	for (i = 0; i < cs.salt_size; i++)
+		cs.salt[i] = (atoi16[ARCH_INDEX(p[2*i])] << 4) | atoi16[ARCH_INDEX(p[2*i+1])];
+	p = strtokm(NULL, "$");
+	p = strtokm(NULL, "$");
+	p = strtokm(NULL, "$");
+	cs.encrypted_pin_size = atoi(p);
+	p = strtokm(NULL, "$");
+	for (i = 0; i < cs.encrypted_pin_size; i++)
+		cs.encrypted_pin[i] = (atoi16[ARCH_INDEX(p[2*i])] << 4) | atoi16[ARCH_INDEX(p[2*i+1])];
+
+	MEM_FREE(keeptr);
+
+	return (void *)&cs;
+}
+
+unsigned int sappse_iteration_count(void *salt)
+{
+	struct custom_salt *cs = salt;
+
+	return (unsigned int) cs->iterations;
+}


### PR DESCRIPTION
This fixes https://github.com/magnumripper/JohnTheRipper/issues/3302 (Add support for cracking SAP's PSE files with PBES1-3DES-SHA1).

```
$ ../run/john --test --format=sappse-opencl 
Device 2: AMD Radeon Pro 560 Compute Engine
Benchmarking: sappse-opencl, SAP PSE - PKCS12 PBE [SHA1 OpenCL]... DONE
Speed for cost 1 (iteration count) of 2048
Raw:	177124 c/s real, 19660K c/s virtual
```
```
$ ../run/john --test --format=sappse-opencl
Device 6: GeForce GTX TITAN X (Maxwell)
Benchmarking: sappse-opencl, SAP PSE - PKCS12 PBE [SHA1 OpenCL]... DONE
Speed for cost 1 (iteration count) of 2048
Raw:	761856 c/s real, 746917 c/s virtual, GPU util: 98%
```