### PR TITLE
fixed dynamic overflows in single mode

### DIFF
--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -848,9 +848,7 @@ static void init(struct fmt_main *pFmt)
 	force_md5_ctx = curdat.force_md5_ctx;
 
 	fmt_Dynamic.params.max_keys_per_crypt = pFmt->params.max_keys_per_crypt;
-	fmt_Dynamic.params.min_keys_per_crypt = pFmt->params.max_keys_per_crypt;
-	if (pFmt->params.min_keys_per_crypt > 64)
-		pFmt->params.min_keys_per_crypt = 64;
+	fmt_Dynamic.params.min_keys_per_crypt = pFmt->params.min_keys_per_crypt;
 	fmt_Dynamic.params.flags              = pFmt->params.flags;
 	fmt_Dynamic.params.format_name        = pFmt->params.format_name;
 	fmt_Dynamic.params.algorithm_name     = pFmt->params.algorithm_name;
@@ -7445,9 +7443,6 @@ int dynamic_SETUP(DYNAMIC_Setup *Setup, struct fmt_main *pFmt)
 	pFmt->params.max_keys_per_crypt = MAX_KEYS_PER_CRYPT_X86;
 	pFmt->params.algorithm_name = ALGORITHM_NAME_X86;
 #endif
-	pFmt->params.min_keys_per_crypt = pFmt->params.max_keys_per_crypt;
-	if (pFmt->params.min_keys_per_crypt > 64)
-		pFmt->params.min_keys_per_crypt = 64;
 	dynamic_use_sse = curdat.dynamic_use_sse;
 
 	// Ok, set the new 'constants' data
@@ -8157,9 +8152,7 @@ struct fmt_main *dynamic_THIN_FORMAT_LINK(struct fmt_main *pFmt, char *ciphertex
 		pFmt->params.plaintext_min_length = pFmtLocal->params.plaintext_min_length;
 	}
 	pFmt->params.max_keys_per_crypt = pFmtLocal->params.max_keys_per_crypt;
-	pFmt->params.min_keys_per_crypt = pFmtLocal->params.max_keys_per_crypt;
-	if (pFmt->params.min_keys_per_crypt > 64)
-		pFmt->params.min_keys_per_crypt = 64;
+	pFmt->params.min_keys_per_crypt = pFmtLocal->params.min_keys_per_crypt;
 	pFmt->params.flags = pFmtLocal->params.flags;
 	if (pFmtLocal->params.salt_size)
 		pFmt->params.salt_size = sizeof(void*);

--- a/src/dynamic_types.h
+++ b/src/dynamic_types.h
@@ -173,7 +173,7 @@ typedef struct private_subformat_data
 #define OMP_MAX       (NON_OMP_MAX*OMP_SCALE)
 
 #ifdef SIMD_COEF_32
- #define MIN_KEYS_PER_CRYPT	SIMD_COEF_32
+ #define MIN_KEYS_PER_CRYPT	(SIMD_COEF_32*SIMD_PARA_MD5*SIMD_PARA_SHA1*(MD5_X2+1))
  #ifdef _OPENMP
   #if SIMD_COEF_32 >= 4
    #define BLOCK_LOOPS		((OMP_MAX/SIMD_COEF_32)*OMP_SCALE)
@@ -296,7 +296,7 @@ typedef struct private_subformat_data
 #ifndef SIMD_COEF_32
 //static MD5_OUT tmpOut;
 #endif
-#define MIN_KEYS_PER_CRYPT_X86	1
+#define MIN_KEYS_PER_CRYPT_X86	(MD5_X2+1)
 #define MAX_KEYS_PER_CRYPT_X86	X86_BLOCK_LOOPS
 #if MD5_X2 && (!MD5_ASM)
 #if defined(_OPENMP) || defined (FORCE_THREAD_MD5_body)


### PR DESCRIPTION
ties to #3417  Possibly #2425 

NOTE, may not be ready to merge.  @magnumripper has worked out some debugging code, and I think there may still be an issue when single mode completes, and all the partial buckets are run.  I think the last array element may still exhibit the problem, and may take some additional work.  

HOWEVER, what we found was dynamic 'min_keys_per_crypt' was hard coded to 64.  This did not work all the time. Prime example was AVX2 md5.  Here SIMD32 was 8, and SIMD_PARA was 3. That means each SIMD block was 24.  24 does not evenly divide into 64.  Thus, the code would clear 64 buffers, BUT later code uses full buffer counts (which in this case were 72).  SO the last 8 buffers would get data appended to them, but NEVER properly reset between runs.  So those 8 buffers grew, until they started to overflow.

Since #2425 was listing things like dynamic, it is very possible that this could be the problem.  What @magnum experienced was the heap got corrupted, putting min_keys_per_crypt to 0, which was causing very slow performance (i.e. 1 candidate at a time, no buffering, but performing 72 crypt cracks.  So I hope this is at least 1 of the issues causing the bug which was reported. 