### PR TITLE
Common.[ch] and misc.[ch] changes

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -59,6 +59,9 @@ void common_init(void)
 int ishex(const char *q)
 {
 	const char *p=q;
+
+	if (!q || !*q)
+		return 0;
 	while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 		++q;
 	return !*q && !(((q-p))&1);
@@ -67,6 +70,8 @@ int ishex_oddOK(const char *q)
 {
 	// Sometimes it is 'ok' to have odd length hex.  Usually not.  If odd is
 	// allowed, then the format will have to properly handle odd length.
+	if (!q || !*q)
+		return 0;
 	while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 		++q;
 	return !*q;
@@ -75,6 +80,9 @@ int ishex_oddOK(const char *q)
 int ishexuc(const char *q)
 {
 	const char *p=q;
+
+	if (!q || !*q)
+		return 0;
 	while (atoi16u[ARCH_INDEX(*q)] != 0x7F)
 		++q;
 	return !*q && !(((p-q))&1);
@@ -83,6 +91,9 @@ int ishexuc(const char *q)
 int ishexlc(const char *q)
 {
 	const char *p=q;
+
+	if (!q || !*q)
+		return 0;
 	while (atoi16l[ARCH_INDEX(*q)] != 0x7F)
 		++q;
 	return !*q && !(((p-q))&1);
@@ -91,6 +102,9 @@ int ishexlc(const char *q)
 int ishexn(const char *q, int n)
 {
 	const char *p=q;
+
+	if (!q || !*q)
+		return 0;
 	while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 		++q;
 	return (q-p) >= n;
@@ -99,6 +113,9 @@ int ishexn(const char *q, int n)
 int ishexucn(const char *q, int n)
 {
 	const char *p=q;
+
+	if (!q || !*q)
+		return 0;
 	while (atoi16u[ARCH_INDEX(*q)] != 0x7F)
 		++q;
 	return (q-p) >= n;
@@ -107,22 +124,33 @@ int ishexucn(const char *q, int n)
 int ishexlcn(const char *q, int n)
 {
 	const char *p=q;
+
+	if (!q || !*q)
+		return 0;
 	while (atoi16l[ARCH_INDEX(*q)] != 0x7F)
 		++q;
 	return (q-p) >= n;
 }
 
-int ishexuc_oddOK(const char *q) {
+int ishexuc_oddOK(const char *q)
+{
+	if (!q || !*q)
+		return 0;
 	while (atoi16[ARCH_INDEX(*q)] != 0x7F) {
-		if (*q >= 'a' && *q <= 'f') return 0;
+		if (*q >= 'a' && *q <= 'f')
+			return 0;
 		++q;
 	}
 	return !*q ;
 }
 
-int ishexlc_oddOK(const char *q) {
+int ishexlc_oddOK(const char *q)
+{
+	if (!q || !*q)
+		return 0;
 	while (atoi16[ARCH_INDEX(*q)] != 0x7F) {
-		if (*q >= 'A' && *q <= 'F') return 0;
+		if (*q >= 'A' && *q <= 'F')
+			return 0;
 		++q;
 	}
 	return !*q ;
@@ -132,6 +160,7 @@ static MAYBE_INLINE size_t _hexlen(const char *q, unsigned char dic[0x100], int 
 {
 	const char *s = q;
 	size_t len = strlen(q);
+
 	if (len&1) --len;
 
 	while (dic[ARCH_INDEX(*q)] != 0x7F)
@@ -144,22 +173,31 @@ static MAYBE_INLINE size_t _hexlen(const char *q, unsigned char dic[0x100], int 
 
 size_t hexlen(const char *q, int *extra_chars)
 {
+	if (!q || !*q)
+		return 0;
 	return _hexlen(q, atoi16, extra_chars);
 }
 
 size_t hexlenu(const char *q, int *extra_chars)
 {
+	if (!q || !*q)
+		return 0;
 	return _hexlen(q, atoi16u, extra_chars);
 }
 
 size_t hexlenl(const char *q, int *extra_chars)
 {
+	if (!q || !*q)
+		return 0;
 	return _hexlen(q, atoi16l, extra_chars);
 }
 
 static int isdec_len(const char *q, const char *mxv)
 {
 	const char *p = q;
+
+	if (!q || !*q)
+		return 0;
 	do {
 		if (*p < '0' || *p > '9' || p - q >= 10)
 			return 0;
@@ -169,15 +207,21 @@ static int isdec_len(const char *q, const char *mxv)
 
 int isdec(const char *q)
 {
+	if (!q || !*q)
+		return 0;
 	return isdec_len(q, "2147483647");
 }
 
 int isdec_negok(const char *q)
 {
+	if (!q || !*q)
+		return 0;
 	return *q == '-' ? isdec_len(q + 1, "2147483648") : isdec(q);
 }
 
 int isdecu(const char *q)
 {
+	if (!q || !*q)
+		return 0;
 	return isdec_len(q, "4294967295");
 }

--- a/src/common.h
+++ b/src/common.h
@@ -125,7 +125,10 @@ int ishexn(const char *q, int n);
 int ishexucn(const char *q, int n);
 int ishexlcn(const char *q, int n);
 /* length of hex. if extra_chars not null, it will be 1 if there are more
- * non-hex characters after the length of valid hex chars returned. */
+ * non-hex characters after the length of valid hex chars returned.
+ * NOTE, the return will always be an even number (rounded down). so if we
+ * want the length of "ABCDE", it will be 4 not 5.
+ */
 size_t hexlen(const char *q, int *extra_chars);
 size_t hexlenl(const char *q, int *extra_chars); /* lower cased only */
 size_t hexlenu(const char *q, int *extra_chars); /* upper cased only */

--- a/src/jumbo.c
+++ b/src/jumbo.c
@@ -36,7 +36,7 @@
 #endif
 
 
-#ifdef _MSC_VER
+#if  (_MSC_VER) && (_MSC_VER < 1900)
 // we will simply fix the broken _snprintf.  In VC, it will not null terminate buffers that get
 // truncated, AND the return is - if we truncate.  We fix both of these issues, and bring snprintf
 // for VC up to C99 standard.

--- a/src/jumbo.h
+++ b/src/jumbo.h
@@ -350,8 +350,14 @@ extern int fileno(FILE *);
 // blindly use these for VC.  For VC, they are used to work around many
 // red-herring compiler warnings
 #undef snprintf
+#if _MSC_VER < 1900
+// note, in VC 2015, snprintf was fixed to be POSIX compliant. The legacy _snprintf function
+// starting at at VC 2015 is no longer the same as snprintf (as it was prior).  The _snprintf
+// was kept at the legacy problematic manner, while snprintf now 'works' properly.
+// _MSC_VER == 1900 is the key for VC 2015
 #define snprintf(str, size, ...) vc_fixed_snprintf((str), (size), __VA_ARGS__)
 extern int vc_fixed_snprintf(char *Dest, size_t max_cnt, const char *Fmt, ...);
+#endif
 #undef alloca
 #define alloca _alloca
 #undef unlink

--- a/src/misc.c
+++ b/src/misc.c
@@ -257,7 +257,7 @@ void *strncpy_pad(void *dst, const void *src, size_t size, uint8_t pad)
 	uint8_t *d = dst;
 	const uint8_t *s = src;
 
-	if ( ((long long)size) < 1)
+	if ((int64_t)size < 1)
 		return dst;
 
 	while (*s && size) {

--- a/src/misc.h
+++ b/src/misc.h
@@ -97,9 +97,7 @@ extern char *fgetl(char *s, int size, FILE *stream);
  * s buffer, then the caller MUST call MEM_FREE to that pointer
  * once it is done with it.
  */
-#ifndef _JOHN_MISC_NO_LOG
 extern char *fgetll(char *s, size_t size, FILE *stream);
-#endif
 
 /*
  * Similar to strncpy(), but with arbitrary padding. We deliberate do
@@ -138,6 +136,12 @@ extern int strnzcpylwrn(char *dst, const char *src, int size);
  * terminates the string.
  */
 extern char *strnzcat(char *dst, const char *src, int size);
+
+/*
+* similar to strncat, but this one protects the dst buffer, AND it
+* assures that dst is properly NULL terminated upon completion.
+*/
+extern char *strnzcatn(char *dst, int size, const char *src, int max_src);
 
 /*
  * Similar to atoi(), but properly handles unsigned int.  Do not use
@@ -182,8 +186,8 @@ char *strtokm(char *s1, const char *delimit);
  */
 const char *jtr_itoa(int num, char *result, int result_len, int base);
 const char *jtr_utoa(unsigned int num, char *result, int result_len, int base);
-const char *jtr_lltoa(long long num, char *result, int result_len, int base);
-const char *jtr_ulltoa(unsigned long long num, char *result, int result_len, int base);
+const char *jtr_lltoa(int64_t num, char *result, int result_len, int base);
+const char *jtr_ulltoa(uint64_t num, char *result, int result_len, int base);
 
 /*
  * Change some large number to a string possibly using SI prefix

--- a/src/sap_pse_common_plug.c
+++ b/src/sap_pse_common_plug.c
@@ -48,7 +48,7 @@ int sappse_common_valid(char *ciphertext, struct fmt_main *self)
 		goto bail;
 	if (hexlenl(p, &extra) > 32 * 2 || extra)
 		goto bail;
-	if (!ishexlc(p))
+	if (*p && !ishexlc(p))
 		goto bail;
 	if ((p = strtokm(NULL, "$")) == NULL) // encrypted_pin_length
 		goto bail;


### PR DESCRIPTION
Here are changes to common.[ch] and misc.[ch] which have been triggered by findings from within the unit-tests project.

Also, one format was changed (it's valid).  It was the only format not handling the change to ishex("") now returning false (prior logic returned true).

There was also a change made in jumbo.[ch] but only for a VC build, and only for VC 2015 or newer.  2015 fixed the snprintf function (leaving the older 'busted' logic in the _snprintf function).  Now, (v 2015), the snprintf works properly, and having a wrapper varargs function to handle it makes things more complex.

There is a comment in the first commit, that lists all things changed.