### PR TITLE
WPAPSK and -PMK formats: Add support for PMKID. Closes #3356.

### DIFF
--- a/src/opencl/wpapsk_kernel.cl
+++ b/src/opencl/wpapsk_kernel.cl
@@ -437,6 +437,92 @@ void wpapsk_final_sha1(__global wpapsk_state *state,
 #endif
 }
 
+__kernel
+__attribute__((vec_type_hint(MAYBE_VECTOR_UINT)))
+void wpapsk_final_pmkid(__global wpapsk_state *state,
+                        MAYBE_CONSTANT wpapsk_salt *salt,
+                        __global mic_t *mic)
+{
+	MAYBE_VECTOR_UINT outbuffer[8];
+	uint gid = get_global_id(0);
+	MAYBE_VECTOR_UINT W[16];
+	MAYBE_VECTOR_UINT ipad[5];
+	MAYBE_VECTOR_UINT opad[5];
+	uint i;
+	MAYBE_CONSTANT uint *cp = salt->data;
+
+	for (i = 0; i < 5; i++)
+		outbuffer[i] = state[gid].partial[i];
+
+	for (i = 0; i < 3; i++)
+		outbuffer[5 + i] = state[gid].out[i];
+
+	// HMAC(sha1(), PMK, 32, "PMK Name" . MAC_AP . MAC_STA)
+	// PMK is the key (32 bytes)
+	for (i = 0; i < 8; i++)
+		W[i] = 0x36363636 ^ outbuffer[i];
+	for (; i < 16; i++)
+		W[i] = 0x36363636;
+	sha1_single(MAYBE_VECTOR_UINT, W, ipad);
+
+	// rest is the message (20 bytes)
+	for (i = 0; i < 5; i++)
+		W[i] = *cp++;
+	W[5] = 0x80000000;
+	W[15] = (64 + 20) << 3;
+	sha1_block_160Z(MAYBE_VECTOR_UINT, W, ipad);
+
+	for (i = 0; i < 8; i++)
+		W[i] = 0x5c5c5c5c ^ outbuffer[i];
+	for (; i < 16; i++)
+		W[i] = 0x5c5c5c5c;
+	sha1_single(MAYBE_VECTOR_UINT, W, opad);
+
+	for (i = 0; i < 5; i++)
+		W[i] = ipad[i];
+	W[5] = 0x80000000;
+	W[15] = (64 + 20) << 3;
+	sha1_block_160Z(MAYBE_VECTOR_UINT, W, opad);
+
+	/* We only use 16 bytes */
+	for (i = 0; i < 4; i++)
+#ifdef SCALAR
+		mic[gid].keymic[i] = SWAP32(opad[i]);
+#else
+
+#undef VEC_OUT
+#define VEC_OUT(NUM)	  \
+	mic[gid * V_WIDTH + 0x##NUM].keymic[i] = SWAP32(opad[i].s##NUM)
+
+	{
+		VEC_OUT(0);
+		VEC_OUT(1);
+#if V_WIDTH > 2
+		VEC_OUT(2);
+#if V_WIDTH > 3
+		VEC_OUT(3);
+#if V_WIDTH > 4
+		VEC_OUT(4);
+		VEC_OUT(5);
+		VEC_OUT(6);
+		VEC_OUT(7);
+#if V_WIDTH > 8
+		VEC_OUT(8);
+		VEC_OUT(9);
+		VEC_OUT(a);
+		VEC_OUT(b);
+		VEC_OUT(c);
+		VEC_OUT(d);
+		VEC_OUT(e);
+		VEC_OUT(f);
+#endif
+#endif
+#endif
+#endif
+	}
+#endif
+}
+
 #define SHA256_MAC_LEN 32
 
 inline void

--- a/src/wpapmk.h
+++ b/src/wpapmk.h
@@ -1,6 +1,6 @@
 /*
  * This software is Copyright (c) 2012 Lukas Odzioba <lukas dot odzioba at gmail dot com>
- * and Copyright (c) 2012-2017 magnum
+ * and Copyright (c) 2012-2018 magnum
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification, are permitted.
  *
@@ -38,8 +38,7 @@
 #define FORMAT_TAG          "$WPAPSK$"
 #define FORMAT_TAG_LEN      (sizeof(FORMAT_TAG)-1)
 
-typedef struct
-{
+typedef struct {
 	unsigned char keymic[16];
 } mic_t;
 
@@ -57,7 +56,7 @@ typedef struct {
 #ifdef JOHN_OCL_WPAPMK
 	uint8_t  eapol[256 + 64];
 	uint32_t eapol_size;
-	uint8_t  data[64 + 12];
+	uint8_t  data[64 + 12]; /* EAPOL data or PMKID */
 #endif
 	uint8_t  salt[36]; // essid
 } wpapsk_salt;
@@ -68,6 +67,8 @@ static struct fmt_tests tests[] = {
 #if (!AC_BUILT || HAVE_OPENSSL_CMAC_H) || defined(JOHN_OCL_WPAPMK)
 	{"$WPAPSK$Neheb#g9a8Jcre9D0WrPnEN4QXDbA5NwAy5TVpkuoChMdFfL/8Dus4i/X.lTnfwuw04ASqHgvo12wJYJywulb6pWM6C5uqiMPNKNe9pkr6LE61.5I0.Eg.2..........1N4QXDbA5NwAy5TVpkuoChMdFfL/8Dus4i/X.lTnfwuw.................................................................3X.I.E..1uk2.E..1uk2.E..1uk4X...................................................................................................................................................................................../t.....k...0sHl.mVkiHW.ryNchcMd4g", "fb57668cd338374412c26208d79aa5c30ce40a110224f3cfb592a8f2e8bf53e8"},
 #endif
+	/* WPAPSK PMKID */
+	{"2582a8281bf9d4308d6f5731d0e61c61*4604ba734d4e*89acf0e761f4*ed487162465a774bfba60eb603a39f3a", "5b13d4babb3714ccc62c9f71864bc984efd6a55f237c7a87fc2151e1ca658a9d"},
 	{NULL}
 };
 
@@ -139,9 +140,16 @@ static void *get_binary(char *ciphertext)
 		unsigned char c[BINARY_SIZE];
 		uint32_t dummy;
 	} binary;
-	hccap_t *hccap = decode_hccap(ciphertext);
 
-	memcpy(binary.c, hccap->keymic, BINARY_SIZE);
+	if (!strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN)) {
+		hccap_t *hccap = decode_hccap(ciphertext);
+
+		memcpy(binary.c, hccap->keymic, BINARY_SIZE);
+	} else {
+		base64_convert(ciphertext, e_b64_hex, 2 * BINARY_SIZE,
+		               binary.c, e_b64_raw, BINARY_SIZE,
+		               flg_Base64_DONOT_NULL_TERMINATE, 0);
+	}
 	return binary.c;
 }
 
@@ -149,7 +157,22 @@ static void *get_salt(char *ciphertext)
 {
 	static hccap_t s;
 
-	memcpy(&s, decode_hccap(ciphertext), SALT_SIZE);
+	if (!strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN)) {
+		memcpy(&s, decode_hccap(ciphertext), SALT_SIZE);
+	} else {
+		memset(&s, 0, sizeof(s));
+		s.keyver = 0;
+		ciphertext += 33;
+		base64_convert(ciphertext, e_b64_hex, 12, s.mac1, e_b64_raw, 6,
+		               flg_Base64_DONOT_NULL_TERMINATE, 0);
+		ciphertext += 13;
+		base64_convert(ciphertext, e_b64_hex, 12, s.mac2, e_b64_raw, 6,
+		               flg_Base64_DONOT_NULL_TERMINATE, 0);
+		ciphertext += 13;
+		base64_convert(ciphertext, e_b64_hex, 64, s.essid, e_b64_raw, 33,
+		               flg_Base64_DONOT_NULL_TERMINATE, 0);
+	}
+
 	return &s;
 }
 
@@ -159,8 +182,24 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	int hashlength = 0;
 	hccap_t *hccap;
 
-	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN) != 0)
-		return 0;
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN)) {
+		int extra;
+
+		if (strnlen(ciphertext, 61) < 61)
+			return 0;
+		if (ciphertext[32] != '*' || hexlenl(ciphertext, NULL) != 32)
+			return 0;
+		if (ciphertext[45] != '*' || hexlenl(ciphertext + 33, NULL) != 12)
+			return 0;
+		if (ciphertext[58] != '*' || hexlenl(ciphertext + 46, NULL) != 12)
+			return 0;
+		if (hexlenl(ciphertext + 59, &extra) < 1)
+			return 0;
+		if (extra)
+			return 0;
+		/* This is a PMKID hash */
+		return 1;
+	}
 
 	hash = strrchr(ciphertext, '#');
 	if (hash == NULL || hash - (ciphertext + FORMAT_TAG_LEN) > 32)
@@ -244,10 +283,17 @@ static void set_salt(void *salt)
 	if (hccap.keyver == 2)
 		alter_endianity(currentsalt.eapol, 256+56);
 	((unsigned int*)currentsalt.eapol)[16 * ((hccap.eapol_size + 8) / 64) + ((hccap.keyver == 1) ? 14 : 15)] = (64 + hccap.eapol_size) << 3;
-	insert_mac(currentsalt.data);
-	insert_nonce(currentsalt.data + 12);
-	if (hccap.keyver < 3)
-		alter_endianity(currentsalt.data, 64 + 12);
+	if (hccap.keyver == 0) {
+		memcpy(currentsalt.data, "PMK Name", 8);
+		memcpy(currentsalt.data + 8, hccap.mac1, 6);
+		memcpy(currentsalt.data + 14, hccap.mac2, 6);
+		alter_endianity(currentsalt.data, 20);
+	} else {
+		insert_mac(currentsalt.data);
+		insert_nonce(currentsalt.data + 12);
+		if (hccap.keyver < 3)
+			alter_endianity(currentsalt.data, 64 + 12);
+	}
 
 	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_salt, CL_FALSE, 0, sizeof(wpapsk_salt), &currentsalt, 0, NULL, NULL), "Copy setting to gpu");
 #endif
@@ -384,6 +430,26 @@ static void wpapsk_postprocess(int keys)
 {
 	int i;
 	uint8_t data[64 + 12];
+
+	if (hccap.keyver == 0) {
+		uint8_t msg[8 + 6 + 6] = "PMK Name";
+
+		memcpy(msg + 8, hccap.mac1, 6);
+		memcpy(msg + 14, hccap.mac2, 6);
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) private(i) shared(keys, outbuffer, msg, mic)
+#endif
+		/* Create "keymic" that is actually PMKID */
+		for (i = 0; i < keys; i++) {
+			hmac_sha1((unsigned char*)outbuffer[i].v, 32,
+			          msg, 20,
+			          mic[i].keymic, 16);
+		}
+
+		return;
+	}
+
 	insert_mac(data);
 	insert_nonce(data + 12);
 
@@ -515,6 +581,7 @@ static int salt_compare(const void *x, const void *y)
 
 /*
  * key version as first tunable cost
+ * 0=PMKID
  * 1=WPA     (MD5)
  * 2=WPA2    (SHA1)
  * 3=802.11w (SHA256)

--- a/src/wpapmk_fmt_plug.c
+++ b/src/wpapmk_fmt_plug.c
@@ -1,5 +1,5 @@
 /*
- * This software is Copyright (c) 2017 magnum,
+ * This software is Copyright (c) 2018 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -34,9 +34,9 @@ john_register_one(&fmt_wpapsk_pmk);
 #else
 #warning Notice: WPAPMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.
 #endif
-#define FORMAT_NAME		"WPA/WPA2 master key"
+#define FORMAT_NAME		"WPA/WPA2/PMKID master key"
 #else
-#define FORMAT_NAME		"WPA/WPA2/PMF master key"
+#define FORMAT_NAME		"WPA/WPA2/PMF/PMKID master key"
 #endif
 
 #define ALGORITHM_NAME		"MD5/SHA-1/SHA-2"
@@ -122,12 +122,14 @@ struct fmt_main fmt_wpapsk_pmk = {
 		FMT_OMP,
 		{
 #if !AC_BUILT || HAVE_OPENSSL_CMAC_H
-			"key version [1:WPA 2:WPA2 3:802.11w]"
+			"key version [0:PMKID 1:WPA 2:WPA2 3:802.11w]"
 #else
-			"key version [1:WPA 2:WPA2]"
+			"key version [0:PMKID 1:WPA 2:WPA2]"
 #endif
 		},
-		{ FORMAT_TAG },
+		{
+			FORMAT_TAG, ""
+		},
 		tests
 	},
 	{

--- a/src/wpapsk_fmt_plug.c
+++ b/src/wpapsk_fmt_plug.c
@@ -1,5 +1,6 @@
 /*
- * This software is Copyright (c) 2012 Lukas Odzioba <ukasz at openwall dot net>
+ * This software is Copyright (c) 2012 Lukas Odzioba <ukasz at openwall dot net>,
+ * Copyright (c) 2012-2018 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -40,9 +41,9 @@ john_register_one(&fmt_wpapsk);
 #else
 #warning Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.
 #endif
-#define FORMAT_NAME		"WPA/WPA2 PSK"
+#define FORMAT_NAME		"WPA/WPA2/PMKID PSK"
 #else
-#define FORMAT_NAME		"WPA/WPA2/PMF PSK"
+#define FORMAT_NAME		"WPA/WPA2/PMF/PMKID PSK"
 #endif
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          "PBKDF2-SHA1 " SHA1_ALGORITHM_NAME
@@ -184,12 +185,14 @@ struct fmt_main fmt_wpapsk = {
 		FMT_CASE | FMT_OMP,
 		{
 #if !AC_BUILT || HAVE_OPENSSL_CMAC_H
-			"key version [1:WPA 2:WPA2 3:802.11w]"
+			"key version [0:PMKID 1:WPA 2:WPA2 3:802.11w]"
 #else
-			"key version [1:WPA 2:WPA2]"
+			"key version [0:PMKID 1:WPA 2:WPA2]"
 #endif
 		},
-		{ FORMAT_TAG },
+		{
+			FORMAT_TAG, ""
+		},
 		tests
 	},
 	{


### PR DESCRIPTION
Bot check. This is less of a hack than I fear it would be. We should unify more of WPAPSK and WPAPMK code but that's a separate issue.