### PR TITLE
OpenCL: tune sha512crypt for Intel

### DIFF
--- a/src/opencl/cryptsha512_kernel_GPU.cl
+++ b/src/opencl/cryptsha512_kernel_GPU.cl
@@ -29,6 +29,8 @@
         #define UNROLL_LOOP    132098
     #elif nvidia_sm_5x(DEVICE_INFO)
         #define UNROLL_LOOP    33686536
+    #elif gpu_intel(DEVICE_INFO)
+        #define UNROLL_LOOP    262658
     #else
         #define UNROLL_LOOP    0
     #endif


### PR DESCRIPTION
It is a 4% performance gain.