### PR TITLE
OpenCL: Avoid anonymous unions.

### DIFF
--- a/src/opencl/sspr_kernel.cl
+++ b/src/opencl/sspr_kernel.cl
@@ -41,23 +41,23 @@
 #define SHA512_DIGEST_LENGTH 64
 #endif
 
-typedef union {
+typedef union out_u {
 	uchar b[BINARY_SIZE_MIN];
 	uint w[BINARY_SIZE_MIN / sizeof(uint)];
 	uint64_t W[BINARY_SIZE_MIN / sizeof(uint64_t)];
 } out_t;
 
-typedef union {
+typedef union hash_u {
 	uchar b[SHA_DIGEST_LENGTH];
 	uint w[SHA_DIGEST_LENGTH / sizeof(uint)];
 } hash_t;
 
-typedef union {
+typedef union hash256_u {
 	uchar b[SHA256_DIGEST_LENGTH];
 	uint w[SHA256_DIGEST_LENGTH / sizeof(uint)];
 } hash256_t;
 
-typedef union {
+typedef union hash512_u {
 	uchar b[SHA512_DIGEST_LENGTH];
 	uint w[SHA512_DIGEST_LENGTH / sizeof(uint)];
 	uint64_t W[SHA512_DIGEST_LENGTH / sizeof(uint64_t)];

--- a/src/opencl_aes.h
+++ b/src/opencl_aes.h
@@ -310,7 +310,7 @@ AES_ige_decrypt(AES_SRC_TYPE void *_in, AES_DST_TYPE void *_out,
 	AES_SRC_TYPE uchar *in = _in;
 	AES_DST_TYPE uchar *out = _out;
 
-	typedef union {
+	typedef union aes_block_u {
 		ulong data[N_WORDS];
 		uchar bytes[AES_BLOCK_SIZE];
 	} aes_block_t;

--- a/src/opencl_rawsha256.h
+++ b/src/opencl_rawsha256.h
@@ -44,7 +44,7 @@
 }
 
 //Data types.
-typedef union {
+typedef union buffer_32_u {
 	uint8_t mem_08[4];
 	uint16_t mem_16[2];
 	uint32_t mem_32[1];

--- a/src/opencl_rawsha512.h
+++ b/src/opencl_rawsha512.h
@@ -44,7 +44,7 @@
 }
 
 //Data types.
-typedef union {
+typedef union buffer_64_u {
 	uint8_t mem_08[8];
 	uint16_t mem_16[4];
 	uint32_t mem_32[2];

--- a/src/opencl_sha256crypt.h
+++ b/src/opencl_sha256crypt.h
@@ -30,7 +30,7 @@
 #define KEYS_PER_CORE_GPU       1
 
 //Data types.
-typedef union {
+typedef union buffer_32_u {
 	uint8_t mem_08[4];
 	uint16_t mem_16[2];
 	uint32_t mem_32[1];

--- a/src/opencl_sha512crypt.h
+++ b/src/opencl_sha512crypt.h
@@ -48,7 +48,7 @@
 #define KEYS_PER_CORE_GPU       1
 
 //Data types.
-typedef union {
+typedef union buffer_64_u {
 	uint8_t mem_08[8];
 	uint16_t mem_16[4];
 	uint32_t mem_32[2];


### PR DESCRIPTION
Some buggy AMD/clang runtime seems to have problem with it. Closes #3387.