### PR TITLE
Install zlib1g-dev package explicitly on Ubuntu (and Debian)

### DIFF
--- a/doc/INSTALL-UBUNTU
+++ b/doc/INSTALL-UBUNTU
@@ -22,7 +22,7 @@ Please, read INSTALL for general information about installing John on your syste
 
 ==== Recommended (extra formats and performance)
 
-    sudo apt-get install yasm libgmp-dev libpcap-dev pkg-config libbz2-dev
+    sudo apt-get install yasm libgmp-dev libpcap-dev pkg-config libbz2-dev zlib1g-dev
 
 ==== If you have an NVIDIA GPU (OpenCL support)
 


### PR DESCRIPTION
This is required on Debian 9 and modern Ubuntu installations.