### PR TITLE
various ztex improvements

### DIFF
--- a/src/ztex/device.c
+++ b/src/ztex/device.c
@@ -326,6 +326,9 @@ void device_list_print(struct device_list *device_list)
 {
 	struct device *dev;
 	for (dev = device_list->device; dev; dev = dev->next) {
+		if (!device_valid(dev))
+			continue;
+
 		int num, j;
 		int has_progclk = 0;
 

--- a/src/ztex/device_format.c
+++ b/src/ztex/device_format.c
@@ -1,5 +1,5 @@
 /*
- * This software is Copyright (c) 2016 Denis Burykin
+ * This software is Copyright (c) 2016-2018 Denis Burykin
  * [denis_burykin yahoo com], [denis-burykin2014 yandex ru]
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
@@ -16,11 +16,13 @@
 #include "../memory.h"
 #include "../misc.h"
 #include "../options.h"
+#include "../params.h"
 
 #include "jtr_device.h"
 #include "task.h"
 #include "jtr_mask.h"
 #include "device_bitstream.h"
+#include "device_format.h"
 
 // Problem: Inclusion of ztex.h results in inclusion of libusb-1.0.h
 // which includes more stuff, on Cygwin that results in redefinition
@@ -67,13 +69,16 @@ struct task_list *task_list;
 struct fmt_params *jtr_fmt_params;
 struct device_bitstream *jtr_bitstream;
 struct list_main *jtr_devices_allow;
+int jtr_verbosity;
 
 void device_format_init(struct fmt_main *fmt_main,
-		struct device_bitstream *bitstream, struct list_main *devices_allow)
+		struct device_bitstream *bitstream, struct list_main *devices_allow,
+		int verbosity)
 {
 	jtr_fmt_params = &fmt_main->params;
 	jtr_bitstream = bitstream;
 	jtr_devices_allow = devices_allow;
+	jtr_verbosity = verbosity;
 
 	struct list_entry *entry;
 	int found_bad_sn = 0;
@@ -150,7 +155,8 @@ void device_format_reset()
 	if (keys_per_crypt > jtr_bitstream->abs_max_keys_per_crypt) {
 		keys_per_crypt = jtr_bitstream->abs_max_keys_per_crypt;
 
-		if (!bench_running) // self-test or benchmark
+		// Don't print on self-test, print on benchmark.
+		if (!self_test_running)
 			fprintf(stderr, "Warning: Slow communication channel "\
 				"to the device. "\
 				"Increase mask or expect performance degradation.\n");
@@ -158,12 +164,15 @@ void device_format_reset()
 
 	jtr_fmt_params->max_keys_per_crypt = keys_per_crypt;
 	jtr_fmt_params->min_keys_per_crypt = keys_per_crypt;
-/*
-	fprintf(stderr, "RESET: mask_num_cand():%d keys_per_crypt:%d devs:%d"
-			" bench:%d self-test:%d\n",
-		mask_num_cand(), jtr_fmt_params->max_keys_per_crypt,
-		jtr_device_list_count(), bench_running, self_test_running);
-*/
+
+	if (jtr_verbosity >= VERB_LEGACY) {
+		fprintf(stderr, "RESET: mask:%d keys:%d", mask_num_cand(),
+			jtr_fmt_params->max_keys_per_crypt);
+		if (mask_num_cand() > 1)
+			fprintf(stderr, " (%d)", mask_num_cand()
+				* jtr_fmt_params->max_keys_per_crypt);
+		fprintf(stderr, " devs:%d\n", jtr_device_list_count());
+	}
 
 	// (re-)allocate keys_buffer, output_key
 	int plaintext_len = jtr_fmt_params->plaintext_length;
@@ -209,6 +218,9 @@ void device_format_set_key(char *key, int index)
 
 int device_format_crypt_all(int *pcount, struct db_salt *salt)
 {
+	if (jtr_verbosity > VERB_LEGACY)
+		fprintf(stderr,"crypt_all:%d ",*pcount);
+
 	// * create tasks from keys_buffer, 1 task for each jtr_device
 	// * equally distribute load among tasks assuming all devices are equal
 	// * assign tasks to jtr_devices
@@ -284,8 +296,14 @@ int device_format_crypt_all(int *pcount, struct db_salt *salt)
 	// Dynamic adjustment of max_keys_per_crypt could be a good idea.
 
 	*pcount *= mask_num_cand();
+	int result_count = task_list_result_count(task_list);
 
-	return task_list_result_count(task_list);
+	if (jtr_verbosity > VERB_LEGACY)
+		fprintf(stderr,"result_count:%d\n", result_count);
+
+	task_list_create_index(task_list);
+
+	return result_count;
 }
 
 

--- a/src/ztex/device_format.h
+++ b/src/ztex/device_format.h
@@ -4,7 +4,7 @@
  * Functions to access remote devices such as ZTEX FPGA board
  * for usage in JtR "formats"
  *
- * This software is Copyright (c) 2016 Denis Burykin
+ * This software is Copyright (c) 2016-2018 Denis Burykin
  * [denis_burykin yahoo com], [denis-burykin2014 yandex ru]
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
@@ -17,7 +17,8 @@
 // (re-)initializes hardware.
 // Saves pointers to 'struct fmt_params', 'struct device_bitstream'.
 void device_format_init(struct fmt_main *fmt_main,
-		struct device_bitstream *bitstream, struct list_main *devices_allow);
+		struct device_bitstream *bitstream, struct list_main *devices_allow,
+		int verbosity);
 
 void device_format_done();
 

--- a/src/ztex/jtr_device.c
+++ b/src/ztex/jtr_device.c
@@ -1,5 +1,5 @@
 /*
- * This software is Copyright (c) 2016-2017 Denis Burykin
+ * This software is Copyright (c) 2016-2018 Denis Burykin
  * [denis_burykin yahoo com], [denis-burykin2014 yandex ru]
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without

--- a/src/ztex/task.h
+++ b/src/ztex/task.h
@@ -35,6 +35,12 @@ struct task_result {
 	struct db_password *pw;
 };
 
+struct task_result_list {
+	int count;
+	struct task_result *result_list;
+	struct task_result **index;
+};
+
 struct task {
 	struct task *next;
 	enum task_status status;
@@ -48,7 +54,7 @@ struct task {
 	char *keys;
 	unsigned char *range_info; // NULL if no mask
 
-	struct task_result *result_list;
+	struct task_result_list result_list;
 	struct jtr_device *jtr_device;
 	int id; // ID is 16-bit, unique within jtr_device
 
@@ -63,20 +69,12 @@ struct task_list {
 struct jtr_device_list;
 
 
-// Inserts newly created 'struct task_result'
-// into the list pointed to by task->result
+// Adds newly created 'struct task_result' to task_result_list
 // Copies 'key' inside 'struct task_result', if mask was used
 // then it reconstructs plaintext.
 struct task_result *task_result_new(struct task *task,
 		char *key, unsigned char *range_info,
 		unsigned int gen_id, struct db_password *pw);
-
-// returns the number of results for given task
-int task_result_count(struct task *task);
-
-// deletes all results from task
-void task_result_list_delete(struct task *task);
-
 
 // inserts newly created 'struct task' into 'task_list'
 struct task *task_new(struct task_list *task_list,
@@ -142,6 +140,9 @@ int task_list_result_count(struct task_list *task_list);
 // execute given function for each task_result
 void task_result_execute(struct task_list *task_list,
 		void (*func)(struct task_result *result));
+
+// Creates index, required by task_result_by_index()
+void task_list_create_index(struct task_list *task_list);
 
 // Returns task_result at given index (NULL if none)
 struct task_result *task_result_by_index(struct task_list *task_list, int index);

--- a/src/ztex_bcrypt.c
+++ b/src/ztex_bcrypt.c
@@ -149,7 +149,8 @@ static void init(struct fmt_main *fmt_main)
 	//fprintf(stderr, "bitstream.candidates_per_crypt=%d\n",
 	//		bitstream.candidates_per_crypt);
 
-	device_format_init(fmt_main, &bitstream, options.acc_devices);
+	device_format_init(fmt_main, &bitstream, options.acc_devices,
+		options.verbosity);
 }
 
 // Existing CPU implementation use following data structures:

--- a/src/ztex_descrypt.c
+++ b/src/ztex_descrypt.c
@@ -55,7 +55,7 @@ struct device_bitstream bitstream = {
 	35 * 1024*1024,
 	64 * 1024,		// 64K keys for each FPGA for self-test
 	// Absolute max. keys/crypt_all_interval for all devices.
-	3 * 1024*1024,	// ~24 MB of USB traffic
+	1024*1024,	// ~8 MB of USB traffic
 	// Max. number of entries in onboard comparator.
 	2047,
 	0,	// Min. number of keys (doesn't matter for fast "formats")
@@ -113,7 +113,8 @@ static unsigned char DES_atoi64_bitswapped[128] = {
 static void init(struct fmt_main *fmt_main)
 {
 	DES_std_init(); // Used DES_std.c to perform des_crypt() on CPU
-	device_format_init(fmt_main, &bitstream, options.acc_devices);
+	device_format_init(fmt_main, &bitstream, options.acc_devices,
+		options.verbosity);
 }
 
 

--- a/src/ztex_drupal7.c
+++ b/src/ztex_drupal7.c
@@ -61,7 +61,6 @@ static int target_rounds;
 
 static void init(struct fmt_main *fmt_main)
 {
-//printf("verbosity (init):%d\n", options.verbosity);
 	// It uses performance estimation (bitstream.candidates_per_crypt)
 	// to calculate keys_per_crypt. Performance depends on count of rounds.
 	// Count is not available in init() and can change at runtime.
@@ -96,8 +95,8 @@ static void init(struct fmt_main *fmt_main)
 	//fprintf(stderr, "bitstream.candidates_per_crypt=%d\n",
 	//		bitstream.candidates_per_crypt);
 
-	device_format_init(fmt_main, &bitstream, options.acc_devices);//,
-		//options.verbosity);
+	device_format_init(fmt_main, &bitstream, options.acc_devices,
+		options.verbosity);
 }
 
 

--- a/src/ztex_md5crypt.c
+++ b/src/ztex_md5crypt.c
@@ -66,9 +66,9 @@ static struct device_bitstream bitstream = {
 	{ 2, 14336, 4094 },
 	// computing performance estimation (in candidates per interval)
 	// (keys * mask_num_cand)/crypt_all_interval per jtr_device.
-	230400,		// keys/fpga for crypt_all()
+	147456,		// keys/fpga for crypt_all()
 	16384,		// keys/fpga for self-test
-	1536 * 1024,	// Would be 48 MB of USB traffic on 32-byte keys
+	460800,		// Would be ~15 MB of USB traffic on 32-byte keys
 	512,		// Max. number of entries in onboard comparator.
 	384,		// Min. number of keys for effective device utilization
 	1, { 180 },	// Programmable clocks
@@ -106,10 +106,8 @@ static struct fmt_tests tests[] = {
 
 static void init(struct fmt_main *fmt_main)
 {
-//printf("verbosity (init):%d\n", options.verbosity);
-
-	device_format_init(fmt_main, &bitstream, options.acc_devices);//,
-		//options.verbosity);
+	device_format_init(fmt_main, &bitstream, options.acc_devices,
+		options.verbosity);
 }
 
 

--- a/src/ztex_phpass.c
+++ b/src/ztex_phpass.c
@@ -62,8 +62,8 @@ static struct device_bitstream bitstream = {
 	// computing performance estimation (in candidates per interval)
 	// (keys * mask_num_cand)/crypt_all_interval per jtr_device.
 	1,		// keys/fpga for crypt_all(): set by init()
-	4096,	// keys/fpga for self-test
-	1536 * 1024,	// Would be 48 MB of USB traffic on 32-byte keys
+	8192,	// keys/fpga for self-test
+	460800,	// Would be ~15 MB of USB traffic on 32-byte keys
 	512,		// Max. number of entries in onboard comparator.
 	384,		// Min. number of keys for effective device utilization
 	1, { 180 },	// Programmable clocks
@@ -76,7 +76,6 @@ static int target_rounds;
 
 static void init(struct fmt_main *fmt_main)
 {
-//printf("verbosity (init):%d\n", options.verbosity);
 	//
 	// It gets TargetRounds from john.conf and adjust
 	// bitstream.candidates_per_crypt.
@@ -84,7 +83,7 @@ static void init(struct fmt_main *fmt_main)
 	// Starting from TARGET_ROUNDS_1KPC, it sets keys_per_crypt
 	// equal to bitstream.min_keys
 	//
-	const int TARGET_ROUNDS_1KPC = 512*1024;
+	const int TARGET_ROUNDS_1KPC = 256*1024;
 
 	target_rounds = cfg_get_int("ZTEX:", bitstream.label,
 			"TargetRounds");
@@ -104,8 +103,8 @@ static void init(struct fmt_main *fmt_main)
 		bitstream.candidates_per_crypt = bitstream.min_keys
 			* (2 * TARGET_ROUNDS_1KPC / target_rounds);
 
-	device_format_init(fmt_main, &bitstream, options.acc_devices);//,
-		//options.verbosity);
+	device_format_init(fmt_main, &bitstream, options.acc_devices,
+		options.verbosity);
 }
 
 

--- a/src/ztex_sha256crypt.c
+++ b/src/ztex_sha256crypt.c
@@ -75,8 +75,8 @@ static struct device_bitstream bitstream = {
 	// computing performance estimation (in candidates per interval)
 	// (keys * mask_num_cand)/crypt_all_interval per jtr_device.
 	1,			// set by init() base on john.conf setting
-	2048,		// 2K keys/fpga for self-test
-	1536 * 1024,	// Would be 48 MB of USB traffic on 32-byte keys
+	4096,		// keys/fpga for self-test
+	600 * 1024,	// Would be ~20 MB of USB traffic on 32-byte keys
 	512,		// Max. number of entries in onboard comparator.
 	150,		// Min. number of keys for effective device utilization
 	1, { 135 },	// Programmable clocks
@@ -257,7 +257,6 @@ static int target_rounds;
 
 static void init(struct fmt_main *fmt_main)
 {
-//printf("verbosity (init):%d\n", options.verbosity);
 	// It uses performance estimation (bitstream.candidates_per_crypt)
 	// to calculate keys_per_crypt. Performance depends on count of rounds.
 	// Count is not available in init() and can change at runtime.
@@ -292,8 +291,8 @@ static void init(struct fmt_main *fmt_main)
 	//fprintf(stderr, "bitstream.candidates_per_crypt=%d\n",
 	//		bitstream.candidates_per_crypt);
 
-	device_format_init(fmt_main, &bitstream, options.acc_devices);//,
-		//options.verbosity);
+	device_format_init(fmt_main, &bitstream, options.acc_devices,
+		options.verbosity);
 }
 
 

--- a/src/ztex_sha512crypt.c
+++ b/src/ztex_sha512crypt.c
@@ -106,7 +106,17 @@ static struct fmt_tests tests[] = {
 		"X9gsxryuhCl6RTDsE.0F8aDMaHBkUzUGqd11", "Hello........."},
 	{"$6$mwt2GD73BqSk4$ol0oMY1zzm59tnAFnH0OM9R/7SL4gi3VJ42AIVQNcGrYx5S"
 		"1rlZggq5TBqvOGNiNQ0AmjmUMPc.70kL8Lqost.", "password"},
+	{"$6$gcN9vA21h3pQXatk$Mwe3tKbnAiL1AwaaER1.kPRsEIZx0SZNoPnqgbnsu"
+		"FG9TOXq6SHhfTvTnok32fqJn9pl6KHKz8gFn2uDshVia1", "key_len8"},
+	{"$6$PryKgHgxITDskF2A$V0pUS/Sr5E3zSwFNJyQoGRNcJXTXfR5zm31ga1aji"
+		"P.gsNG9dvImnqjtyh5Ph/h6DfnyrUi5ZdFDFMpAC2Dep.", "123"},
+	{"$6$ZD5KgeC9I.JGkMLw$wsw5ii8e5TtuVZIrD6i9nglLkya33DbXYLHGeLYuL"
+		"3Tp/pMpQAN6wq6utTlRYdnZPtVmU6VEsrvF/mtvYPpQL.", "ab"},
 /*
+	{"$6$EG5klJHV.nDaIb8U$UOJg2Fr3xQh6h8o8eoDMHUPRV65PPCo0ObRNzLKR4u61"
+		"ey1hHvFeowIm6oxdlLj4LxH6CN.DPXW4NHh0hYUwP1", "key_length=13"},
+	{"$6$4r7KJHHVwndsyF0m$OX4XwClhVI8TiHf02Olhh37/XFD03mQ0lU1rsfUJhG/Y"
+		"Xtf418M59Cmy3NhSUAUzfU3Z0QSuWtdoqh0VrNpJk.", "key_length=15//"},
 	{"$6$rounds=2000$saltSALTsaltSALT$TQ.57CbfxQTWKO8b1rkPVic99auVj.Je"
 		"fhUjAB9YtTXRGiZH.NmgSS04t1WaSLhkTrGxt.Aj61KS0oq46Jpal1",
 		"salt_len=16, key_len=64, contains 8-bit chars ("
@@ -184,7 +194,6 @@ int target_rounds;
 
 static void init(struct fmt_main *fmt_main)
 {
-//printf("verbosity (init):%d\n", options.verbosity);
 	// It uses performance estimation (bitstream.candidates_per_crypt)
 	// to calculate keys_per_crypt. Performance depends on count of rounds.
 	// Count is not available in init() and can change at runtime.
@@ -219,8 +228,8 @@ static void init(struct fmt_main *fmt_main)
 	//fprintf(stderr, "bitstream.candidates_per_crypt=%d\n",
 	//		bitstream.candidates_per_crypt);
 
-	device_format_init(fmt_main, &bitstream, options.acc_devices);//,
-		//options.verbosity);
+	device_format_init(fmt_main, &bitstream, options.acc_devices,
+		options.verbosity);
 }
 
 


### PR DESCRIPTION
- Use of verbosity. With -v=4 it prints mask size, keys_per_crypt on ```reset()```. With -v=5 it prints every ```crypt_all``` call with result count.
- Indexing the list of results (```struct task_result_list```) collected in ```crypt_all()```. With ```--test```, ```--test_full=1``` it sometimes (on a pseudo-random fashion) returns large number of results, sometimes >60K in 1 crypt_all, unless indexed it looks like it hangs (takes tens of seconds of CPU time to process).
- Reviewed parameters in some ztex format to better fit tests. Still there're questions - if tests properly represent various real uses and corner cases? And it also raises questions on how tests operate, e.g. for sha512crypt-ztex ```test-full=1``` runs crypt_all with max.number of keys 10 times, for Drupal7-ztex 4 times, for phpass-ztex 32 times.  
