### PR TITLE
Expose min_length constant in rules

### DIFF
--- a/doc/RULES
+++ b/doc/RULES
@@ -49,6 +49,7 @@ following characters:
 
 0...9	for 0...9
 A...Z	for 10...35
+#	for min_length
 *	for max_length
 -	for (max_length - 1)
 +	for (max_length + 1)
@@ -58,8 +59,8 @@ m	initial or memorized word's last character position
 p	position of the character last found with the "/" or "%" commands
 z	"infinite" position or length (beyond end of word)
 
-Here max_length is the maximum plaintext length supported for the
-current hash type.
+Here min/max_length is the minimum/maximum plaintext length supported for
+the current hash type (possible overriden by --min/max-len options).
 
 These may be used to specify character positions, substring lengths, and
 other numeric parameters to rule commands as appropriate for a given

--- a/doc/RULES
+++ b/doc/RULES
@@ -60,7 +60,7 @@ p	position of the character last found with the "/" or "%" commands
 z	"infinite" position or length (beyond end of word)
 
 Here min/max_length is the minimum/maximum plaintext length supported for
-the current hash type (possible overriden by --min/max-len options).
+the current hash type (possibly overriden by --min/max-len options).
 
 These may be used to specify character positions, substring lengths, and
 other numeric parameters to rule commands as appropriate for a given

--- a/src/rules.c
+++ b/src/rules.c
@@ -1157,6 +1157,8 @@ static void rules_init_length(int max_length)
 	rules_vars['-'] = max_length - 1;
 	rules_vars['+'] = max_length + 1;
 
+	rules_vars['#'] = min_length;
+
 	rules_vars['z'] = INFINITE_LENGTH;
 }
 


### PR DESCRIPTION
@solardiz is the `#` character OK or do you have a better suggestion? For `min_length` there doesn't seem to be need for the additional +/- 1 constants that max_length have, does it? If we need them later I was thinking `@` for `min_length - 1` and `$` for `min_length + 1`. as the three then come in sequence on many keyboards.