### PR TITLE
Line gap for each status output

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -25,7 +25,6 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <assert.h>
-
 #include <sys/ioctl.h>
 #include <unistd.h>
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -26,6 +26,9 @@
 #include <errno.h>
 #include <assert.h>
 
+#include <sys/ioctl.h>
+#include <unistd.h>
+
 #include "memory.h"
 #include "logger.h"
 #include "params.h"
@@ -34,6 +37,8 @@
 
 #include "john_mpi.h"
 #include "memdbg.h"
+
+char gap[999];
 
 void real_error(char *file, int line)
 {
@@ -492,4 +497,16 @@ char *human_prefix(uint64_t num)
 		snprintf(out, 16, "%u ", (uint32_t)num);
 
 	return out;
+}
+
+char *status_gap()
+{
+    int gap_c;
+
+    struct winsize w;
+    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+    memset(gap, '\0', sizeof(gap));
+    for (gap_c=0;gap_c<w.ws_col && gap_c<sizeof(gap);gap_c++) gap[gap_c]='-';
+
+	return gap;
 }

--- a/src/misc.h
+++ b/src/misc.h
@@ -186,3 +186,8 @@ const char *jtr_ulltoa(unsigned long long num, char *result, int result_len, int
 extern char *human_prefix(uint64_t num);
 
 #endif
+
+/*
+ * Returns line(gap) with width of terminal
+*/
+extern char *status_gap();

--- a/src/status.c
+++ b/src/status.c
@@ -298,6 +298,9 @@ static void status_print_cracking(double percent)
 		if (n > 0)
 			p += n;
 	}
+		
+	if (options.node_min == 1)
+		fprintf(stderr, "%s\n", status_gap());
 
 	if (showcand)
 		sprintf(sc, " %"PRIu64"p", status.cands);


### PR DESCRIPTION
Dear Developers,

Added a line(gap) output for each status print(when fork option is being used(child count > 1)).
This is how it looks like:

![john](https://user-images.githubusercontent.com/25136754/49484505-f7dec500-f83f-11e8-972b-df5dc3dc3b2b.png)

Also, there's an bug of status printing when user asks for it too fast(**this is not related to this commit**), for example: 
```
...
-----------------------------------------------------------------------------------
1 0g 0:00:00:01  3/3 0g/s 100965p/s 424977c/s 424977C/s 44119..55123
----------------------------------------------------------------------------------- // Here user asked for status faster than(before) last child has shown his status
1 0g 0:00:00:02  3/3 0g/s 60070p/s 253697c/s 253697C/s asaak..512221
2 0g 0:00:00:01  3/3 0g/s 60793p/s 257470c/s 257470C/s merold..321489
2 0g 0:00:00:02  3/3 0g/s 43712p/s 190864c/s 190864C/s mernher..mernent
...
```
Does anyone know how to fix this? Is that something like defining a variable which would contain output's status and if previous output has been finished then continue?

Best regards