### PR TITLE
Make GCC 8 happy by enlarging the buffer

### DIFF
--- a/src/scrypt_fmt.c
+++ b/src/scrypt_fmt.c
@@ -121,8 +121,8 @@ static char N_to_c(int N) {
 
 static char *prepare(char *fields[10], struct fmt_main *self)
 {
-	static char Buf[256];
 	char tmp[512], tmp2[512], tmp4[256], tmp5[6], tmp6[6], *cp, *cp2;
+	static char Buf[sizeof(tmp2) + sizeof(tmp4) + sizeof(tmp5) + sizeof(tmp6) + 4];
 	int N, r, p;
 
 	if (!strncmp(fields[1], FMT_CISCO9, FMT_CISCO9_LEN)) {


### PR DESCRIPTION
This fixes the following warnings,

```
scrypt_fmt.c: In function 'prepare':
scrypt_fmt.c:189:30: warning: '%s' directive output may be truncated writing up to 255 bytes into a region of size between 242 and 252 [-Wformat-truncation=]
   snprintf(Buf, sizeof(Buf), "%s%c%s%s%s$%s", FMT_TAG7, N_to_c(N), tmp5, tmp6, tmp4, tmp2);
                              ^~~~~~~~~~~~~~~                                   ~~~~
scrypt_fmt.c:189:3: note: '__builtin_snprintf' output between 6 and 782 bytes into a destination of size 256
   snprintf(Buf, sizeof(Buf), "%s%c%s%s%s$%s", FMT_TAG7, N_to_c(N), tmp5, tmp6, tmp4, tmp2);
   ^~~~~~~~
```