### PR TITLE
using void* in arithmetic is not valid, even though gcc extension allows

### DIFF
--- a/src/sapB_fmt_plug.c
+++ b/src/sapB_fmt_plug.c
@@ -362,7 +362,7 @@ static int cmp_one(void *binary, int index)
 	if (half_hashes)
 		return (!memcmp(binary, crypt_key[index], BINARY_SIZE) ||
 		        (!memcmp(binary, crypt_key[index], BINARY_SIZE / 2) &&
-		         !memcmp(binary + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
+		         !memcmp(((unsigned char*)binary) + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
 	else
 		return (!memcmp(binary, crypt_key[index], BINARY_SIZE));
 #endif

--- a/src/sapG_fmt_plug.c
+++ b/src/sapG_fmt_plug.c
@@ -341,7 +341,7 @@ static int cmp_one(void *binary, int index)
 	if (half_hashes)
 		return (!memcmp(binary, crypt_key[index], BINARY_SIZE) ||
 		        (!memcmp(binary, crypt_key[index], BINARY_SIZE / 2) &&
-		         !memcmp(binary + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
+		         !memcmp(((unsigned char*)binary) + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
 	else
 		return (!memcmp(binary, crypt_key[index], BINARY_SIZE));
 #endif


### PR DESCRIPTION
Doing arithmetic on the contents of a void pointer is not defined (or at least NOT portable).  I believe this is an implementation defined operation (vs undefined), but in the same case, this is not portable.

This all falls down to this (and what the sizeof actually is

```c
#include <stdio.h>
int get_size(void *p) {
     return sizeof(p[0]);
}
int main() {
     printf ("size of void object is:  %d\n", get_size(0));
}
```

This compiles on gcc and VC.  Gcc returns sizeof void object as 1.  VC returns its size as 0 (which 0 REALLY is correct, as per the C standard).

I did find this:   https://www.geeksforgeeks.org/void-pointer-c-cpp/   ``` 2) The C standard doesn’t allow pointer arithmetic with void pointers. However, in GNU C it is allowed by considering the size of void is 1 ```   and this:    https://stackoverflow.com/questions/20967868/should-the-compiler-warn-on-pointer-arithmetic-with-a-void-pointer  ``` Pointer arithmetic with void * is a GCC extension and not standard C. ```

NOTE, adding ``` -Wpointer-arith``` to the build forces the compiler to SHOW this problem __(we might want to look at adding that switch, if it is available)__.  Here is a full build, where I added this warning flag.  This warning flag only showed up these 2 items.  It can also flag code like the sizeof code in my first sample code post, as being ```warning: invalid application of ‘sizeof’ to a void type [-Wpointer-arith]```  The john project has only the 2 warnings I have fixed in this PR.

```
$ make -sj3
sapB_fmt_plug.c: In function ‘cmp_one’:
sapB_fmt_plug.c:365:27: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
            !memcmp(binary + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
                           ^
sapG_fmt_plug.c: In function ‘cmp_one’:
sapG_fmt_plug.c:344:27: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
            !memcmp(binary + BINARY_SIZE / 2, zeros, BINARY_SIZE / 2)));
                           ^
ar: creating aes.a
ar: creating secp256k1.a
ar: creating ed25519-donna.a
```