### PR TITLE
format openssl-enc. Implement ascii percentage check.

### DIFF
--- a/run/openssl2john.py
+++ b/run/openssl2john.py
@@ -21,7 +21,7 @@ from binascii import hexlify
 PY3 = sys.version_info[0] == 3
 
 
-def process(filename, plaintext=None, cipher=0, md=0):
+def process(filename, plaintext=None, cipher=0, md=0, minascii=0):
 
     with open(filename, "rb") as f:
         data = f.read()
@@ -51,6 +51,8 @@ def process(filename, plaintext=None, cipher=0, md=0):
             last_chunk = data[-16:]
             if plaintext:
                 s = "1$%s" % plaintext
+            elif minascii:
+                s = "2$%d" % minascii
             else:
                 s = "0"
             last_chunk = hexlify(last_chunk)
@@ -64,6 +66,8 @@ def process(filename, plaintext=None, cipher=0, md=0):
             rdata = data[16:16*17]
             if plaintext:
                 s = "1$%s" % plaintext
+            elif minascii:
+                s = "2$%d" % minascii
             else:
                 s = "0"
             last_chunk = hexlify(last_chunk)
@@ -80,17 +84,19 @@ def process(filename, plaintext=None, cipher=0, md=0):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        sys.stderr.write("Usage: %s [-c cipher] [-m md] [-p plaintext] <OpenSSL encrypted files>\n" % sys.argv[0])
+        sys.stderr.write("Usage: %s [-c cipher] [-m md] [-p plaintext] [-a ascii_pct] <OpenSSL encrypted files>\n" % sys.argv[0])
         sys.stderr.write("\ncipher: 0 => aes-256-cbc, 1 => aes-128-cbc\n")
         sys.stderr.write("md: 0 => md5, 1 => sha1, 2 => sha256\n")
+        sys.stderr.write("ascii_pct: minimum ascii percent (1-100) on decrypted output (ignored if plaintext present)\n")
         sys.stderr.write("\nOpenSSL 1.1.0e uses aes-256-cbc with sha256\n")  # See "apps/enc.c" in OpenSSL
         sys.exit(-1)
 
     parser = optparse.OptionParser()
     parser.add_option('-p', action="store", dest="plaintext")
+    parser.add_option('-a', action="store", dest="minascii", type="int", default=0)
     parser.add_option('-c', action="store", dest="cipher", default=0)
     parser.add_option('-m', action="store", dest="md", default=0)
     options, remainder = parser.parse_args()
 
     for j in range(0, len(remainder)):
-        process(remainder[j], options.plaintext, options.cipher, options.md)
+        process(remainder[j], options.plaintext, options.cipher, options.md, options.minascii)

--- a/src/openssl_enc_fmt_plug.c
+++ b/src/openssl_enc_fmt_plug.c
@@ -88,6 +88,7 @@ static struct custom_salt {
 	int kpa;
 	int datalen;
 	unsigned char kpt[256];
+	int asciipct;
 	unsigned char data[1024];
 	unsigned char last_chunks[32];
 } *cur_salt;
@@ -209,7 +210,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	q = q + 1;
 	if ((q - p - 1) != 1)
 		return 0;
-	if (*p != '0' && *p != '1')
+	if (*p != '0' && *p != '1' && *p != '2')
 		return 0;
 	if (strlen(q) > sizeof(cur_salt->kpt) - 1)
 		return 0;
@@ -251,6 +252,12 @@ static void *get_salt(char *ciphertext)
 		if (cs.kpa) {
 			p = strtokm(NULL, "$");
 			strncpy((char*)cs.kpt, p, 255);
+			if (cs.kpa == 2) {
+				cs.asciipct = atoi(p);
+				if (!cs.asciipct) {
+					cs.asciipct = 90;
+				}
+			}
 		}
 	}
 	else {
@@ -265,11 +272,27 @@ static void *get_salt(char *ciphertext)
 		if (cs.kpa) {
 			p = strtokm(NULL, "$");
 			strncpy((char*)cs.kpt, p, 255);
+			if (cs.kpa == 2) {
+				cs.asciipct = atoi(p);
+				if (!cs.asciipct) {
+					cs.asciipct = 90;
+				}
+			}
 		}
 	}
 
 	MEM_FREE(keeptr);
 	return (void *)&cs;
+}
+
+static int countascii(unsigned char *data, int len) {
+	int nascii = 0;
+	int c;
+	for(c=0; c<len; c++) {
+		if (data[c]==0x0a || (data[c]>=32 && data[c]<127))
+			nascii++;
+	}
+	return nascii;
 }
 
 static int kpa(unsigned char *key, unsigned char *iv, int inlined)
@@ -279,13 +302,27 @@ static int kpa(unsigned char *key, unsigned char *iv, int inlined)
 	AES_set_decrypt_key(key, 256, &akey);
 	if (inlined) {
 		AES_cbc_encrypt(cur_salt->last_chunks, out, 16, &akey, iv, AES_DECRYPT);
-		if (memmem(out, 16, cur_salt->kpt, strlen((char*)cur_salt->kpt)))
-			return 0;
+		if (cur_salt->kpa==1) {
+			if (memmem(out, 16, cur_salt->kpt, strlen((char*)cur_salt->kpt)))
+				return 0;
+		} else if (cur_salt->kpa==2) {
+			int len = check_pkcs_pad(out, 16, 16);
+			int nascii = countascii(out, len);
+			if ( (nascii * 100) / len >= cur_salt->asciipct )
+				return 0;
+		}
 	}
 	else {
 		AES_cbc_encrypt(cur_salt->data, out, cur_salt->datalen, &akey, iv, AES_DECRYPT);
-		if (memmem(out, cur_salt->datalen, cur_salt->kpt, strlen((char*)cur_salt->kpt)))
-			return 0;
+		if (cur_salt->kpa==1) {
+			if (memmem(out, cur_salt->datalen, cur_salt->kpt, strlen((char*)cur_salt->kpt)))
+				return 0;
+		} else if (cur_salt->kpa==2) {
+			int len = check_pkcs_pad(out, cur_salt->datalen, 16);
+			int nascii = countascii(out, len);
+			if ( (nascii * 100) / len >= cur_salt->asciipct )
+				return 0;
+		}
 	}
 	return -1;
 }

--- a/src/openssl_enc_fmt_plug.c
+++ b/src/openssl_enc_fmt_plug.c
@@ -288,7 +288,7 @@ static void *get_salt(char *ciphertext)
 static int count_ascii(unsigned char *data, int len) {
 	int nascii = 0;
 	int c;
-	for( c = 0 ; c < len ; c++) {
+	for (c = 0 ; c < len ; c++) {
 		if (data[c] == 0x0a || data[c] == 0x0d || (data[c] >= 32 && data[c] < 127))
 			nascii++;
 	}
@@ -302,10 +302,10 @@ static int kpa(unsigned char *key, unsigned char *iv, int inlined)
 	AES_set_decrypt_key(key, 256, &akey);
 	if (inlined) {
 		AES_cbc_encrypt(cur_salt->last_chunks, out, 16, &akey, iv, AES_DECRYPT);
-		if (cur_salt->kpa==1) {
+		if (cur_salt->kpa == 1) {
 			if (memmem(out, 16, cur_salt->kpt, strlen((char*)cur_salt->kpt)))
 				return 0;
-		} else if (cur_salt->kpa==2) {
+		} else if (cur_salt->kpa == 2) {
 			int len = check_pkcs_pad(out, 16, 16);
 			int nascii = count_ascii(out, len);
 			if ( (nascii * 100) / len >= cur_salt->asciipct )
@@ -314,10 +314,10 @@ static int kpa(unsigned char *key, unsigned char *iv, int inlined)
 	}
 	else {
 		AES_cbc_encrypt(cur_salt->data, out, cur_salt->datalen, &akey, iv, AES_DECRYPT);
-		if (cur_salt->kpa==1) {
+		if (cur_salt->kpa == 1) {
 			if (memmem(out, cur_salt->datalen, cur_salt->kpt, strlen((char*)cur_salt->kpt)))
 				return 0;
-		} else if (cur_salt->kpa==2) {
+		} else if (cur_salt->kpa == 2) {
 			int len = check_pkcs_pad(out, cur_salt->datalen, 16);
 			int nascii = count_ascii(out, len);
 			if ( (nascii * 100) / len >= cur_salt->asciipct )

--- a/src/openssl_enc_fmt_plug.c
+++ b/src/openssl_enc_fmt_plug.c
@@ -285,11 +285,11 @@ static void *get_salt(char *ciphertext)
 	return (void *)&cs;
 }
 
-static int countascii(unsigned char *data, int len) {
+static int count_ascii(unsigned char *data, int len) {
 	int nascii = 0;
 	int c;
-	for(c=0; c<len; c++) {
-		if (data[c]==0x0a || (data[c]>=32 && data[c]<127))
+	for( c = 0 ; c < len ; c++) {
+		if (data[c] == 0x0a || data[c] == 0x0d || (data[c] >= 32 && data[c] < 127))
 			nascii++;
 	}
 	return nascii;
@@ -307,7 +307,7 @@ static int kpa(unsigned char *key, unsigned char *iv, int inlined)
 				return 0;
 		} else if (cur_salt->kpa==2) {
 			int len = check_pkcs_pad(out, 16, 16);
-			int nascii = countascii(out, len);
+			int nascii = count_ascii(out, len);
 			if ( (nascii * 100) / len >= cur_salt->asciipct )
 				return 0;
 		}
@@ -319,7 +319,7 @@ static int kpa(unsigned char *key, unsigned char *iv, int inlined)
 				return 0;
 		} else if (cur_salt->kpa==2) {
 			int len = check_pkcs_pad(out, cur_salt->datalen, 16);
-			int nascii = countascii(out, len);
+			int nascii = count_ascii(out, len);
 			if ( (nascii * 100) / len >= cur_salt->asciipct )
 				return 0;
 		}


### PR DESCRIPTION
Sometimes you don't know any part of the plaintext, but the plaintext is mostly ascii characters. 
With this patch, you can define the ascii threshold.