### PR TITLE
OpenCL versus Fork validation

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1432,6 +1432,7 @@ static void john_load(void)
 	if (database.format &&
 	    strstr(database.format->params.label, "-opencl") &&
 	    !strstr(database.format->params.label, "mscash2-opencl") &&
+	    !default_device_selected &&
 #if HAVE_MPI
 	    (mpi_p_local ? mpi_p_local : mpi_p) *
 #endif

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -709,6 +709,20 @@ static void build_device_list(char *device_list[MAX_GPU_DEVICES])
 			add_device_type(CL_DEVICE_TYPE_GPU);
 		else if (!strncmp(device_list[n], "accelerator", len))
 			add_device_type(CL_DEVICE_TYPE_ACCELERATOR);
+		else if (!strncmp(device_list[n], "best", len)) {
+			int i = 0;
+			cl_device_type trial_list[] = {
+				CL_DEVICE_TYPE_GPU, CL_DEVICE_TYPE_ACCELERATOR,
+				CL_DEVICE_TYPE_CPU, CL_DEVICE_TYPE_DEFAULT
+			};
+
+			do {
+				/* Add devices in the preferable order: gpu,
+				 * accelerator, and cpu. */
+				add_device_type(trial_list[i++]);
+			} while (get_number_of_devices_in_use() == 0 &&
+			         trial_list[i] != CL_DEVICE_TYPE_DEFAULT);
+		}
 		else if (!isdigit(ARCH_INDEX(device_list[n][0]))) {
 			fprintf(stderr, "Error: --device must be numerical, "
 			        "or one of \"all\", \"cpu\", \"gpu\" and\n"

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -82,6 +82,7 @@
 /* Common OpenCL variables */
 int platform_id;
 int default_gpu_selected;
+int default_device_selected;
 int ocl_autotune_running;
 size_t ocl_max_lws;
 

--- a/src/opencl_common.h
+++ b/src/opencl_common.h
@@ -124,6 +124,7 @@ typedef struct {
 /* Common OpenCL variables */
 extern int platform_id;
 extern int default_gpu_selected;
+extern int default_device_selected;
 extern int ocl_autotune_running;
 extern size_t ocl_max_lws;
 

--- a/src/options.c
+++ b/src/options.c
@@ -586,6 +586,8 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 	if (options.format && strcasestr(options.format, "opencl") &&
 	    (options.flags & FLG_FORK) && options.acc_devices->count == 0) {
 		list_add(options.acc_devices, "all");
+		/* Set a flag that JtR has changed the value of --devices. */
+		default_device_selected = 1;
 	}
 #endif
 

--- a/src/options.c
+++ b/src/options.c
@@ -585,7 +585,7 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 #if HAVE_OPENCL
 	if (options.format && strcasestr(options.format, "opencl") &&
 	    (options.flags & FLG_FORK) && options.acc_devices->count == 0) {
-		list_add(options.acc_devices, "all");
+		list_add(options.acc_devices, "best");
 		/* Set a flag that JtR has changed the value of --devices. */
 		default_device_selected = 1;
 	}


### PR DESCRIPTION
I tested it like this:
```
rm -f ../run/pot; ../run/john -form:SHA256crypt-opencl alltests.in -incremental -max-run=30 -fork=2            #OK
rm -f ../run/pot; ../run/john -form:SHA256crypt-opencl alltests.in -incremental -max-run=30 -fork=2 -dev=0,1,2 #error 
rm -f ../run/pot; ../run/john -form:SHA256crypt-opencl alltests.in -incremental -max-run=30 -fork=2 -dev=6     #OK
rm -f ../run/pot; ../run/john -form:SHA256crypt-opencl alltests.in -incremental -max-run=30 -fork=2 -dev=6,7   #OK

rm -f ../run/pot; ../run/john -form:SHA256crypt-opencl alltests.in -incremental -max-run=30 --fork=3 -dev=1,2   #OK
rm -f ../run/pot; ../run/john -form:SHA256crypt-opencl alltests.in -incremental -max-run=30          -dev=1,2,3 #error 

rm -f ../run/pot; ../run/john -form:SHA256crypt-opencl alltests.in -incremental -max-run=30 --dev=gpu           #error
```

Error is shown only if I have more listed devices than forked instances (and I prefer this way, john still allows the user run advanced use cases.).