### PR TITLE
AC: Find OpenSSL on macOS Homebrew without any special options.

### DIFF
--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -155,8 +155,8 @@ that probably work fine but these instructions are for "Homebrew":
   2. Install Homebrew's gcc and openssl:
 	brew install gcc openssl
   3. Make sure /usr/local/bin precedes /usr/bin in your $PATH
-  4. Provide the path to GCC and the OpenSSL libraries to the configure script:
-        ./configure CC="gcc-6" CPPFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib"
+  4. Configure, possibly adding a CC option for pointing to a specific gcc:
+        ./configure CC="gcc-6"
   5. Clean old files and make:
         make -s clean && make -sj4
 

--- a/src/configure
+++ b/src/configure
@@ -1418,7 +1418,7 @@ Optional Features:
   --enable-native-march   Use things like -march=native if valid compiler
                           option(s).
   --enable-ln-s           Use ln -s vs symlink.c wrappers (Cygwin only)
-  --disable-pkg-config    do not use pkg-config for any probing tests
+  --enable-pkg-config     use pkg-config for some probing tests
   --enable-nt-full-unicode
                           support 4-byte UTF-8 for MS formats
   --disable-int128        Do not use int128
@@ -3567,7 +3567,7 @@ fi
 if test "${enable_pkg_config+set}" = set; then :
   enableval=$enable_pkg_config; enable_pkg_config=$enableval
 else
-  enable_pkg_config=auto
+  enable_pkg_config=no
 fi
 
 # Check whether --enable-nt-full-unicode was given.
@@ -5247,6 +5247,12 @@ if test -d /usr/local/lib; then
 fi
 if test -d /usr/local/include; then
    ADD_CFLAGS="$ADD_CFLAGS -I/usr/local/include"
+fi
+if test -d /usr/local/opt/openssl/lib; then
+   ADD_LDFLAGS="$ADD_LDFLAGS -L/usr/local/opt/openssl/lib"
+fi
+if test -d /usr/local/opt/openssl/include; then
+   ADD_CFLAGS="$ADD_CFLAGS -I/usr/local/opt/openssl/include"
 fi
 
    for i in $ADD_CFLAGS; do

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -83,7 +83,7 @@ AC_ARG_ENABLE([pcap], [AC_HELP_STRING([--disable-pcap], [Do not build helpers de
 AC_ARG_ENABLE([native-tests], [AC_HELP_STRING([--disable-native-tests], [Do not test build system for target features.])], [enable_native_tests=$enableval], [enable_native_tests=auto])
 AC_ARG_ENABLE([native-march], [AC_HELP_STRING([--enable-native-march], [Use things like -march=native if valid compiler option(s).])], [enable_native_march=$enableval], [enable_native_march=no])
 AC_ARG_ENABLE([ln-s], [AS_HELP_STRING([--enable-ln-s],[Use ln -s vs symlink.c wrappers (Cygwin only)])], [enable_ln_s=$enableval], [enable_ln_s=no])
-AC_ARG_ENABLE([pkg-config], [AS_HELP_STRING([--disable-pkg-config],[do not use pkg-config for any probing tests])], [enable_pkg_config=$enableval], [enable_pkg_config=auto])
+AC_ARG_ENABLE([pkg-config], [AS_HELP_STRING([--enable-pkg-config],[use pkg-config for some probing tests])], [enable_pkg_config=$enableval], [enable_pkg_config=no])
 AC_ARG_ENABLE([nt-full-unicode], [AS_HELP_STRING([--enable-nt-full-unicode],[support 4-byte UTF-8 for MS formats])], [enable_nt_unicode=$enableval], [enable_nt_unicode=no])
 AC_ARG_ENABLE([int128], [AC_HELP_STRING([--disable-int128], [Do not use int128])], [enable_int128=$enableval], [enable_int128=auto])
 AC_ARG_ENABLE([experimental-code], [AC_HELP_STRING([--enable-experimental-code], [Use experimental code])], [experimental=$enableval], [experimental=no])

--- a/src/m4/jtr_utility_macros.m4
+++ b/src/m4/jtr_utility_macros.m4
@@ -112,6 +112,13 @@ fi
 if test -d /usr/local/include; then
    ADD_CFLAGS="$ADD_CFLAGS -I/usr/local/include"
 fi
+dnl macOS Homebrew paths.
+if test -d /usr/local/opt/openssl/lib; then
+   ADD_LDFLAGS="$ADD_LDFLAGS -L/usr/local/opt/openssl/lib"
+fi
+if test -d /usr/local/opt/openssl/include; then
+   ADD_CFLAGS="$ADD_CFLAGS -I/usr/local/opt/openssl/include"
+fi
 JTR_LIST_ADD(CPPFLAGS, [$ADD_CFLAGS]) # no typo here
 jtr_list_add_result=""
 JTR_LIST_ADD(LDFLAGS, [$ADD_LDFLAGS])


### PR DESCRIPTION
To achieve this I had to disable pkg-config by default, because it's broken. Actually I can't remember having seen a non-broken pkg-config in my entire life so it's probably a good thing in most cases but it might break some other system so you'd have to add --enable-pkg-config to the configure options.
This hopefully addresses #2347.

We need to test this on a few places before merging.