### PR TITLE
dynamic_types: fix non-SIMD compile error caused by c31b66d

### DIFF
--- a/src/dynamic_types.h
+++ b/src/dynamic_types.h
@@ -228,6 +228,7 @@ typedef struct private_subformat_data
  #define ALGORITHM_NAME			"32/" ARCH_BITS_STR
  #define ALGORITHM_NAME_S		"32/" ARCH_BITS_STR
  #define ALGORITHM_NAME_4		"32/" ARCH_BITS_STR
+ #define MIN_KEYS_PER_CRYPT		(MD5_X2+1)
 #endif
 
 #ifdef _OPENMP


### PR DESCRIPTION
This replaces #3558 and should get Circle CI botcheck