### PR TITLE
Stop aborting on lock error #3482

### DIFF
--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1310,7 +1310,8 @@ void opencl_build(int sequential_id, char *opts, int save, char *file_name, cl_p
 	if (options.verbosity == VERB_MAX)
 		fprintf(stderr, "Node %d releasing lock\n", NODE);
 #endif
-	fclose(kludge_file);
+	if (kludge_file)
+		fclose(kludge_file);
 #endif /* (HAVE_MPI || OS_FORK) && (OS_FLOCK || FCNTL_LOCKS) */
 
 #if HAVE_MPI


### PR DESCRIPTION
Fix HEAD. JtR can run if the OpenCL build lock is failing. No reason to abort.

After this patch, a message will be printed, but JtR will work (as it used to before