### PR TITLE
HDAA: remove check that cnonce is lowercase hex

### DIFF
--- a/src/HDAA_fmt_plug.c
+++ b/src/HDAA_fmt_plug.c
@@ -221,8 +221,6 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto end_hdaa_legacy;
 	if ((p = strtokm(NULL, "$")) == NULL) /* clientnonce */
 		goto err;
-	if (!ishexlc(p) )
-		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL) /* qop */
 		goto err;
 	if ((p = strtokm(NULL, "$")) != NULL)


### PR DESCRIPTION
RFC 7616 section 3.4 does not put such constraints on cnonce: it specifies that cnonce is ASCII-only (we may want to check this property, but I don't see why john should reject invalid cnonce values).
The examples of RFC 7616 section 3.9.1 contain non-hex values for nonce and cnonce.
Note that RFC 7616 section 3.3 recommends that the nonce is Base64 or hexadecimal data, but it is not mandatory.