### PR TITLE
Void sizeof undefined

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -42,9 +42,10 @@ SingleRules = Single
 # Default batch mode Wordlist rules
 BatchModeWordlistRules = Wordlist
 
-# Default wordlist mode rules when not in batch mode (if any)
-# If this is set and you want to run once without rules, use --rules:none
-#WordlistRules = Wordlist
+# Default wordlist mode rules when not in batch mode (if any).  If this is
+# changed from 'none' to have default rules applied, and you DO want to run
+# once without rules, use --rules:none on the command line.
+WordlistRules = none
 
 # Default loopback mode rules (if any)
 # If this is set and you want to run once without rules, use --rules:none
@@ -60,8 +61,9 @@ RelaxKPCWarningCheck = N
 
 # Default/batch mode Incremental mode
 # Warning: changing these might currently break resume on existing sessions
+# one option frequently changed (with above caveat) is setting DefaultIncrementalUTF8 = UTF8
 DefaultIncremental = ASCII
-#DefaultIncrementalUTF8 = UTF8
+DefaultIncrementalUTF8 = ASCII
 DefaultIncrementalLM = LM_ASCII
 
 # Time formatting string used in status ETA.
@@ -85,19 +87,23 @@ TimeFormat24 = %H:%M:%S
 # strftime for more information:
 # http://en.cppreference.com/w/c/chrono/strftime
 #
+# examples:
 # 2016-02-20T22:35:38+01:00 would be %Y-%m-%dT%H:%M:%S%z
 # Feb 20 22:35:38           would be %b %d %H:%M:%S
-#LogDateFormat = %Y-%m-%dT%H:%M:%S%z
+LogDateFormat =
 
 # if log date is being used, the time will default to local
-# time.  But if the next line is uncommented, it will output
+# time.  But if the next line is changed to 'Y', date output
 # in UTC.  Note, if LogDateFormat is not set, this option
-# does nothing.
-#LogDateFormatUTC = Y
+# is ignored.
+LogDateFormatUTC = N
 
 # if logging to stderr (--log-stderr command line switch used),
 # then use date format when outputting to the stderr.
-#LogDateStderrFormat = %b %d %H:%M:%S
+#
+# example
+# Feb 20 22:35:38           would be %b %d %H:%M:%S
+LogDateStderrFormat =
 
 # This can be used to colorize (on screen) or otherwise emphasize (in log
 # files) output whenever a supposed administrator password gets cracked.
@@ -118,16 +124,16 @@ MarkAdminString = (ADMIN ACCOUNT)
 
 # Permissions to set for session.log file
 # Default is 0600
-#LogFilePermissions = 0600
+LogFilePermissions = 0600
 
 # Permissions to set for POT file
 # Default is 0600
-#PotFilePermissions = 0600
+PotFilePermissions = 0600
 
 # John exits if another user owns log or pot file because CHMOD fails,
 # If this is set John prints a warning and continues
 # Default is N
-#IgnoreChmodErrors = N
+IgnoreChmodErrors = N
 
 # This figure is in MB. The default is to memory map wordlists not larger
 # than one terabyte.
@@ -186,7 +192,7 @@ SinglePrioResume = N
 # with a --session=xxxx will be protected from being overwritten. If
 # the option is set to "Always", then all .rec files will be kept from
 # being overwritten, even ${JOHN}/john.rec file
-#SessionFileProtect = Named
+SessionFileProtect = Disabled
 
 # Protect the log files (*.log) from being reused by new sessons.
 # The default mode is "Disabled". That means, a nee session will just append
@@ -199,7 +205,7 @@ SinglePrioResume = N
 # existing log file.)
 # Unless you use the --nolog option, setting LogFileProtect will also
 # prevent overwriting existing session files.
-#LogFileProtect = Named
+LogFileProtect = Disabled
 
 # Emit a status line whenever a password is cracked (this is the same as
 # passing the --crack-status option flag to john). NOTE: if this is set

--- a/src/logger.c
+++ b/src/logger.c
@@ -299,7 +299,7 @@ static int log_time(void)
 
 	Time = pot.fd >= 0 ? status_get_time() : status_restored_time;
 
-	if (LogDateFormat) {
+	if (LogDateFormat && *LogDateFormat) {
 		struct tm *t_m;
 		char Buf[128];
 		time_t t;
@@ -613,7 +613,7 @@ void log_event(const char *format, ...)
 	if (options.flags & FLG_LOG_STDERR) {
 		unsigned int Time;
 
-		if (LogDateStderrFormat) {
+		if (LogDateStderrFormat && *LogDateStderrFormat) {
 			struct tm *t_m;
 			char Buf[128];
 			time_t t;

--- a/src/sapB_fmt_plug.c
+++ b/src/sapB_fmt_plug.c
@@ -362,7 +362,7 @@ static int cmp_one(void *binary, int index)
 	if (half_hashes)
 		return (!memcmp(binary, crypt_key[index], BINARY_SIZE) ||
 		        (!memcmp(binary, crypt_key[index], BINARY_SIZE / 2) &&
-		         !memcmp(binary + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
+		         !memcmp(((unsigned char*)binary) + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
 	else
 		return (!memcmp(binary, crypt_key[index], BINARY_SIZE));
 #endif

--- a/src/sapG_fmt_plug.c
+++ b/src/sapG_fmt_plug.c
@@ -341,7 +341,7 @@ static int cmp_one(void *binary, int index)
 	if (half_hashes)
 		return (!memcmp(binary, crypt_key[index], BINARY_SIZE) ||
 		        (!memcmp(binary, crypt_key[index], BINARY_SIZE / 2) &&
-		         !memcmp(binary + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
+		         !memcmp(((unsigned char*)binary) + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
 	else
 		return (!memcmp(binary, crypt_key[index], BINARY_SIZE));
 #endif

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -971,7 +971,7 @@ int cp_name2id(char *encoding)
 	char enc[16] = "";
 	char *d = enc;
 
-	if (!encoding)
+	if (!encoding || !encoding[0])
 		return CP_UNDEF;
 	if (strlen(encoding) > sizeof(enc))
 		goto err;


### PR DESCRIPTION
Doing arithmetic on the contents of a void pointer is not defined (or at least NOT portable).  I believe this is an implementation defined operation (vs undefined), but in the same case, this is not portable.

This all falls down to this (and what the sizeof actually is

```c
#include <stdio.h>
int get_size(void *p) {
     return sizeof(p[0]);
}
int main() {
     printf ("size of void object is:  %d\n", get_size(0));
}
```

This compiles on gcc and VC.  Gcc returns sizeof void object as 1.  VC returns its size as 0 (which 0 REALLY is correct, as per the C standard).

I did find this:   https://www.geeksforgeeks.org/void-pointer-c-cpp/   ``` 2) The C standard doesn’t allow pointer arithmetic with void pointers. However, in GNU C it is allowed by considering the size of void is 1 ```   and this:    https://stackoverflow.com/questions/20967868/should-the-compiler-warn-on-pointer-arithmetic-with-a-void-pointer  ``` Pointer arithmetic with void * is a GCC extension and not standard C. ```

NOTE, adding ``` -Wpointer-arith``` to the build forces the compiler to SHOW this problem (we might want to look at adding that switch, if it is available).  Here is a full build, where I added this warning flag.  This warning flag only showed up these 2 items.  It can also flag code like the sizeof code in my first sample code post, as being ```warning: invalid application of ‘sizeof’ to a void type [-Wpointer-arith]```  The john project has only the 2 warnings I have fixed in this PR.

```
$ make -sj3
sapB_fmt_plug.c: In function ‘cmp_one’:
sapB_fmt_plug.c:365:27: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
            !memcmp(binary + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
                           ^
sapG_fmt_plug.c: In function ‘cmp_one’:
sapG_fmt_plug.c:344:27: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
            !memcmp(binary + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
                           ^
ar: creating aes.a
ar: creating secp256k1.a
ar: creating ed25519-donna.a
```