### PR TITLE
sunMD5: define an OpenMP variable data scope

### DIFF
--- a/src/sunmd5_fmt_plug.c
+++ b/src/sunmd5_fmt_plug.c
@@ -532,9 +532,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #endif // SIMD_COEF_32
 #else
 #ifdef SIMD_COEF_32
-#pragma omp parallel for default(none) private(idx) shared(ngroups, group_sz, saved_salt, data, input_buf, input_buf_big, out_buf)
+#pragma omp parallel for default(none) private(idx) shared(ngroups, group_sz, saved_salt, data, input_buf, input_buf_big, out_buf, constant_phrase)
 #else
-#pragma omp parallel for default(none) private(idx) shared(ngroups, group_sz, saved_salt, data)
+#pragma omp parallel for default(none) private(idx) shared(ngroups, group_sz, saved_salt, data, constant_phrase)
 #endif // SIMD_COEF_32
 #endif // __INTEL_COMPILER
 #endif // _OPENMP


### PR DESCRIPTION
See lines 529 and 531. Why there is a difference? Commit 2a63d1b54f8e5e7a22b310d6baf27dba82466a79 says nothing.
* Intel do not handle the "const-qualified type"? So, "count" should be added too (L548)? I expect a failure otherwise.

*****
Even better, why not remove the `#ifdef __INTEL_COMPILER` and define scope for all variables?

Reasoning:
gcc 9 is, for a while, unhappy with the source code.