### PR TITLE
improvements to md5crypt-ztex, phpass-ztex

### DIFF
--- a/doc/README-ZTEX
+++ b/doc/README-ZTEX
@@ -3,7 +3,7 @@ Overview
 ---------
 If you have ZTEX boards USB-FPGA 1.15y, you can use them with JtR.
 Available "formats" are descrypt-ztex, bcrypt-ztex, sha512crypt-ztex,
-Drupal7-ztex, sha256crypt-ztex, more are planned.
+Drupal7-ztex, sha256crypt-ztex, md5crypt-ztex, phpass-ztex.
 
 -------------
 How to build

--- a/src/ztex/device.c
+++ b/src/ztex/device.c
@@ -95,7 +95,7 @@ static int device_init_fpgas(struct device *device,
 
 	// Frequency
 	if (bitstream->num_progclk) {
-		// Default frequency (for every device)
+		// Default frequency (for every device for given bitstream)
 		cfg_get_int_array(CFG_SECTION, bitstream->label, "Frequency",
 				default_freq, NUM_PROGCLK_MAX);
 
@@ -115,6 +115,8 @@ static int device_init_fpgas(struct device *device,
 	// Runtime configuration packet.
 	// Only subtype 1 is currently supported.
 	// Length is specific to bitstream.
+	// If configuration packet is of incorrect length then
+	// the FPGA would raise an error (app_status=0x08)
 	char conf_name_board_config1[256], conf_name_config1[256];
 	char default_config1[CONFIG_MAX_LEN], board_config1[CONFIG_MAX_LEN];
 	int len_default, len_board, len;

--- a/src/ztex_phpass.c
+++ b/src/ztex_phpass.c
@@ -41,6 +41,9 @@
 
 #define BENCHMARK_COMMENT	""
 
+#undef PLAINTEXT_LENGTH
+#define PLAINTEXT_LENGTH	64
+
 // Partial hash in the database - differs from CPU/GPU implementations
 #undef	BINARY_SIZE
 #define	BINARY_SIZE		4
@@ -63,7 +66,7 @@ static struct device_bitstream bitstream = {
 	1536 * 1024,	// Would be 48 MB of USB traffic on 32-byte keys
 	512,		// Max. number of entries in onboard comparator.
 	384,		// Min. number of keys for effective device utilization
-	1, { 135 },	// Programmable clocks
+	1, { 180 },	// Programmable clocks
 	"phpass",	// label for configuration file
 	"\x01", 1	// Initialization data
 };
@@ -90,7 +93,8 @@ static void init(struct fmt_main *fmt_main)
 
 	if (target_rounds < 512) {
 		fprintf(stderr, "Warning: invalid TargetRounds=%d in john.conf."
-			" Valid values are 1000-999999999\n", target_rounds);
+			" Valid values are 512-1048576, must be power of 2\n",
+			target_rounds);
 		target_rounds = 512;
 	}
 


### PR DESCRIPTION
- Increased PLAINTEXT_LENGTH for phpass-ztex to 64, tested on a hash provided by Solar;
- In md5crypt-ztex, removed dummy "iteration count" tunable cost from a view of a user, let it pass "silently" to fpgas, without a modification of bitstream's application-level input packet processing unified for both "formats";
- Reviewed where it sets programmable clocks' frequency on fpga's "soft" reset (Global Set Reset, GSR).  Internal programmable clock sources (DCMs, PLLs) don't reset with GSR. It sets: if it finds "Frequency" in ```john.conf``` then it sets given frequency, else uses frequency value from ```struct device_bitstream```. Everything seems correct.
- Minor corrections.