### PR TITLE
configure: detect openssl installed by MacPorts on macOS

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -5227,6 +5227,12 @@ fi
 if test -d /usr/local/include; then
    ADD_CFLAGS="$ADD_CFLAGS -I/usr/local/include"
 fi
+if test -d /opt/local/lib; then
+   ADD_LDFLAGS="$ADD_LDFLAGS -L/opt/local/lib"
+fi
+if test -d /opt/local/include; then
+   ADD_CFLAGS="$ADD_CFLAGS -I/opt/local/include"
+fi
 if test -d /usr/local/opt/openssl/lib; then
    ADD_LDFLAGS="$ADD_LDFLAGS -L/usr/local/opt/openssl/lib"
 fi

--- a/src/m4/jtr_utility_macros.m4
+++ b/src/m4/jtr_utility_macros.m4
@@ -112,6 +112,13 @@ fi
 if test -d /usr/local/include; then
    ADD_CFLAGS="$ADD_CFLAGS -I/usr/local/include"
 fi
+dnl macOS MacPorts paths.
+if test -d /opt/local/lib; then
+   ADD_LDFLAGS="$ADD_LDFLAGS -L/opt/local/lib"
+fi
+if test -d /opt/local/include; then
+   ADD_CFLAGS="$ADD_CFLAGS -I/opt/local/include"
+fi
 dnl macOS Homebrew paths.
 if test -d /usr/local/opt/openssl/lib; then
    ADD_LDFLAGS="$ADD_LDFLAGS -L/usr/local/opt/openssl/lib"


### PR DESCRIPTION
Without this patch, configure needs to be called with additional arguments.
This patch is made to be similar to the surrounding lines.