### PR TITLE
Drop redundant memset zero padding before strncpy

### DIFF
--- a/src/dynamic_compiler.c
+++ b/src/dynamic_compiler.c
@@ -564,9 +564,9 @@ SPH_FUNC(skein224,28) SPH_FUNC(skein256,32) SPH_FUNC(skein384,48) SPH_FUNC(skein
 
 static int encode_le()         { int len = enc_to_utf16((UTF16*)gen_conv, 260, (UTF8*)h, h_len); memcpy(h, gen_conv, len*2); return len*2; }
 static int encode_be()         { int len = enc_to_utf16_be((UTF16*)gen_conv, 260, (UTF8*)h, h_len); memcpy(h, gen_conv, len*2); return len*2; }
-static char *pad16()           { memset(gen_conv, 0, 16); strncpy(gen_conv, gen_pw, 16); return gen_conv; }
-static char *pad20()           { memset(gen_conv, 0, 20); strncpy(gen_conv, gen_pw, 20); return gen_conv; }
-static char *pad100()          { memset(gen_conv, 0, 100); strncpy(gen_conv, gen_pw, 100); return gen_conv; }
+static char *pad16()           { strncpy(gen_conv, gen_pw, 16); return gen_conv; } /* NUL padding is required */
+static char *pad20()           { strncpy(gen_conv, gen_pw, 20); return gen_conv; } /* NUL padding is required */
+static char *pad100()          { strncpy(gen_conv, gen_pw, 100); return gen_conv; } /* NUL padding is required */
 
 /*
  * helper functions, to reduce the size of our dynamic_*() functions


### PR DESCRIPTION
This is related to https://github.com/magnumripper/JohnTheRipper/issues/3339 (Review use of strncpy / strncat and the like).

GCC 8 doesn't like such a `strncpy` construct. I don't know if I still care about satisfying GCC 8 ;(

Tested with,

* ./jtrts.pl -type dynamic_39

* ./jtrts.pl -type dynamic_40

* ./jtrts.pl -type dynamic_1010