### PR TITLE
ztex --test works (also with --mask), displays correct numbers

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -690,6 +690,7 @@ AGAIN:
 		/* format and needs init called to change the name     */
 		if ((format->params.flags & FMT_DYNAMIC) ||
 		    strstr(format->params.label, "-opencl") ||
+		    strstr(format->params.label, "-ztex") ||
 		    !strcmp(format->params.label, "crypt"))
 			fmt_init(format);
 

--- a/src/idle.c
+++ b/src/idle.c
@@ -66,6 +66,8 @@ int idle_requested(struct fmt_main *format)
 	if (strstr(format->params.label, "-opencl"))
 		return 0;
 #endif
+	if (strstr(format->params.label, "-ztex"))
+		return 0;
 
 	return 1;
 }

--- a/src/john.h
+++ b/src/john.h
@@ -41,4 +41,7 @@ extern char *john_terminal_locale;
 /* Current target for options.max_cands */
 extern unsigned long long john_max_cands;
 
+/* Self-test is running */
+extern int self_test_running;
+
 #endif

--- a/src/ztex/device_format.c
+++ b/src/ztex/device_format.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <sys/time.h>
 
+#include "../john.h"
 #include "../loader.h"
 #include "../formats.h"
 #include "../memory.h"
@@ -135,11 +136,12 @@ void device_format_reset()
 	// Mask data is ready, calculate and set keys_per_crypt
 	unsigned int keys_per_crypt;
 
-	if (!bench_running)
+	if (self_test_running)
+		// Self-test runs too long, using different keys_per_crypt
+		keys_per_crypt = jtr_bitstream->test_keys_per_crypt;
+	else
 		keys_per_crypt = jtr_bitstream->candidates_per_crypt
 			 / mask_num_cand();
-	else
-		keys_per_crypt = jtr_bitstream->test_keys_per_crypt;
 
 	if (!keys_per_crypt)
 		keys_per_crypt = 1;
@@ -156,10 +158,12 @@ void device_format_reset()
 
 	jtr_fmt_params->max_keys_per_crypt = keys_per_crypt;
 	jtr_fmt_params->min_keys_per_crypt = keys_per_crypt;
-
-	//fprintf(stderr, "RESET: mask_num_cand():%d keys_per_crypt:%d devs:%d\n",
-	//		mask_num_cand(), jtr_fmt_params->max_keys_per_crypt,jtr_device_list_count());
-
+/*
+	fprintf(stderr, "RESET: mask_num_cand():%d keys_per_crypt:%d devs:%d"
+			" bench:%d self-test:%d\n",
+		mask_num_cand(), jtr_fmt_params->max_keys_per_crypt,
+		jtr_device_list_count(), bench_running, self_test_running);
+*/
 
 	// (re-)allocate keys_buffer, output_key
 	int plaintext_len = jtr_fmt_params->plaintext_length;

--- a/src/ztex_bcrypt.c
+++ b/src/ztex_bcrypt.c
@@ -80,10 +80,10 @@ static struct fmt_tests tests[] = {
 	//	"1E!dpr"},
 	//{"$2a$05$CCCCCCCCCCCCCCCCCCCCC.7uG0VCzI2bS7j6ymqJi9CdcdxiRTWNy",
 	//	""},
-	{"$2a$08$CCCCCCCCCCCCCCCCCCCCC.LuntE/dBezheibpSOXBeR3W7q5mt2NW",
-		">RQ7la"},
 	{"$2b$05$XXXXXXXXXXXXXXXXXXXXXOAcXxm9kjPGEMsLznoKqmqw7tc8WCx4a",
 		"U*U*U"},
+	{"$2a$08$CCCCCCCCCCCCCCCCCCCCC.LuntE/dBezheibpSOXBeR3W7q5mt2NW",
+		">RQ7la"},
 
 	{"$2a$05$/OK.fbVrR/bpIqNJ5ianF.swQOIzjOiJ9GHEPuhEkvqrUyvWhEMx6",
 		"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"

--- a/src/ztex_sha512crypt.c
+++ b/src/ztex_sha512crypt.c
@@ -104,7 +104,9 @@ static struct fmt_tests tests[] = {
 		"QJuesI68u4OTLiBFdcbYEdFCoEOfaS35inz1", "Hello world!"},
 	{"$6$saltstring$thYL/sWXcrctga2PlQjFsvA3l.lG3RPHgk7ADjxkgKZoo0UsYV"
 		"X9gsxryuhCl6RTDsE.0F8aDMaHBkUzUGqd11", "Hello........."},
-
+	{"$6$mwt2GD73BqSk4$ol0oMY1zzm59tnAFnH0OM9R/7SL4gi3VJ42AIVQNcGrYx5S"
+		"1rlZggq5TBqvOGNiNQ0AmjmUMPc.70kL8Lqost.", "password"},
+/*
 	{"$6$rounds=2000$saltSALTsaltSALT$TQ.57CbfxQTWKO8b1rkPVic99auVj.Je"
 		"fhUjAB9YtTXRGiZH.NmgSS04t1WaSLhkTrGxt.Aj61KS0oq46Jpal1",
 		"salt_len=16, key_len=64, contains 8-bit chars ("
@@ -134,6 +136,7 @@ static struct fmt_tests tests[] = {
 	{"$6$rounds=1021$1234567890aBcde$QxJixRbv7Pg4Wdgz7HNwjnGR/QYwMoRe"
 		"d3lHeq8lJKH6UShkNcSmbXwoqYKQkWvdhp9xcikUXD5AKxNwHgZHE.",
 		"sha512crypt-ztex test #5 (salt_len=15, key_len=56) ....."},
+*/
 	{NULL}
 };
 


### PR DESCRIPTION
- New global variable ```int self_test_running``` available in ```john.h``` to distinguish between self-test and benchmark
- Log message "Candidate passwords %s be buffered and tried in chunks of %d" delayed to let  ```mask_init()```, ```fmt_reset()``` be performed first
- Reviewed test vectors in ztex formats