### PR TITLE
Fix recent incorrect buffer resizing in charset handling code

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -666,7 +666,7 @@ static void charset_generate_all(struct list_main **lists, char *charset)
 
 	fflush(file);
 	if (!ferror(file) && !fseek(file, 0, SEEK_SET)) {
-		strncpy(header->version, CHARSET_V, sizeof(header->version));
+		memcpy(header->version, CHARSET_V, strlen(CHARSET_V));
 		header->min = CHARSET_MIN;
 		header->max = CHARSET_MAX;
 		header->length = CHARSET_LENGTH;

--- a/src/charset.h
+++ b/src/charset.h
@@ -33,7 +33,7 @@
  */
 struct charset_header {
 /* CHARSET_V* */
-	char version[5];
+	char version[4];
 
 /* A checksum of the file or equivalent plus some space for future extensions
  * (only 4 bytes are used currently) */


### PR DESCRIPTION
The Fedora Rawhide (or 27) MinGW GCC won't be happy with this reversion. I am working on finding away to make the CI happy as well.

This fixes issue #3333.