### PR TITLE
Add support for cracking SolarWinds Orion hashes

### DIFF
--- a/src/opencl/solarwinds_kernel.cl
+++ b/src/opencl/solarwinds_kernel.cl
@@ -1,0 +1,94 @@
+/*
+ * OpenCL kernel for SolarWinds Orion hashes.
+ *
+ * This software is  Copyright (c) 2018 Dhiru Kholia, Copyright (c) 2017
+ * magnum, and it is hereby released to the general public under the following
+ * terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#define MAYBE_CONSTANT __global
+#include "opencl_sha2_ctx.h"
+#include "pbkdf2_hmac_sha1_kernel.cl"
+
+typedef struct {
+	union {
+		uint w[((OUTLEN + 19) / 20) * 20 / sizeof(uint)];
+		uchar c[((OUTLEN + 19) / 20) * 20];
+	} key;
+} solarwinds_out;
+
+typedef struct {
+	uchar hash[12];
+} solarwinds_final_out;
+
+typedef struct {
+	uint  length;
+	uint  outlen;
+	uint  iters;
+	uchar salt[8];
+} solarwinds_salt;
+
+__kernel
+void solarwinds_loop(MAYBE_CONSTANT solarwinds_salt *salt,
+                  __global solarwinds_out *out,
+                  __global pbkdf2_state *state)
+{
+	uint gid = get_global_id(0);
+	uint i;
+#if !OUTLEN || OUTLEN > 20
+	uint base = state[gid].pass++ * 5;
+	uint pass = state[gid].pass;
+#else
+#define base 0
+#define pass 1
+#endif
+#ifndef OUTLEN
+#define OUTLEN salt->outlen
+#endif
+
+	// First/next 20 bytes of output
+	for (i = 0; i < 5; i++)
+		out[gid].key.w[base + i] = SWAP32(state[gid].out[i]);
+
+	/* Was this the last pass? If not, prepare for next one */
+	if (4 * base + 20 < OUTLEN) {
+		_phsk_hmac_sha1(state[gid].out, state[gid].ipad, state[gid].opad,
+		                salt->salt, salt->length, 1 + pass);
+
+		for (i = 0; i < 5; i++)
+			state[gid].W[i] = state[gid].out[i];
+
+#ifndef ITERATIONS
+		state[gid].iter_cnt = salt->iterations - 1;
+#endif
+	} else {
+		union {
+			uchar c[8192 / 8];
+			uint  w[8192 / 8 / 4];
+		} hash;
+
+		unsigned char output[64];
+
+		SHA512_CTX ctx;
+
+		for (i = 0; i < 8192/8/4; i++)
+			hash.w[i] = out[gid].key.w[i];
+
+		SHA512_Init(&ctx);
+		SHA512_Update(&ctx, hash.c, 1024);
+		SHA512_Final(output, &ctx);
+
+		memcpy_macro(out[gid].key.c, output, 64);
+	}
+}
+
+__kernel
+void solarwinds_final(__global solarwinds_out *out,  __global solarwinds_final_out *final_out)
+{
+	uint gid = get_global_id(0);
+
+	memcpy_macro(final_out[gid].hash, out[gid].key.c, 12);
+}

--- a/src/opencl_solarwinds_fmt_plug.c
+++ b/src/opencl_solarwinds_fmt_plug.c
@@ -1,0 +1,368 @@
+/*
+ * JtR OpenCL format to crack SolarWinds Orion hashes.
+ *
+ * This software is Copyright (c) 2018, Dhiru Kholia <dhiru at openwall.com>,
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * The OpenCL boilerplate code is borrowed from other OpenCL formats.
+ */
+
+#ifdef HAVE_OPENCL
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_opencl_solarwinds;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_opencl_solarwinds);
+#else
+
+#include <stdint.h>
+#include <string.h>
+
+#include "aes.h"
+#include "arch.h"
+#include "formats.h"
+#include "common.h"
+#include "solarwinds_common.h"
+#include "options.h"
+#include "jumbo.h"
+#include "opencl_common.h"
+#include "misc.h"
+#define OUTLEN                  1024
+#define PLAINTEXT_LENGTH        28
+#include "opencl_pbkdf2_hmac_sha1.h"
+
+#define FORMAT_LABEL            "solarwinds-opencl"
+#define OCL_ALGORITHM_NAME      "PBKDF2-SHA1 OpenCL"
+#define ALGORITHM_NAME          OCL_ALGORITHM_NAME
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        -1
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+
+#define BINARY_SIZE             64
+#define BINARY_ALIGN            MEM_ALIGN_WORD
+#define SALT_SIZE               sizeof(*cur_salt)
+#define SALT_ALIGN              MEM_ALIGN_WORD
+
+/* This handles all widths */
+#define GETPOS(i, index)        (((index) % ocl_v_width) * 4 + ((i) & ~3U) * ocl_v_width + (((i) & 3) ^ 3) + ((index) / ocl_v_width) * 64 * ocl_v_width)
+
+static struct custom_salt *cur_salt;
+
+typedef struct {
+	unsigned int key[((OUTLEN + 19) / 20) * 20 / sizeof(uint32_t)];
+} solarwinds_out;
+
+typedef struct {
+	unsigned char hash[12];
+} solarwinds_final_out;
+
+typedef struct {
+	unsigned int  length;
+	unsigned int  outlen;
+	unsigned int  iterations;
+	unsigned char salt[8];
+} solarwinds_salt;
+
+static size_t key_buf_size, outsize, final_outsize;
+static unsigned int *inbuffer;
+static solarwinds_out *output;
+static solarwinds_final_out *final_output;
+static solarwinds_salt currentsalt;
+static cl_mem mem_in, mem_out, mem_salt, mem_state, mem_final_out;
+static size_t key_buf_size;
+static int new_keys;
+static struct fmt_main *self;
+static cl_kernel pbkdf2_init, pbkdf2_loop, solarwinds_loop, solarwinds_final;
+
+/*
+ * HASH_LOOPS is ideally made by factors of (iteration count - 1) and should
+ * be chosen for a kernel duration of not more than 200 ms
+ */
+#define HASH_LOOPS              (333)
+#define ITERATIONS              1000
+#define LOOP_COUNT              (((currentsalt.iterations - 1 + HASH_LOOPS - 1)) / HASH_LOOPS)
+#define STEP                    0
+#define SEED                    128
+
+static const char * warn[] = {
+	"P xfer: "  ,  ", init: "   , ", loop: " , ", final: ", ", res xfer: "
+};
+
+static int split_events[] = { 2, -1, -1 };
+
+// This file contains auto-tuning routine(s). Has to be included after formats definitions.
+#include "opencl_autotune.h"
+#include "memdbg.h"
+
+/* ------- Helper functions ------- */
+static size_t get_task_max_work_group_size()
+{
+	size_t s;
+
+	s = autotune_get_task_max_work_group_size(FALSE, 0, pbkdf2_init);
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, pbkdf2_loop));
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, solarwinds_loop));
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, solarwinds_final));
+	return s;
+}
+
+#if 0
+struct fmt_main *me;
+#endif
+
+static void create_clobj(size_t gws, struct fmt_main *self)
+{
+	key_buf_size = 64 * gws;
+	outsize = sizeof(solarwinds_out) * gws;
+	final_outsize = sizeof(solarwinds_final_out) * gws;
+
+	// Allocate memory
+	inbuffer = mem_calloc(1, key_buf_size);
+	output = mem_alloc(outsize);
+	final_output = mem_alloc(final_outsize);
+
+	mem_in = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, key_buf_size, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem in");
+	mem_salt = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, sizeof(solarwinds_salt), NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem setting");
+	mem_out = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE, outsize, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem out");
+	mem_final_out = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE, final_outsize, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem final out");
+	mem_state = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE, sizeof(pbkdf2_state) * gws, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error allocating mem_state");
+
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_init, 0, sizeof(mem_in), &mem_in), "Error while setting mem_in kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_init, 1, sizeof(mem_salt), &mem_salt), "Error while setting mem_salt kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_init, 2, sizeof(mem_state), &mem_state), "Error while setting mem_state kernel argument");
+
+	HANDLE_CLERROR(clSetKernelArg(pbkdf2_loop, 0, sizeof(mem_state), &mem_state), "Error while setting mem_state kernel argument");
+
+	HANDLE_CLERROR(clSetKernelArg(solarwinds_loop, 0, sizeof(mem_salt), &mem_salt), "Error while setting mem_salt kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(solarwinds_loop, 1, sizeof(mem_out), &mem_out), "Error while setting mem_out kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(solarwinds_loop, 2, sizeof(mem_state), &mem_state), "Error while setting mem_state kernel argument");
+
+	HANDLE_CLERROR(clSetKernelArg(solarwinds_final, 0, sizeof(mem_out), &mem_out), "Error while setting mem_out kernel argument");
+	HANDLE_CLERROR(clSetKernelArg(solarwinds_final, 1, sizeof(mem_final_out), &mem_final_out), "Error while setting mem_final_out kernel argument");
+}
+
+static void release_clobj(void)
+{
+	if (output) {
+		HANDLE_CLERROR(clReleaseMemObject(mem_in), "Release mem in");
+		HANDLE_CLERROR(clReleaseMemObject(mem_salt), "Release mem setting");
+		HANDLE_CLERROR(clReleaseMemObject(mem_state), "Release mem state");
+		HANDLE_CLERROR(clReleaseMemObject(mem_out), "Release mem out");
+		HANDLE_CLERROR(clReleaseMemObject(mem_final_out), "Release mem final out");
+
+		MEM_FREE(inbuffer);
+		MEM_FREE(output);
+	}
+}
+
+static void done(void)
+{
+	if (autotuned) {
+		release_clobj();
+
+		HANDLE_CLERROR(clReleaseKernel(pbkdf2_init), "Release kernel");
+		HANDLE_CLERROR(clReleaseKernel(pbkdf2_loop), "Release kernel");
+		HANDLE_CLERROR(clReleaseKernel(solarwinds_loop), "Release kernel");
+		HANDLE_CLERROR(clReleaseKernel(solarwinds_final), "Release kernel");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program");
+
+		autotuned--;
+	}
+}
+
+static void init(struct fmt_main *_self)
+{
+	self = _self;
+
+	opencl_prepare_dev(gpu_id);
+}
+
+static void reset(struct db_main *db)
+{
+	if (!autotuned) {
+		char build_opts[96];
+
+		snprintf(build_opts, sizeof(build_opts),
+		         "-DHASH_LOOPS=%u -DOUTLEN=%u "
+		         "-DPLAINTEXT_LENGTH=%u -DITERATIONS=%u",
+		         HASH_LOOPS, OUTLEN, PLAINTEXT_LENGTH, ITERATIONS - 1);
+		opencl_init("$JOHN/kernels/solarwinds_kernel.cl", gpu_id, build_opts);
+
+		pbkdf2_init = clCreateKernel(program[gpu_id], "pbkdf2_init", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+		crypt_kernel = pbkdf2_loop = clCreateKernel(program[gpu_id], "pbkdf2_loop", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+		solarwinds_loop = clCreateKernel(program[gpu_id], "solarwinds_loop", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+		solarwinds_final = clCreateKernel(program[gpu_id], "solarwinds_final", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+
+		// Initialize openCL tuning (library) for this format.
+		opencl_init_auto_setup(SEED, 2 * HASH_LOOPS, split_events,
+		                       warn, 2, self, create_clobj,
+		                       release_clobj,
+		                       sizeof(pbkdf2_state), 0, db);
+
+		// Auto tune execution from shared/included code.
+		autotune_run(self, 2 * (ITERATIONS - 1) + 4, 0, 200);
+	}
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (struct custom_salt *)salt;
+
+	/* PBKDF2 */
+	memcpy((char*)currentsalt.salt, cur_salt->salt, 8);
+	currentsalt.length = 8;
+	currentsalt.iterations = 1000;
+	currentsalt.outlen = 1024;
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_salt, CL_FALSE, 0,
+		sizeof(solarwinds_salt), &currentsalt, 0, NULL, NULL), "Copy salt to gpu");
+}
+
+static void clear_keys(void)
+{
+	memset(inbuffer, 0, key_buf_size);
+}
+
+static void solarwinds_set_key(char *key, int index)
+{
+	int i;
+	int length = strlen(key);
+
+	for (i = 0; i < length; i++)
+		((char*)inbuffer)[GETPOS(i, index)] = key[i];
+
+	new_keys = 1;
+}
+
+static char *get_key(int index)
+{
+	static char ret[PLAINTEXT_LENGTH + 1];
+	int i = 0;
+
+	while (i < PLAINTEXT_LENGTH &&
+	       (ret[i] = ((char*)inbuffer)[GETPOS(i, index)]))
+		i++;
+	ret[i] = 0;
+
+	return ret;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int i, j;
+	size_t *lws = local_work_size ? &local_work_size : NULL;
+
+	global_work_size = GET_MULTIPLE_OR_BIGGER_VW(count, local_work_size);
+
+	// Copy data to gpu
+	if (ocl_autotune_running || new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
+		new_keys = 0;
+	}
+
+	// Run kernels
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], pbkdf2_init, 1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]), "Run initial kernel");
+
+	for (j = 0; j < (ocl_autotune_running ? 1 : (currentsalt.outlen + 19) / 20); j++) {
+		for (i = 0; i < (ocl_autotune_running ? 1 : LOOP_COUNT); i++) {
+			BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], pbkdf2_loop, 1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[2]), "Run loop kernel");
+			BENCH_CLERROR(clFinish(queue[gpu_id]), "Error running loop kernel");
+			opencl_process_event();
+		}
+
+		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], solarwinds_loop, 1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[3]), "Run intermediate kernel");
+	}
+
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], solarwinds_final, 1, NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[4]), "Run final kernel");
+
+	// Read the result back
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_final_out, CL_TRUE, 0, final_outsize, final_output, 0, NULL, multi_profilingEvent[5]), "Copy result back");
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (!memcmp(binary, final_output[index].hash, ARCH_SIZE))
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, final_output[index].hash, 12);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main fmt_opencl_solarwinds = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT,
+		{ NULL },
+		{ FORMAT_TAG },
+		solarwinds_tests
+	}, {
+		init,
+		done,
+		reset,
+		fmt_default_prepare,
+		solarwinds_valid,
+		fmt_default_split,
+		solarwinds_get_binary,
+		solarwinds_get_salt,
+		{ NULL },
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		solarwinds_set_key,
+		get_key,
+		clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */
+
+#endif /* HAVE_OPENCL */

--- a/src/solarwinds_common.h
+++ b/src/solarwinds_common.h
@@ -1,0 +1,26 @@
+/*
+ * Common code for the SolarWinds Orion format.
+ *
+ * This file takes replicated but common code, shared between the CPU
+ * and the GPU formats, and places it into one common location.
+ */
+
+#include "formats.h"
+
+#define FORMAT_NAME             "SolarWinds Orion"
+#define FORMAT_TAG              "$solarwinds$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+
+#define BINARY_SIZE             64
+#define SALT_PADDING            "1244352345234"
+
+extern struct fmt_tests solarwinds_tests[];
+
+struct custom_salt {
+	char username[64+1];
+	char salt[8+1];
+};
+
+int solarwinds_valid(char *ciphertext, struct fmt_main *self);
+void *solarwinds_get_salt(char *ciphertext);
+void *solarwinds_get_binary(char *ciphertext);

--- a/src/solarwinds_common_plug.c
+++ b/src/solarwinds_common_plug.c
@@ -1,0 +1,88 @@
+/*
+ * Common code for the SolarWinds Orion format.
+ */
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "base64_convert.h"
+#include "solarwinds_common.h"
+#include "memdbg.h"
+
+#define HASH_LENGTH 88
+
+struct fmt_tests solarwinds_tests[] = {
+        {"$solarwinds$0$admin$/+PA4Zck3arkLA7iwWIugnAEoq4ocRsYjF7lzgQWvJc+pepPz2a5z/L1Pz3c366Y/CasJIa7enKFDPJCWNiKRg==", ""},
+        {"$solarwinds$0$admin$5BqFpldsj5H9nbkkLjB+Cdi7WCXiUp5zBpO9Xs7/MKnnQAI0IE9gH+58LlS7/+a/7x1wWScI2iCGEtukgTiNeA==", "letmein"},
+        {NULL}
+};
+
+int solarwinds_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *keeptr, *p;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+		return 0;
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LEN;
+	if ((p = strtokm(ctcopy, "$")) == NULL)	/* version */
+		goto err;
+	if (atoi(p) != 0)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL) /* username */
+		goto err;
+	if (strlen(p) > 64)
+		goto err;
+	if ((p = strtokm(NULL, "$")) == NULL) /* hash */
+		goto err;
+
+	if (strlen(p)-2 != base64_valid_length(p,e_b64_mime,flg_Base64_MIME_TRAIL_EQ, 0) || strlen(p)-1 > HASH_LENGTH-1)
+                goto err;
+
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *solarwinds_get_binary(char *ciphertext)
+{
+        static union {
+                unsigned char c[BINARY_SIZE];
+                uint32_t dummy;
+        } buf;
+        unsigned char *out = buf.c;
+        char *p;
+
+	memset(buf.c, 0, BINARY_SIZE);
+
+        p = strrchr(ciphertext, '$') + 1;
+        base64_convert(p, e_b64_mime, strlen(p), (char*)out, e_b64_raw, sizeof(buf.c), flg_Base64_DONOT_NULL_TERMINATE, 0);
+
+        return out;
+}
+
+void *solarwinds_get_salt(char *ciphertext)
+{
+	static struct custom_salt cs;
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	char *p;
+
+	memset(&cs, 0, sizeof(cs));
+
+	ctcopy += FORMAT_TAG_LEN;
+        p = strtokm(ctcopy, "$");
+        p = strtokm(NULL, "$");
+
+	strncpy(cs.salt, p, 8);
+
+	if (strlen(p) < 8)
+		strncat(cs.salt, SALT_PADDING, 8 - strlen(cs.salt));
+
+	MEM_FREE(keeptr);
+	return (void *)&cs;
+}

--- a/src/solarwinds_fmt_plug.c
+++ b/src/solarwinds_fmt_plug.c
@@ -1,0 +1,208 @@
+/*
+ * JtR format to crack SolarWinds Orion hashes.
+ *
+ * These hashes can be dumped from the "Accounts" table.
+ *
+ * This software is Copyright (c) 2018, Dhiru Kholia <dhiru at openwall.com>,
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted.
+ *
+ * References:
+ *
+ * + https://github.com/atredispartners/solarwinds-orion-cryptography
+ *
+ * + https://www.atredis.com/blog/2018/10/24/fun-with-the-solarwinds-orion-platform
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_solarwinds;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_solarwinds);
+#else
+
+#include <string.h>
+#include <stdint.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#define OMP_SCALE               1  // MKPC and OMP_SCALE tuned on Core i5-6500
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "options.h"
+#include "sha.h"
+#include "jumbo.h"
+#include "johnswap.h"
+#include "solarwinds_common.h"
+#include "pbkdf2_hmac_sha1.h"
+#include "memdbg.h"
+
+#define FORMAT_LABEL         "solarwinds"
+#ifdef SIMD_COEF_32
+#define ALGORITHM_NAME       "PBKDF2-SHA1 " SHA1_ALGORITHM_NAME
+#else
+#define ALGORITHM_NAME       "PBKDF2-SHA1 32/" ARCH_BITS_STR
+#endif
+#define BENCHMARK_COMMENT    ""
+#define BENCHMARK_LENGTH     -1
+#define PLAINTEXT_LENGTH     125
+#define BINARY_ALIGN         4
+#define SALT_SIZE            sizeof(struct custom_salt)
+#define SALT_ALIGN           sizeof(unsigned int)
+#ifdef SIMD_COEF_32
+#define MIN_KEYS_PER_CRYPT   SSE_GROUP_SZ_SHA1
+#define MAX_KEYS_PER_CRYPT   SSE_GROUP_SZ_SHA1
+#else
+#define MIN_KEYS_PER_CRYPT   1
+#define MAX_KEYS_PER_CRYPT   1
+#endif
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+
+static struct custom_salt *cur_salt;
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+
+	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
+	crypt_out = mem_calloc(sizeof(*crypt_out), self->params.max_keys_per_crypt);
+}
+
+static void done(void)
+{
+	MEM_FREE(saved_key);
+	MEM_FREE(crypt_out);
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = (struct custom_salt *)salt;
+}
+
+static void solarwinds_set_key(char *key, int index)
+{
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index += MAX_KEYS_PER_CRYPT) {
+		unsigned char master[MAX_KEYS_PER_CRYPT][1024];
+		int i;
+
+#ifdef SIMD_COEF_32
+		int len[MAX_KEYS_PER_CRYPT];
+		unsigned char *pin[MAX_KEYS_PER_CRYPT], *pout[MAX_KEYS_PER_CRYPT];
+		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i) {
+			len[i] = strlen(saved_key[i+index]);
+			pin[i] = (unsigned char*)saved_key[i+index];
+			pout[i] = master[i];
+		}
+		pbkdf2_sha1_sse((const unsigned char **)pin, len, (unsigned char *)cur_salt->salt, 8, 1000, pout, 1024, 0);
+#else
+		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i)
+			pbkdf2_sha1((unsigned char *)saved_key[index+i], strlen(saved_key[index+i]),
+				(unsigned char *)cur_salt->salt, 8, 1000, master[i], 1024, 0);
+#endif
+		for (i = 0; i < MAX_KEYS_PER_CRYPT; ++i) {
+			SHA512_CTX ctx;
+
+			SHA512_Init(&ctx);
+			SHA512_Update(&ctx, master[i], 1024);
+			SHA512_Final((unsigned char*)crypt_out[index+i], &ctx);
+		}
+	}
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (((uint32_t*)binary)[0] == crypt_out[index][0])
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], 12);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main fmt_solarwinds = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		{ NULL },
+		{ FORMAT_TAG },
+		solarwinds_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		solarwinds_valid,
+		fmt_default_split,
+		solarwinds_get_binary,
+		solarwinds_get_salt,
+		{ NULL },
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		solarwinds_set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */


### PR DESCRIPTION
Current speed,

```
$ ../run/john --format=solarwinds-opencl --test
Device 6: GeForce GTX TITAN X
Benchmarking: solarwinds-opencl, SolarWinds Orion [PBKDF2-SHA1 OpenCL]... DONE
Raw:	45936 c/s real, 46369 c/s virtual, GPU util: 99%
```

CPU speed,

```
$ ../run/john --format=solarwinds --test
Will run 32 OpenMP threads
Benchmarking: solarwinds, SolarWinds Orion [PBKDF2-SHA1 128/128 AVX 4x]... (32xOMP) DONE
Raw:	3200 c/s real, 103 c/s virtual
```

The GPU utilization percentage is decent.