### PR TITLE
Add support for cracking APFS FVDE volumes

### DIFF
--- a/src/fvde_common.h
+++ b/src/fvde_common.h
@@ -5,7 +5,7 @@
 #include "formats.h"
 
 #define SALTLEN                 16
-#define BLOBLEN                 24
+#define BLOBLEN                 40  // 24 for AES-128
 #define FORMAT_NAME             "FileVault 2"
 #define FORMAT_TAG              "$fvde$"
 #define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
@@ -14,6 +14,8 @@ typedef struct {
 	int salt_length;
 	unsigned char salt[SALTLEN];
 	unsigned int iterations;
+	unsigned int bloblen;
+	unsigned int type;
 	union blob {  // wrapped kek
 		uint64_t qword[BLOBLEN/sizeof(uint64_t)];
 		unsigned char chr[BLOBLEN];

--- a/src/notes_common.h
+++ b/src/notes_common.h
@@ -14,6 +14,7 @@ struct custom_salt {
 	int salt_length;
 	unsigned char salt[SALTLEN];
 	unsigned int iterations;
+	unsigned int type;
 	union blob {  // wrapped kek
 		uint64_t qword[BLOBLEN/sizeof(uint64_t)];
 		unsigned char chr[BLOBLEN];

--- a/src/notes_common_plug.c
+++ b/src/notes_common_plug.c
@@ -67,6 +67,7 @@ void *notes_common_get_salt(char *ciphertext)
 
 	ctcopy += TAG_LENGTH;
 	p = strtokm(ctcopy, "*");
+	cs->type = 1;
 	p = strtokm(NULL, "*");
 	cs->iterations = atoi(p);
 	cs->salt_length = SALTLEN;

--- a/src/opencl/fvde_kernel.cl
+++ b/src/opencl/fvde_kernel.cl
@@ -12,14 +12,13 @@
 #define AES_KEY_TYPE __global const
 #include "opencl_aes.h"
 
-#define BLOBLEN                 24
-
 /*
  * Note that this struct includes the one in opencl_pbkdf2_hmac_sha256.h
  * and custom stuff appended.
  */
 typedef struct {
 	salt_t pbkdf2;
+	int32_t type;
 	union blob {  // wrapped kek
 		uint64_t qword[BLOBLEN/8];
 		uint8_t chr[BLOBLEN];
@@ -31,9 +30,9 @@ __kernel void fvde_decrypt(MAYBE_CONSTANT fvde_salt_t *salt,
                            __global uint32_t *cracked)
 {
 	uint32_t gid = get_global_id(0);
-	MAYBE_CONSTANT uint64_t *C = salt->blob.qword; // len(C) == 3
-	int32_t n = 2;  // len(C) - 1
-	uint64_t R[3]; // n + 1 = 3
+	MAYBE_CONSTANT uint64_t *C = salt->blob.qword; // len(C) == 3 or 5 (AES-256)
+	int32_t n = BLOBLEN / 8 - 1;  // len(C) - 1
+	uint64_t R[5]; // n + 1 = 5
 	union {
 		uint64_t qword[2];
 		uint8_t stream[16];
@@ -42,13 +41,18 @@ __kernel void fvde_decrypt(MAYBE_CONSTANT fvde_salt_t *salt,
 	AES_KEY akey;
 	uint64_t A = C[0];
 
-	AES_set_decrypt_key(out[gid].hash, 128, &akey);
+	if (salt->type == 1) {
+		AES_set_decrypt_key(out[gid].hash, 128, &akey);
+		n = 2;  // note
+	} else {
+		AES_set_decrypt_key(out[gid].hash, 256, &akey);
+	}
 
 	for (i = 0; i < n + 1; i++)
 		R[i] = C[i];
 
 	for (j = 5; j >= 0; j--) { // 5 is fixed!
-		for (i = 2; i >= 1; i--) { // i = n
+		for (i = n; i >= 1; i--) { // i = n
 			todecrypt.qword[0] = SWAP64(A ^ (n * j + i));
 			todecrypt.qword[1] = SWAP64(R[i]);
 			AES_decrypt(todecrypt.stream, todecrypt.stream, &akey);

--- a/src/opencl_fvde_fmt_plug.c
+++ b/src/opencl_fvde_fmt_plug.c
@@ -46,6 +46,7 @@ john_register_one(&fmt_opencl_fvde);
 
 typedef struct {
 	salt_t salt;	// MUST match opencl_pbkdf2_hmac_sha256.cl structure!
+	int type;
 	union {  // wrapped kek
 		uint64_t qword[BLOBLEN/8];
 		uint8_t chr[BLOBLEN];
@@ -158,8 +159,8 @@ static void reset(struct db_main *db)
 		char build_opts[64];
 
 		snprintf(build_opts, sizeof(build_opts),
-		         "-DHASH_LOOPS=%u -DPLAINTEXT_LENGTH=%u",
-		         HASH_LOOPS, PLAINTEXT_LENGTH);
+		         "-DHASH_LOOPS=%u -DPLAINTEXT_LENGTH=%u -DBLOBLEN=%u",
+		         HASH_LOOPS, PLAINTEXT_LENGTH, BLOBLEN);
 		opencl_init("$JOHN/kernels/fvde_kernel.cl",
 		            gpu_id, build_opts);
 
@@ -212,6 +213,7 @@ static void set_salt(void *salt)
 	memcpy(host_salt->blob.qword, cur_salt->blob.qword, BLOBLEN);
 	host_salt->salt.length = cur_salt->salt_length;
 	host_salt->salt.rounds = cur_salt->iterations;
+	host_salt->type = cur_salt->type;
 
 	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_salt,
 		CL_FALSE, 0, sizeof(salt_t2), host_salt, 0, NULL, NULL),

--- a/src/opencl_notes_fmt_plug.c
+++ b/src/opencl_notes_fmt_plug.c
@@ -46,6 +46,7 @@ john_register_one(&fmt_opencl_notes);
 
 typedef struct {
 	salt_t salt;
+	int type;
 	union {  // wrapped kek
 		uint64_t qword[BLOBLEN/8];
 		uint8_t chr[BLOBLEN];
@@ -158,8 +159,8 @@ static void reset(struct db_main *db)
 		char build_opts[64];
 
 		snprintf(build_opts, sizeof(build_opts),
-		         "-DHASH_LOOPS=%u -DPLAINTEXT_LENGTH=%u",
-		         HASH_LOOPS, PLAINTEXT_LENGTH);
+		         "-DHASH_LOOPS=%u -DPLAINTEXT_LENGTH=%u -DBLOBLEN=%u",
+		         HASH_LOOPS, PLAINTEXT_LENGTH, BLOBLEN);
 		opencl_init("$JOHN/kernels/fvde_kernel.cl",
 		            gpu_id, build_opts);
 
@@ -212,6 +213,7 @@ static void set_salt(void *salt)
 	memcpy(host_salt->blob.qword, cur_salt->blob.qword, BLOBLEN);
 	host_salt->salt.length = cur_salt->salt_length;
 	host_salt->salt.rounds = cur_salt->iterations;
+	host_salt->type = cur_salt->type;
 
 	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_salt,
 		CL_FALSE, 0, sizeof(salt_t2), host_salt, 0, NULL, NULL),


### PR DESCRIPTION
This fixes https://github.com/magnumripper/JohnTheRipper/issues/3267 (Modify FVDE mode to accept length 40 blob).

CC @trounce1, can you please test this PR?

Notes,

* Use https://github.com/kholia/apfs2john to extract hashes.

Usage,

```

$ sudo ./bin/apfs-dump-quick /dev/sdc1 log.txt 
Device /dev/sdc1 opened. Size is 1000304128
starting LoadKeybag
 all blocks verified
Volume openwall is encrypted.
starting LoadKeybag
 all blocks verified
Hint: Openwall
starting LoadKeybag
 all blocks verified

!!!!!!!

$fvde$2$16$0d7426917b673738a1e39c987ec0f477$181461$...

!!!!!!!
```

Update: This steps may / may not work for system volumes.