### PR TITLE
dynamic_types: fix non-SIMD compile error caused by c31b66d

### DIFF
--- a/src/dynamic_types.h
+++ b/src/dynamic_types.h
@@ -228,6 +228,7 @@ typedef struct private_subformat_data
  #define ALGORITHM_NAME			"32/" ARCH_BITS_STR
  #define ALGORITHM_NAME_S		"32/" ARCH_BITS_STR
  #define ALGORITHM_NAME_4		"32/" ARCH_BITS_STR
+ #define MIN_KEYS_PER_CRYPT		(MD5_X2+1)
 #endif
 
 #ifdef _OPENMP


### PR DESCRIPTION
The testing on this was to build with --disable-simd   Then the dyna_types.h failed (as it was), but this change allows it to build properly.  Also, the 2 MIN (where I have MD5_X2=1), IS correct.  If MD5_X2 would be 0, then the MIN being set to 1 is also correct.

NOTE, my pushes do not trigger circleCI (which is the CI which was failing).    I need some CI guru to help me find out why I am not triggering the circleCI stuff.  If it would have been working, then this PR would not have been needed, because the CI would not have allowed the prior PR to be merged until this was fixed.