### PR TITLE
Ignore GCC 8's -Wstringop-truncation warning

### DIFF
--- a/.travis/check.sh
+++ b/.travis/check.sh
@@ -45,7 +45,8 @@ elif [[ "$TEST" == "fresh test" ]]; then
     docker run -v $HOME:/root -v $(pwd):/cwd ubuntu:rolling sh -c " \
       cd /cwd/src; \
       apt-get update -qq; \
-      apt-get install -y build-essential libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev libbz2-dev libomp-dev; \
+      apt-get install -y build-essential libssl-dev yasm libgmp-dev libpcap-dev pkg-config debhelper libnet1-dev libbz2-dev zlib1g-dev libomp-dev; \
+      gcc --version; \
       ./configure --enable-werror --enable-asan; \
       make -sj4; \
       export OPENCL="""$OPENCL"""; \

--- a/src/SIPdump.c
+++ b/src/SIPdump.c
@@ -75,7 +75,7 @@ typedef struct {
 	uint32_t server_ip;
 	uint16_t server_port;
 	char method[SIP_METHOD_LEN];
-	char buffer[SIP_LINE_LEN+1];
+	char buffer[SIP_LINE_LEN];
 } sip_conn_t;
 
 /* Basic connection table */
@@ -448,10 +448,9 @@ static void parse_payload(const conn_t * connection,
 
 			/* Keep non-line-terminated buffer, new data will be appended */
 			else if (!ret) {
-				if (buffer[0] != 0x00) {
-					strncpy(conn_table[i].buffer, buffer, SIP_LINE_LEN);
-					conn_table[i].buffer[SIP_LINE_LEN] = 0;
-				}
+				if (buffer[0] != 0x00)
+					strncpy(conn_table[i].buffer, buffer,
+					    sizeof(conn_table[i].buffer) - 1);
 			}
 
 			/* Break lookup in connection table */

--- a/src/c3_fmt.c
+++ b/src/c3_fmt.c
@@ -350,8 +350,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 static void *binary(char *ciphertext)
 {
 	static char out[BINARY_SIZE];
-	strncpy(out, ciphertext, sizeof(out)-1);
-	out[sizeof(out)-1] = 0;
+	strncpy(out, ciphertext, sizeof(out)); /* NUL padding is required */
 	return out;
 }
 

--- a/src/configure
+++ b/src/configure
@@ -6138,6 +6138,56 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+   if test 1 -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wno-stringop-truncation" >&5
+$as_echo_n "checking if $CC supports -Wno-stringop-truncation... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -Wno-stringop-truncation"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -Wno-stringop-truncation"
+
+else
+  if test 1 -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+    if test "1" = 2; then :
+  as_fn_error $? "Not supported by compiler" "$LINENO" 5
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+
    if test "x$werror" = xyes; then :
   if test 1 -gt 0; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Werror" >&5
@@ -6266,55 +6316,6 @@ if ac_fn_c_try_compile "$LINENO"; then :
 $as_echo "yes" >&6; }
 fi
       CFLAGS_EX="$CFLAGS_EX -Wno-error=#warnings"
-
-else
-  if test 1 -gt 0; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-    if test "1" = 2; then :
-  as_fn_error $? "Not supported by compiler" "$LINENO" 5
-fi
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  CFLAGS="$ac_saved_cflags"
-  ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-
-      if test 1 -gt 0; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wno-stringop-truncation" >&5
-$as_echo_n "checking if $CC supports -Wno-stringop-truncation... " >&6; }
-fi
-  ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-  ac_saved_cflags="$CFLAGS"
-  CFLAGS="-Werror -Wno-stringop-truncation"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  if test "1" -gt 0; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-fi
-      CFLAGS_EX="$CFLAGS_EX -Wno-stringop-truncation"
 
 else
   if test 1 -gt 0; then :

--- a/src/configure
+++ b/src/configure
@@ -6286,6 +6286,55 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
+      if test 1 -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wno-stringop-truncation" >&5
+$as_echo_n "checking if $CC supports -Wno-stringop-truncation... " >&6; }
+fi
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror -Wno-stringop-truncation"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  if test "1" -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+      CFLAGS_EX="$CFLAGS_EX -Wno-stringop-truncation"
+
+else
+  if test 1 -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+    if test "1" = 2; then :
+  as_fn_error $? "Not supported by compiler" "$LINENO" 5
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS="$ac_saved_cflags"
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
 
 fi
    if test "x$asan" = xyes || test "x$ubsan" = xyes || test "x$ubsantrap" ; then

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -237,6 +237,7 @@ fi
       JTR_FLAG_CHECK([-Werror], 1)
       JTR_FLAG_CHECK([-Wno-error=cpp], 1)
       JTR_FLAG_CHECK([[-Wno-error=#warnings]], 1)
+      JTR_FLAG_CHECK([[-Wno-stringop-truncation]], 1)
    )
    if test "x$asan" = xyes || test "x$ubsan" = xyes || test "x$ubsantrap" ; then
       JTR_FLAG_CHECK([-fno-omit-frame-pointer], 1)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -233,11 +233,12 @@ fi
    JTR_FLAG_CHECK([-Wall], 1)
    JTR_FLAG_CHECK([-Wdeclaration-after-statement], 1)
 
+   JTR_FLAG_CHECK([[-Wno-stringop-truncation]], 1)
+
    AS_IF([test "x$werror" = xyes],
       JTR_FLAG_CHECK([-Werror], 1)
       JTR_FLAG_CHECK([-Wno-error=cpp], 1)
       JTR_FLAG_CHECK([[-Wno-error=#warnings]], 1)
-      JTR_FLAG_CHECK([[-Wno-stringop-truncation]], 1)
    )
    if test "x$asan" = xyes || test "x$ubsan" = xyes || test "x$ubsantrap" ; then
       JTR_FLAG_CHECK([-fno-omit-frame-pointer], 1)

--- a/src/django_scrypt_fmt_plug.c
+++ b/src/django_scrypt_fmt_plug.c
@@ -146,8 +146,7 @@ static void *get_salt(char *ciphertext)
 	static struct custom_salt *cs = &(un._cs);
 	ctcopy += TAG_LENGTH;
 	p = strtokm(ctcopy, "$");
-	strncpy((char*)cs->salt, p, sizeof(cs->salt) - 1);
-	cs->salt[sizeof(cs->salt) - 1] = 0;
+	strncpy((char*)cs->salt, p, 32);
 	p = strtokm(NULL, "$");
 	cs->N = atoi(p);
 	p = strtokm(NULL, "$");

--- a/src/dynamic_compiler.c
+++ b/src/dynamic_compiler.c
@@ -564,9 +564,9 @@ SPH_FUNC(skein224,28) SPH_FUNC(skein256,32) SPH_FUNC(skein384,48) SPH_FUNC(skein
 
 static int encode_le()         { int len = enc_to_utf16((UTF16*)gen_conv, 260, (UTF8*)h, h_len); memcpy(h, gen_conv, len*2); return len*2; }
 static int encode_be()         { int len = enc_to_utf16_be((UTF16*)gen_conv, 260, (UTF8*)h, h_len); memcpy(h, gen_conv, len*2); return len*2; }
-static char *pad16()           { memset(gen_conv, 0, 16); strncpy(gen_conv, gen_pw, 16); gen_conv[16] = 0; return gen_conv; }
-static char *pad20()           { memset(gen_conv, 0, 20); strncpy(gen_conv, gen_pw, 20); gen_conv[20] = 0; return gen_conv; }
-static char *pad100()          { memset(gen_conv, 0, 100); strncpy(gen_conv, gen_pw, 100); gen_conv[100] =0; return gen_conv; }
+static char *pad16()           { memset(gen_conv, 0, 16); strncpy(gen_conv, gen_pw, 16); return gen_conv; }
+static char *pad20()           { memset(gen_conv, 0, 20); strncpy(gen_conv, gen_pw, 20); return gen_conv; }
+static char *pad100()          { memset(gen_conv, 0, 100); strncpy(gen_conv, gen_pw, 100); return gen_conv; }
 
 /*
  * helper functions, to reduce the size of our dynamic_*() functions
@@ -723,7 +723,7 @@ static const char *get_param(const char *p, const char *what) {
 static int handle_extra_params(DC_struct *ptr) {
 	// c1=boobies,c2=bootie
 	int i;
-	char cx[13];
+	char cx[4];
 	const char *cp;
 
 	nConst = 0;

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -3814,7 +3814,6 @@ void DynamicFunc__append_keys_pad16(DYNA_OMP_PARAMS)
 {
 	unsigned int j;
 	unsigned int til;
-	char *p = NULL;
 #ifdef _OPENMP
 	til = last;
 	j = first;
@@ -3849,9 +3848,7 @@ void DynamicFunc__append_keys_pad16(DYNA_OMP_PARAMS)
 			strncpy(&(input_buf_X86[j>>MD5_X2].x2.b2[total_len_X86[j]]), saved_key[j], 17);
 		else
 #endif
-		p = &(input_buf_X86[j>>MD5_X2].x1.b[total_len_X86[j]]);
-		strncpy(p, saved_key[j], 17);
-		p[17] = 0;  // ugly hack
+		strncpy(&(input_buf_X86[j>>MD5_X2].x1.b[total_len_X86[j]]), saved_key[j], 17);
 		total_len_X86[j] += 16;
 	}
 }
@@ -3860,7 +3857,6 @@ void DynamicFunc__append_keys_pad20(DYNA_OMP_PARAMS)
 {
 	unsigned int j;
 	unsigned int til;
-	char *p = NULL;
 #ifdef _OPENMP
 	til = last;
 	j = first;
@@ -3895,9 +3891,7 @@ void DynamicFunc__append_keys_pad20(DYNA_OMP_PARAMS)
 			strncpy(&(input_buf_X86[j>>MD5_X2].x2.b2[total_len_X86[j]]), saved_key[j], 21);
 		else
 #endif
-		p = &(input_buf_X86[j>>MD5_X2].x1.b[total_len_X86[j]]);
-		strncpy(p, saved_key[j], 21);
-		p[21] = 0;
+		strncpy(&(input_buf_X86[j>>MD5_X2].x1.b[total_len_X86[j]]), saved_key[j], 21);
 		total_len_X86[j] += 20;
 	}
 }
@@ -8264,7 +8258,7 @@ static char *FixupIfNeeded(char *ciphertext, private_subformat_data *pPriv)
 			int i;
 			for (i = 0; i < 10; ++i) {
 				if ((pPriv->FldMask & (MGF_FLDx_BIT<<i)) == (MGF_FLDx_BIT<<i)) {
-					char Fld[15];
+					char Fld[8];
 					sprintf(Fld, "$$F%d", i);
 					if (!strstr(&ciphertext[pPriv->dynamic_SALT_OFFSET-1], Fld))
 						return ciphertext;

--- a/src/mysql_netauth_fmt_plug.c
+++ b/src/mysql_netauth_fmt_plug.c
@@ -108,8 +108,7 @@ static char* split(char *ciphertext, int index, struct fmt_main *self)
 {
 	static char out[CIPHERTEXT_LENGTH + 1];
 
-	strncpy(out, ciphertext, CIPHERTEXT_LENGTH);
-	out[CIPHERTEXT_LENGTH] = 0;
+	strncpy(out, ciphertext, sizeof(out));
 	strlwr(out);
 
 	return out;

--- a/src/scrypt_fmt.c
+++ b/src/scrypt_fmt.c
@@ -243,8 +243,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 static void *get_binary(char *ciphertext)
 {
 	static char out[BINARY_SIZE];
-	strncpy(out, ciphertext, sizeof(out)-1);
-	out[sizeof(out)-1] = 0;
+	strncpy(out, ciphertext, sizeof(out)); /* NUL padding is required */
 	return out;
 }
 

--- a/src/truecrypt_fmt_plug.c
+++ b/src/truecrypt_fmt_plug.c
@@ -319,8 +319,8 @@ static void* get_salt(char *ciphertext)
 		q = strchr(p, '$');
 
 		if (!q) { // last file
-			memset(tpath, 0, sizeof(tpath));
-			strncpy(tpath, p, sizeof(tpath)-1);
+			memset(tpath, 0, sizeof(tpath) - 1);
+			strncpy(tpath, p, sizeof(tpath));
 		} else {
 			memset(tpath, 0, sizeof(tpath) - 1);
 			strncpy(tpath, p, q-p);
@@ -494,8 +494,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			for (j = 0; j < SSE_GROUP_SZ_SHA512; ++j) {
 				lens[j] = strlen((char*)(key_buffer[i+j]));
 
-				strncpy((char*)Keys[j], (char*)key_buffer[i+j], sizeof(Keys[j])-1);
-				Keys[j][sizeof(Keys[j])-1] = 0;
+				strncpy((char*)Keys[j], (char*)key_buffer[i+j], 64);
 
 				/* process keyfile(s) */
 				if (psalt->nkeyfiles) {

--- a/src/undrop.c
+++ b/src/undrop.c
@@ -25,9 +25,9 @@
 int undrop(int argc, char *argv[]) {
 
     FILE *userfile;
-    char username[USERNAME_LENGTH+1];
+    char username[USERNAME_LENGTH];
     char password[PASSWORD_LENGTH];
-    char flags[MAX_FLAGS_LENGTH+1];
+    char flags[MAX_FLAGS_LENGTH];
     char t_username[BUFSIZE];
     char t_flags[BUFSIZE];
     char t_line[BUFSIZE];
@@ -63,9 +63,7 @@ int undrop(int argc, char *argv[]) {
 		strncmp(t_username, "$$", 2) != 0
 	    ) {
 		strncpy(username, t_username, USERNAME_LENGTH);
-		username[USERNAME_LENGTH] = 0;
 	        strncpy(flags, t_flags, MAX_FLAGS_LENGTH);
-		flags[MAX_FLAGS_LENGTH] = 0;
 	    }
 	}
 


### PR DESCRIPTION
I am introducing changes to silence GCC warnings. The changes to `configure` file were done by running `autoreconf`.

Next, I will start reverting the wrong changes I introduced in commit bf2048be86c352efdd02b107687a464937c81bd3.

It would be great if we can remove these warning silencing hacks at some point. I will start looking into this.