### PR TITLE
Autoconf: Add a way to check if -Wno-foo is supported.

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -3397,6 +3397,8 @@ ac_config_headers="$ac_config_headers autoconfig.h"
 
 
 
+
+
 #
 # AX_ZTEX
 #
@@ -6138,9 +6140,11 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
-   if test 1 -gt 0; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wno-stringop-truncation" >&5
-$as_echo_n "checking if $CC supports -Wno-stringop-truncation... " >&6; }
+   warn="-Wstringop-truncation"
+ nowarn="-Wno-stringop-truncation"
+ if test 1 -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports $nowarn" >&5
+$as_echo_n "checking if $CC supports $nowarn... " >&6; }
 fi
   ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -6149,7 +6153,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
   ac_saved_cflags="$CFLAGS"
-  CFLAGS="-Werror -Wno-stringop-truncation"
+  CFLAGS="-Werror $warn"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -6166,7 +6170,7 @@ if ac_fn_c_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 fi
-      CFLAGS_EX="$CFLAGS_EX -Wno-stringop-truncation"
+      CFLAGS_EX="$CFLAGS_EX $nowarn"
 
 else
   if test 1 -gt 0; then :
@@ -6238,9 +6242,11 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-      if test 1 -gt 0; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wno-error=cpp" >&5
-$as_echo_n "checking if $CC supports -Wno-error=cpp... " >&6; }
+      warn="-Werror=cpp"
+ nowarn="-Wno-error=cpp"
+ if test 1 -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports $nowarn" >&5
+$as_echo_n "checking if $CC supports $nowarn... " >&6; }
 fi
   ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -6249,7 +6255,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
   ac_saved_cflags="$CFLAGS"
-  CFLAGS="-Werror -Wno-error=cpp"
+  CFLAGS="-Werror $warn"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -6266,7 +6272,7 @@ if ac_fn_c_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 fi
-      CFLAGS_EX="$CFLAGS_EX -Wno-error=cpp"
+      CFLAGS_EX="$CFLAGS_EX $nowarn"
 
 else
   if test 1 -gt 0; then :
@@ -6287,9 +6293,11 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-      if test 1 -gt 0; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wno-error=#warnings" >&5
-$as_echo_n "checking if $CC supports -Wno-error=#warnings... " >&6; }
+      warn="-Werror=#warnings"
+ nowarn="-Wno-error=#warnings"
+ if test 1 -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports $nowarn" >&5
+$as_echo_n "checking if $CC supports $nowarn... " >&6; }
 fi
   ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -6298,7 +6306,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
   ac_saved_cflags="$CFLAGS"
-  CFLAGS="-Werror -Wno-error=#warnings"
+  CFLAGS="-Werror $warn"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -6315,7 +6323,7 @@ if ac_fn_c_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 fi
-      CFLAGS_EX="$CFLAGS_EX -Wno-error=#warnings"
+      CFLAGS_EX="$CFLAGS_EX $nowarn"
 
 else
   if test 1 -gt 0; then :
@@ -6489,9 +6497,11 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-      if test 1 -gt 0; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wno-deprecated-declarations" >&5
-$as_echo_n "checking if $CC supports -Wno-deprecated-declarations... " >&6; }
+      warn="-Wdeprecated-declarations"
+ nowarn="-Wno-deprecated-declarations"
+ if test 1 -gt 0; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports $nowarn" >&5
+$as_echo_n "checking if $CC supports $nowarn... " >&6; }
 fi
   ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -6500,7 +6510,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
   ac_saved_cflags="$CFLAGS"
-  CFLAGS="-Werror -Wno-deprecated-declarations"
+  CFLAGS="-Werror $warn"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -6517,7 +6527,7 @@ if ac_fn_c_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 fi
-      CFLAGS_EX="$CFLAGS_EX -Wno-deprecated-declarations"
+      CFLAGS_EX="$CFLAGS_EX $nowarn"
 
 else
   if test 1 -gt 0; then :

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -233,12 +233,12 @@ fi
    JTR_FLAG_CHECK([-Wall], 1)
    JTR_FLAG_CHECK([-Wdeclaration-after-statement], 1)
 
-   JTR_FLAG_CHECK([[-Wno-stringop-truncation]], 1)
+   JTR_NOWARN_CHECK([stringop-truncation], 1)
 
    AS_IF([test "x$werror" = xyes],
       JTR_FLAG_CHECK([-Werror], 1)
-      JTR_FLAG_CHECK([-Wno-error=cpp], 1)
-      JTR_FLAG_CHECK([[-Wno-error=#warnings]], 1)
+      JTR_NOWARN_CHECK([error=cpp], 1)
+      JTR_NOWARN_CHECK([[error=#warnings]], 1)
    )
    if test "x$asan" = xyes || test "x$ubsan" = xyes || test "x$ubsantrap" ; then
       JTR_FLAG_CHECK([-fno-omit-frame-pointer], 1)
@@ -249,11 +249,11 @@ fi
    dnl gcc bug workaround, see issue 632
    JTR_FLAG_CHECK([--param allow-store-data-races=0], 1)
    dnl Silly OSX warnings
-   JTR_FLAG_CHECK([-Wno-deprecated-declarations], 1)
+   JTR_NOWARN_CHECK([deprecated-declarations], 1)
    dnl clang warnings
    JTR_FLAG_CHECK([-Wformat-extra-args], 1)
    JTR_FLAG_CHECK([-Wunused-but-set-variable], 1)
-   dnl JTR_FLAG_CHECK([-Wno-unneeded-internal-declaration], 1)
+   dnl JTR_NOWARN_CHECK([unneeded-internal-declaration], 1)
    AS_IF([test "x$JTR_FLAG_Q_CHECK_WORKS" = xyes], [JTR_FLAG_CHECK([-Qunused-arguments],1)])
    dnl Justified and Ancient (see issue 1093)
    JTR_FLAG_CHECK([-std=gnu89], 1)

--- a/src/m4/jtr_utility_macros.m4
+++ b/src/m4/jtr_utility_macros.m4
@@ -50,6 +50,32 @@ AC_DEFUN([JTR_FLAG_CHECK],
   AC_LANG_POP([C])
 ])
 
+dnl @synopsis JTR_NOWARN_CHECK([specific-warning], flags)
+dnl @summary check whether compiler supports -Wspecific-warning and if
+dnl it does, CFLAGS_EX is appended with -Wno-specific-warning
+dnl
+dnl The reason is we can test for -Wfoo but not -Wno-foo (soft fail by design)
+dnl
+dnl If a second argument is 0, don't show progress
+dnl If a second argument is 1, show progress
+dnl If a second argument is 2, bails if not supported
+AC_DEFUN([JTR_NOWARN_CHECK],
+ warn="-W$1"
+ nowarn="-Wno-$1"
+ [AS_IF([test $2 -gt 0], [AC_MSG_CHECKING([if $CC supports $nowarn])])
+  AC_LANG_PUSH([C])
+  ac_saved_cflags="$CFLAGS"
+  CFLAGS="-Werror $warn"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
+    [AS_IF([test "$2" -gt 0], [AC_MSG_RESULT([yes])])]
+      [CFLAGS_EX="$CFLAGS_EX $nowarn"]
+    ,[AS_IF([test $2 -gt 0], [AC_MSG_RESULT([no])])]
+    [AS_IF([test "$2" = 2], [AC_MSG_ERROR([Not supported by compiler])])]
+  )
+  CFLAGS="$ac_saved_cflags"
+  AC_LANG_POP([C])
+])
+
 dnl @synopsis JTR_FLAG_CHECK_LINK(compiler flags[, flags])
 dnl @summary check whether compiler and linker supports given options or not.
 dnl CFLAGS_EX is appended with each 'valid' command.


### PR DESCRIPTION
This has to be implemented by checking if `-Wfoo` is supported because the `no-` forms will soft-fail.