### PR TITLE
md5crypt-opencl: choose slow path on len >= 10*4*8 instead of on x[9]

### DIFF
--- a/src/opencl/cryptmd5_kernel.cl
+++ b/src/opencl/cryptmd5_kernel.cl
@@ -12,9 +12,13 @@
 
 //#define USE_BITSELECT 1
 //#define BITALIGN_AGGRESSIVE
-#define BUF_UPDATE_SWITCH
 //#define UNROLL_AGGRESSIVE
 //#define UNROLL_LESS
+
+/* AMDGPU-PRO libamdocl64.so segfaults trying to compile our switch code */
+#if !amd_gcn(DEVICE_INFO) || DEV_VER_MAJOR < 2500
+#define BUF_UPDATE_SWITCH
+#endif
 
 #undef MD5_LUT3 /* No good for this format, just here for reference */
 

--- a/src/opencl/cryptmd5_kernel.cl
+++ b/src/opencl/cryptmd5_kernel.cl
@@ -2,7 +2,7 @@
  * This software is
  * Copyright (c) 2011 - 2013 Lukas Odzioba
  * Copyright (c) 2012 - 2013 magnum
- * Copyright (c) 2015, 2018 Solar Designer
+ * Copyright (c) 2015, 2019 Solar Designer
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -278,8 +278,8 @@ inline void md5_digest(uint *x, uint *result, uint len,
 	FF(c, d, a, b, x[6], S13, 0xa8304613);	/* 7 */
 	FF(b, c, d, a, x[7], S14, 0xfd469501);	/* 8 */
 	FF(a, b, c, d, x[8], S11, 0x698098d8);	/* 9 */
-	if (x[9]) {
-		FF(d, a, b, c, x[9], S12, 0x8b44f7af);	/* 10 */
+	FF(d, a, b, c, x[9], S12, 0x8b44f7af);	/* 10 */
+	if (len >= 10*4*8) {
 		FF(c, d, a, b, x[10], S13, 0xffff5bb1);	/* 11 */
 		FF(b, c, d, a, x[11], S14, 0x895cd7be);	/* 12 */
 		FF(a, b, c, d, x[12], S11, 0x6b901122);	/* 13 */
@@ -335,10 +335,7 @@ inline void md5_digest(uint *x, uint *result, uint len,
 		II(b, c, d, a, x[13], S44, 0x4e0811a1);	/* 60 */
 		II(a, b, c, d, x[4], S41, 0xf7537e82);	/* 61 */
 		II(d, a, b, c, x[11], S42, 0xbd3af235);	/* 62 */
-		II(c, d, a, b, x[2], S43, 0x2ad7d2bb);	/* 63 */
-		II(b, c, d, a, x[9], S44, 0xeb86d391);	/* 64 */
 	} else {
-		FF(d, a, b, c, 0, S12, 0x8b44f7af);	/* 10 */
 		FF(c, d, a, b, 0, S13, 0xffff5bb1);	/* 11 */
 		FF(b, c, d, a, 0, S14, 0x895cd7be);	/* 12 */
 		FF(a, b, c, d, 0, S11, 0x6b901122);	/* 13 */
@@ -354,7 +351,7 @@ inline void md5_digest(uint *x, uint *result, uint len,
 		GG(d, a, b, c, 0, S22, 0x2441453);	/* 22 */
 		GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
 		GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
-		GG(a, b, c, d, 0, S21, 0x21e1cde6);	/* 25 */
+		GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
 		GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
 		GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
 		GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
@@ -375,7 +372,7 @@ inline void md5_digest(uint *x, uint *result, uint len,
 		HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
 		HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
 		HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
-		HH(a, b, c, d, 0, S31, 0xd9d4d039);	/* 45 */
+		HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
 		HH2(d, a, b, c, 0, S32, 0xe6db99e5);/* 46 */
 		HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
 		HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
@@ -394,9 +391,10 @@ inline void md5_digest(uint *x, uint *result, uint len,
 		II(b, c, d, a, 0, S44, 0x4e0811a1);	/* 60 */
 		II(a, b, c, d, x[4], S41, 0xf7537e82);	/* 61 */
 		II(d, a, b, c, 0, S42, 0xbd3af235);	/* 62 */
-		II(c, d, a, b, x[2], S43, 0x2ad7d2bb);	/* 63 */
-		II(b, c, d, a, 0, S44, 0xeb86d391);	/* 64 */
 	}
+
+	II(c, d, a, b, x[2], S43, 0x2ad7d2bb);	/* 63 */
+	II(b, c, d, a, x[9], S44, 0xeb86d391);	/* 64 */
 
 	a += 0x67452301;
 	b += 0xefcdab89;


### PR DESCRIPTION
This fixes the problem described in https://github.com/magnumripper/JohnTheRipper/pull/3622#issuecomment-459312997

Also, the `-test -mask` speed improves with this change, but I'm not sure what this is actually benchmarking because the speed doesn't change as I'd have expected it to with different mask lengths (I am getting the same high speed for much longer masks, which is unrealistic, and even for mask lengths exceeding 15, which is this format's max). Perhaps our `-test -mask` is broken.

```
[solar@super run]$ rm -r ~/.nv/ComputeCache
[solar@super run]$ LWS=256 GWS=10240 ./john -test=10 -form=md5crypt-opencl -dev=3 -v=5 -mask='?a?a?a?a?a?a?a' 
initUnicode(UNICODE, ASCII/ASCII)
ASCII -> ASCII -> ASCII
Device 3: GeForce GTX 1080
Benchmarking: md5crypt-opencl, crypt(3) $1$ [MD5 OpenCL]... Loaded 61 hashes with 39 different salts to test db from test vectors
Options used: -I /home/solar/j/bleeding-jumbo-20190120/run/kernels -cl-mad-enable -DSM_MAJOR=6 -DSM_MINOR=1 -cl-nv-verbose -D__GPU__ -DDEVICE_INFO=524306 -DSIZEOF_SIZE_T=8 -DDEV_VER_MAJOR=410 -DDEV_VER_MINOR=79 -D_OPENCL_COMPILER -DPLAINTEXT_LENGTH=15 $JOHN/kernels/cryptmd5_kernel.cl
Build log: 
ptxas info    : 0 bytes gmem, 54 bytes cmem[3]
ptxas info    : Compiling entry function 'cryptmd5' for 'sm_61'
ptxas info    : Function properties for cryptmd5
ptxas         .     480 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 32 registers, 344 bytes cmem[0], 88 bytes cmem[2]

Local worksize (LWS) 256, global worksize (GWS) 10240 (40 blocks)
DONE
Raw:	7752K c/s real, 7752K c/s virtual, GPU util: 98%
```

Actual runs against one salt length 8 hash give 6300K to 6800K at mask length 7, ~5750K at length 8, ~4850K at length 15.

I've also tested this for proper operation by cracking 200k+ same-salt hashes (all salt length 8, though) of all password lengths 5 to 15.

Further speedup might be possible by moving away from 8 same-size context buffers (currently 14*4 bytes each) to one buffer for all 8 actually different-size portions and maintaining offsets into it (can be compile-time constants assuming password length 15) instead of indices. This would reduce the "480 bytes stack frame" reported above to something like 300 bytes.