### PR TITLE
OpenCL: xSHA512 lacks proper binary_hash()

### DIFF
--- a/src/opencl_rawsha256_fmt_plug.c
+++ b/src/opencl_rawsha256_fmt_plug.c
@@ -607,8 +607,8 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 {
 	const int count = *pcount;
 	const struct db_salt *salt = _salt;
-	size_t gws, initial = 128;
-	size_t *lws = local_work_size ? &local_work_size : &initial;
+	size_t gws;
+	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	gws = GET_NEXT_MULTIPLE(count, local_work_size);
 

--- a/src/opencl_rawsha512_gpl_fmt_plug.c
+++ b/src/opencl_rawsha512_gpl_fmt_plug.c
@@ -694,8 +694,8 @@ static void load_hash()
 static int crypt_all(int *pcount, struct db_salt *_salt)
 {
 	const int count = *pcount;
-	size_t gws, initial = 128;
-	size_t *lws = local_work_size ? &local_work_size : &initial;
+	size_t gws;
+	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	gws = GET_NEXT_MULTIPLE(count, local_work_size);
 

--- a/src/opencl_rawsha512_gpl_fmt_plug.c
+++ b/src/opencl_rawsha512_gpl_fmt_plug.c
@@ -940,7 +940,13 @@ struct fmt_main fmt_opencl_xsha512_gpl = {
 		{NULL},
 		fmt_default_source,
 		{
-			fmt_default_binary_hash
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
 		},
 		salt_hash,
 		NULL,
@@ -950,7 +956,13 @@ struct fmt_main fmt_opencl_xsha512_gpl = {
 		clear_keys,
 		crypt_all,
 		{
-			fmt_default_get_hash
+			get_hash_0,
+			get_hash_1,
+			get_hash_2,
+			get_hash_3,
+			get_hash_4,
+			get_hash_5,
+			get_hash_6
 		},
 		cmp_all,
 		cmp_one,


### PR DESCRIPTION
It is a bug.