### PR TITLE
Fix a leak in cracker.c

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -215,6 +215,7 @@ void crk_init(struct db_main *db, void (*fix_state)(void),
 
 	if (db->loaded) {
 		size = crk_params->max_keys_per_crypt * sizeof(uint64_t);
+		MEM_FREE(crk_timestamps);
 		memset(crk_timestamps = mem_alloc(size), -1, size);
 	} else
 		crk_stdout_key[0] = 0;


### PR DESCRIPTION
The crk_init rounine is called more than once.

539b8fd72a560a25c3f2ae5af7c9fcdce4204156 is not enough.