### PR TITLE
Further md5crypt-opencl optimizations

### DIFF
--- a/src/opencl/cryptmd5_kernel.cl
+++ b/src/opencl/cryptmd5_kernel.cl
@@ -264,21 +264,33 @@ inline void init_ctx(md5_ctx *ctx, uchar *ctx_buflen)
 	*ctx_buflen = 0;
 }
 
-inline void md5_digest(uint *x, uint *result, uint len,
-    uint res_offset)
+inline void md5_digest(uint *x, uint *y, uint *z, uint *zmem, uint zmem_offset, uint len)
 {
 	uint a;
 	uint b = 0xefcdab89;
 	uint c = 0x98badcfe;
 	uint d = 0x10325476;
 
-	a = ROTATE_LEFT(AC1 + x[0], S11);
+	uint x0, x1, x2, x3;
+	if (y) {
+		x0 = y[0];
+		x1 = y[1];
+		x2 = y[2];
+		x3 = y[3];
+	} else {
+		x0 = x[0];
+		x1 = x[1];
+		x2 = x[2];
+		x3 = x[3];
+	}
+
+	a = ROTATE_LEFT(AC1 + x0, S11);
 	a += b;			/* 1 */
-	d = ROTATE_LEFT((c ^ (a & MASK1)) + x[1] + AC2pCd, S12);
+	d = ROTATE_LEFT((c ^ (a & MASK1)) + x1 + AC2pCd, S12);
 	d += a;			/* 2 */
-	c = ROTATE_LEFT(F(d, a, b) + x[2] + AC3pCc, S13);
+	c = ROTATE_LEFT(F(d, a, b) + x2 + AC3pCc, S13);
 	c += d;			/* 3 */
-	b = ROTATE_LEFT(F(c, d, a) + x[3] + AC4pCb, S14);
+	b = ROTATE_LEFT(F(c, d, a) + x3 + AC4pCb, S14);
 	b += c;			/* 4 */
 	FF(a, b, c, d, x[4], S11, 0xf57c0faf);	/* 5 */
 	FF(d, a, b, c, x[5], S12, 0x4787c62a);	/* 6 */
@@ -293,53 +305,53 @@ inline void md5_digest(uint *x, uint *result, uint len,
 		FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
 		FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
 		FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
-		GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
+		GG(a, b, c, d, x1, S21, 0xf61e2562);	/* 17 */
 		GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
 		GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
-		GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);	/* 20 */
+		GG(b, c, d, a, x0, S24, 0xe9b6c7aa);	/* 20 */
 		GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
 		GG(d, a, b, c, 0, S22, 0x2441453);	/* 22 */
 		GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
 		GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
 		GG(a, b, c, d, 0, S21, 0x21e1cde6);	/* 25 */
 		GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
-		GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
+		GG(c, d, a, b, x3, S23, 0xf4d50d87);	/* 27 */
 		GG(b, c, d, a, 0, S24, 0x455a14ed);	/* 28 */
 		GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
-		GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
+		GG(d, a, b, c, x2, S22, 0xfcefa3f8);	/* 30 */
 		GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
 		GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
 		HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
 		HH2(d, a, b, c, 0, S32, 0x8771f681);	/* 34 */
 		HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
 		HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
-		HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
+		HH(a, b, c, d, x1, S31, 0xa4beea44);	/* 37 */
 		HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
 		HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
 		HH2(b, c, d, a, 0, S34, 0xbebfbc70);	/* 40 */
 		HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
-		HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
-		HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
+		HH2(d, a, b, c, x0, S32, 0xeaa127fa);	/* 42 */
+		HH(c, d, a, b, x3, S33, 0xd4ef3085);	/* 43 */
 		HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
 		HH(a, b, c, d, 0, S31, 0xd9d4d039);	/* 45 */
 		HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
 		HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
-		HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
-		II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
+		HH2(b, c, d, a, x2, S34, 0xc4ac5665);	/* 48 */
+		II(a, b, c, d, x0, S41, 0xf4292244);	/* 49 */
 		II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
 		II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
 		II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
 		II(a, b, c, d, 0, S41, 0x655b59c3);	/* 53 */
-		II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
+		II(d, a, b, c, x3, S42, 0x8f0ccc92);	/* 54 */
 		II(c, d, a, b, 0, S43, 0xffeff47d);	/* 55 */
-		II(b, c, d, a, x[1], S44, 0x85845dd1);	/* 56 */
+		II(b, c, d, a, x1, S44, 0x85845dd1);	/* 56 */
 		II(a, b, c, d, 0, S41, 0x6fa87e4f);	/* 57 */
 		II(d, a, b, c, 0, S42, 0xfe2ce6e0);	/* 58 */
 		II(c, d, a, b, x[6], S43, 0xa3014314);	/* 59 */
 		II(b, c, d, a, 0, S44, 0x4e0811a1);	/* 60 */
 		II(a, b, c, d, x[4], S41, 0xf7537e82);	/* 61 */
 		II(d, a, b, c, 0, S42, 0xbd3af235);	/* 62 */
-		II(c, d, a, b, x[2], S43, 0x2ad7d2bb);	/* 63 */
+		II(c, d, a, b, x2, S43, 0x2ad7d2bb);	/* 63 */
 		II(b, c, d, a, 0, S44, 0xeb86d391);	/* 64 */
 	} else {
 		FF(a, b, c, d, x[8], S11, 0x698098d8);	/* 9 */
@@ -353,44 +365,44 @@ inline void md5_digest(uint *x, uint *result, uint len,
 				FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
 				FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
 				FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
-				GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
+				GG(a, b, c, d, x1, S21, 0xf61e2562);	/* 17 */
 				GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
 				GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
-				GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);	/* 20 */
+				GG(b, c, d, a, x0, S24, 0xe9b6c7aa);	/* 20 */
 				GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
 				GG(d, a, b, c, 0x80, S22, 0x2441453);	/* 22 */
 				GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
 				GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
 				GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
 				GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
-				GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
+				GG(c, d, a, b, x3, S23, 0xf4d50d87);	/* 27 */
 				GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
 				GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
-				GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
+				GG(d, a, b, c, x2, S22, 0xfcefa3f8);	/* 30 */
 				GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
 				GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
 				HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
 				HH2(d, a, b, c, x[8], S32, 0x8771f681);	/* 34 */
 				HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
 				HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
-				HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
+				HH(a, b, c, d, x1, S31, 0xa4beea44);	/* 37 */
 				HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
 				HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
 				HH2(b, c, d, a, 0x80, S34, 0xbebfbc70);	/* 40 */
 				HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
-				HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
-				HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
+				HH2(d, a, b, c, x0, S32, 0xeaa127fa);	/* 42 */
+				HH(c, d, a, b, x3, S33, 0xd4ef3085);	/* 43 */
 				HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
 				HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
 				HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
 				HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
-				HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
-				II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
+				HH2(b, c, d, a, x2, S34, 0xc4ac5665);	/* 48 */
+				II(a, b, c, d, x0, S41, 0xf4292244);	/* 49 */
 				II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
 				II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
 				II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
 				II(a, b, c, d, 0, S41, 0x655b59c3);	/* 53 */
-				II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
+				II(d, a, b, c, x3, S42, 0x8f0ccc92);	/* 54 */
 				II(c, d, a, b, 0x80, S43, 0xffeff47d);	/* 55 */
 			} else {
 				FF(c, d, a, b, 0, S13, 0xffff5bb1);	/* 11 */
@@ -399,47 +411,47 @@ inline void md5_digest(uint *x, uint *result, uint len,
 				FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
 				FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
 				FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
-				GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
+				GG(a, b, c, d, x1, S21, 0xf61e2562);	/* 17 */
 				GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
 				GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
-				GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);	/* 20 */
+				GG(b, c, d, a, x0, S24, 0xe9b6c7aa);	/* 20 */
 				GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
 				GG(d, a, b, c, 0, S22, 0x2441453);	/* 22 */
 				GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
 				GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
 				GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
 				GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
-				GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
+				GG(c, d, a, b, x3, S23, 0xf4d50d87);	/* 27 */
 				GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
 				GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
-				GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
+				GG(d, a, b, c, x2, S22, 0xfcefa3f8);	/* 30 */
 				GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
 				GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
 				HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
 				HH2(d, a, b, c, x[8], S32, 0x8771f681);	/* 34 */
 				HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
 				HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
-				HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
+				HH(a, b, c, d, x1, S31, 0xa4beea44);	/* 37 */
 				HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
 				HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
 				HH2(b, c, d, a, 0, S34, 0xbebfbc70);	/* 40 */
 				HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
-				HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
-				HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
+				HH2(d, a, b, c, x0, S32, 0xeaa127fa);	/* 42 */
+				HH(c, d, a, b, x3, S33, 0xd4ef3085);	/* 43 */
 				HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
 				HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
 				HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
 				HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
-				HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
-				II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
+				HH2(b, c, d, a, x2, S34, 0xc4ac5665);	/* 48 */
+				II(a, b, c, d, x0, S41, 0xf4292244);	/* 49 */
 				II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
 				II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
 				II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
 				II(a, b, c, d, 0, S41, 0x655b59c3);	/* 53 */
-				II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
+				II(d, a, b, c, x3, S42, 0x8f0ccc92);	/* 54 */
 				II(c, d, a, b, 0, S43, 0xffeff47d);	/* 55 */
 			}
-			II(b, c, d, a, x[1], S44, 0x85845dd1);	/* 56 */
+			II(b, c, d, a, x1, S44, 0x85845dd1);	/* 56 */
 			II(a, b, c, d, x[8], S41, 0x6fa87e4f);	/* 57 */
 			II(d, a, b, c, 0, S42, 0xfe2ce6e0);	/* 58 */
 			II(c, d, a, b, x[6], S43, 0xa3014314);	/* 59 */
@@ -453,46 +465,46 @@ inline void md5_digest(uint *x, uint *result, uint len,
 			FF(d, a, b, c, x[13], S12, 0xfd987193);	/* 14 */
 			FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
 			FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
-			GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
+			GG(a, b, c, d, x1, S21, 0xf61e2562);	/* 17 */
 			GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
 			GG(c, d, a, b, x[11], S23, 0x265e5a51);	/* 19 */
-			GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);	/* 20 */
+			GG(b, c, d, a, x0, S24, 0xe9b6c7aa);	/* 20 */
 			GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
 			GG(d, a, b, c, x[10], S22, 0x2441453);	/* 22 */
 			GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
 			GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
 			GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
 			GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
-			GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
+			GG(c, d, a, b, x3, S23, 0xf4d50d87);	/* 27 */
 			GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
 			GG(a, b, c, d, x[13], S21, 0xa9e3e905);	/* 29 */
-			GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
+			GG(d, a, b, c, x2, S22, 0xfcefa3f8);	/* 30 */
 			GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
 			GG(b, c, d, a, x[12], S24, 0x8d2a4c8a);	/* 32 */
 			HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
 			HH2(d, a, b, c, x[8], S32, 0x8771f681);	/* 34 */
 			HH(c, d, a, b, x[11], S33, 0x6d9d6122);	/* 35 */
 			HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
-			HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
+			HH(a, b, c, d, x1, S31, 0xa4beea44);	/* 37 */
 			HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
 			HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
 			HH2(b, c, d, a, x[10], S34, 0xbebfbc70);/* 40 */
 			HH(a, b, c, d, x[13], S31, 0x289b7ec6);	/* 41 */
-			HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
-			HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
+			HH2(d, a, b, c, x0, S32, 0xeaa127fa);	/* 42 */
+			HH(c, d, a, b, x3, S33, 0xd4ef3085);	/* 43 */
 			HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
 			HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
 			HH2(d, a, b, c, x[12], S32, 0xe6db99e5);/* 46 */
 			HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
-			HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
-			II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
+			HH2(b, c, d, a, x2, S34, 0xc4ac5665);	/* 48 */
+			II(a, b, c, d, x0, S41, 0xf4292244);	/* 49 */
 			II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
 			II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
 			II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
 			II(a, b, c, d, x[12], S41, 0x655b59c3);	/* 53 */
-			II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
+			II(d, a, b, c, x3, S42, 0x8f0ccc92);	/* 54 */
 			II(c, d, a, b, x[10], S43, 0xffeff47d);	/* 55 */
-			II(b, c, d, a, x[1], S44, 0x85845dd1);	/* 56 */
+			II(b, c, d, a, x1, S44, 0x85845dd1);	/* 56 */
 			II(a, b, c, d, x[8], S41, 0x6fa87e4f);	/* 57 */
 			II(d, a, b, c, 0, S42, 0xfe2ce6e0);	/* 58 */
 			II(c, d, a, b, x[6], S43, 0xa3014314);	/* 59 */
@@ -500,7 +512,7 @@ inline void md5_digest(uint *x, uint *result, uint len,
 			II(a, b, c, d, x[4], S41, 0xf7537e82);	/* 61 */
 			II(d, a, b, c, x[11], S42, 0xbd3af235);	/* 62 */
 		}
-		II(c, d, a, b, x[2], S43, 0x2ad7d2bb);	/* 63 */
+		II(c, d, a, b, x2, S43, 0x2ad7d2bb);	/* 63 */
 		II(b, c, d, a, x[9], S44, 0xeb86d391);	/* 64 */
 	}
 
@@ -509,15 +521,24 @@ inline void md5_digest(uint *x, uint *result, uint len,
 	c += 0x98badcfe;
 	d += 0x10325476;
 
-	if (!res_offset) {
-		result[0] = a;
-		result[1] = b;
-		result[2] = c;
-		result[3] = d;
+	if (z) {
+		z[0] = a;
+		z[1] = b;
+		z[2] = c;
+		z[3] = d;
 		return;
 	}
 
-	buf_update(result, a, b, c, d, res_offset);
+	/* y != NULL implies zmem_offset != 0, and is known at compile time */
+	if (!y && !zmem_offset) {
+		zmem[0] = a;
+		zmem[1] = b;
+		zmem[2] = c;
+		zmem[3] = d;
+		return;
+	}
+
+	buf_update(zmem, a, b, c, d, zmem_offset);
 }
 
 __kernel void cryptmd5(__global const crypt_md5_password *inbuffer,
@@ -554,7 +575,7 @@ __kernel void cryptmd5(__global const crypt_md5_password *inbuffer,
 	ctx_update(&ctx[1], salt.c, salt_len, &ctx_buflen[1]);
 	ctx_update(&ctx[1], pass.c, pass_len, &ctx_buflen[1]);
 	PUTCHAR(ctx[1].buffer, ctx_buflen[1], 0x80);
-	md5_digest(ctx[1].buffer, alt_result, ctx_buflen[1] << 3, 0);
+	md5_digest(ctx[1].buffer, 0, 0, alt_result, 0, ctx_buflen[1] << 3);
 
 	init_ctx(&ctx[1], &ctx_buflen[1]);
 	ctx_update(&ctx[1], pass.c, pass_len, &ctx_buflen[1]);
@@ -586,7 +607,7 @@ __kernel void cryptmd5(__global const crypt_md5_password *inbuffer,
 	init_ctx(&ctx[0], &ctx_buflen[0]);
 	PUTCHAR(ctx[1].buffer, ctx_buflen[1], 0x80);
 	//alt pass
-	md5_digest(ctx[1].buffer, ctx[0].buffer, ctx_buflen[1] << 3, 0);	//add results from init
+	md5_digest(ctx[1].buffer, 0, 0, ctx[0].buffer, 0, ctx_buflen[1] << 3);
 	ctx_buflen[0] = 16;
 	for (i = 1; i < 8; i++)	//1 not 0
 		init_ctx(&ctx[i], &ctx_buflen[i]);
@@ -662,45 +683,59 @@ __kernel void cryptmd5(__global const crypt_md5_password *inbuffer,
 #ifdef UNROLL_LESS
 	for (i = 0; i < 1000; i++) {
 		id2 = g[j];
-		md5_digest(ctx[id1 / 8].buffer, ctx[id2 / 8].buffer, (uint)ctx_buflen[id1 / 8] << 3,
-		    (j & 1) ? (altpos >> id2) & 0xff : 0);
+		md5_digest(ctx[id1 / 8].buffer, 0, 0, ctx[id2 / 8].buffer,
+		    (j & 1) ? (altpos >> id2) & 0xff : 0,
+		    (uint)ctx_buflen[id1 / 8] << 3);
 		if (j == 41)
 			j = -1;
 		id1 = id2;
 		id2 = g[++j];
 	}
 #else
+	uint tmp[4]; /* Use with fixed indices, so it's kept in registers */
+	tmp[0] = ctx[id1 / 8].buffer[0];
+	tmp[1] = ctx[id1 / 8].buffer[1];
+	tmp[2] = ctx[id1 / 8].buffer[2];
+	tmp[3] = ctx[id1 / 8].buffer[3];
 #ifdef UNROLL_AGGRESSIVE
 	for (i = 0; i < 250; i++) {
 #else
 	for (i = 0; i < 500; i++) {
 #endif
 		id2 = g[j];
-		md5_digest(ctx[id1 / 8].buffer, ctx[id2 / 8].buffer, ((ctx_buflen1 >> id1) & 0xff) << 1,
-		    (altpos >> id2) & 0xff);
+		md5_digest(ctx[id1 / 8].buffer, tmp, 0, ctx[id2 / 8].buffer,
+		    (altpos >> id2) & 0xff,
+		    ((ctx_buflen1 >> id1) & 0xff) << 1);
 		if (j == 41)
 			j = -1;
 		id1 = g[j + 1];
-		md5_digest(ctx[id2 / 8].buffer, ctx[id1 / 8].buffer, ((ctx_buflen2 >> id2) & 0xff) << 1, 0);
+		md5_digest(ctx[id2 / 8].buffer, 0, tmp, 0, 0,
+		    ((ctx_buflen2 >> id2) & 0xff) << 1);
 
 #ifdef UNROLL_AGGRESSIVE
 		id2 = g[j + 2];
-		md5_digest(ctx[id1 / 8].buffer, ctx[id2 / 8].buffer, ((ctx_buflen1 >> id1) & 0xff) << 1,
-		    (altpos >> id2) & 0xff);
+		md5_digest(ctx[id1 / 8].buffer, tmp, 0, ctx[id2 / 8].buffer,
+		    (altpos >> id2) & 0xff,
+		    ((ctx_buflen1 >> id1) & 0xff) << 1);
 		if (j == 39)
 			j = -3;
 		id1 = g[j + 3];
 		j += 4;
-		md5_digest(ctx[id2 / 8].buffer, ctx[id1 / 8].buffer, ((ctx_buflen2 >> id2) & 0xff) << 1, 0);
+		md5_digest(ctx[id2 / 8].buffer, 0, tmp, 0, 0,
+		    ((ctx_buflen2 >> id2) & 0xff) << 1);
 #else
 		j += 2;
 #endif
 	}
 #endif
 
-#ifdef UNROLL_AGGRESSIVE
-#pragma unroll 4
-#endif
+#ifdef UNROLL_LESS
 	for (i = 0; i < 4; i++)
 		outbuffer[idx].v[i] = ctx[3].buffer[i];
+#else
+	outbuffer[idx].v[0] = tmp[0];
+	outbuffer[idx].v[1] = tmp[1];
+	outbuffer[idx].v[2] = tmp[2];
+	outbuffer[idx].v[3] = tmp[3];
+#endif
 }

--- a/src/opencl/cryptmd5_kernel.cl
+++ b/src/opencl/cryptmd5_kernel.cl
@@ -284,72 +284,15 @@ inline void md5_digest(uint *x, uint *result, uint len,
 	FF(d, a, b, c, x[5], S12, 0x4787c62a);	/* 6 */
 	FF(c, d, a, b, x[6], S13, 0xa8304613);	/* 7 */
 	FF(b, c, d, a, x[7], S14, 0xfd469501);	/* 8 */
-	FF(a, b, c, d, x[8], S11, 0x698098d8);	/* 9 */
-	FF(d, a, b, c, x[9], S12, 0x8b44f7af);	/* 10 */
-	if (len >= 10*4*8) {
-		FF(c, d, a, b, x[10], S13, 0xffff5bb1);	/* 11 */
-		FF(b, c, d, a, x[11], S14, 0x895cd7be);	/* 12 */
-		FF(a, b, c, d, x[12], S11, 0x6b901122);	/* 13 */
-		FF(d, a, b, c, x[13], S12, 0xfd987193);	/* 14 */
-		FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
-		FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
-
-		GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
-		GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
-		GG(c, d, a, b, x[11], S23, 0x265e5a51);	/* 19 */
-		GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);	/* 20 */
-		GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
-		GG(d, a, b, c, x[10], S22, 0x2441453);	/* 22 */
-		GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
-		GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
-		GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
-		GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
-		GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
-		GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
-		GG(a, b, c, d, x[13], S21, 0xa9e3e905);	/* 29 */
-		GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
-		GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
-		GG(b, c, d, a, x[12], S24, 0x8d2a4c8a);	/* 32 */
-
-		HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
-		HH2(d, a, b, c, x[8], S32, 0x8771f681);	/* 34 */
-		HH(c, d, a, b, x[11], S33, 0x6d9d6122);	/* 35 */
-		HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
-		HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
-		HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
-		HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
-		HH2(b, c, d, a, x[10], S34, 0xbebfbc70);/* 40 */
-		HH(a, b, c, d, x[13], S31, 0x289b7ec6);	/* 41 */
-		HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
-		HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
-		HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
-		HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
-		HH2(d, a, b, c, x[12], S32, 0xe6db99e5);/* 46 */
-		HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
-		HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
-
-		II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
-		II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
-		II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
-		II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
-		II(a, b, c, d, x[12], S41, 0x655b59c3);	/* 53 */
-		II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
-		II(c, d, a, b, x[10], S43, 0xffeff47d);	/* 55 */
-		II(b, c, d, a, x[1], S44, 0x85845dd1);	/* 56 */
-		II(a, b, c, d, x[8], S41, 0x6fa87e4f);	/* 57 */
-		II(d, a, b, c, 0, S42, 0xfe2ce6e0);	/* 58 */
-		II(c, d, a, b, x[6], S43, 0xa3014314);	/* 59 */
-		II(b, c, d, a, x[13], S44, 0x4e0811a1);	/* 60 */
-		II(a, b, c, d, x[4], S41, 0xf7537e82);	/* 61 */
-		II(d, a, b, c, x[11], S42, 0xbd3af235);	/* 62 */
-	} else {
+	if (len < 8*4*8) {
+		FF(a, b, c, d, 0, S11, 0x698098d8);	/* 9 */
+		FF(d, a, b, c, 0, S12, 0x8b44f7af);	/* 10 */
 		FF(c, d, a, b, 0, S13, 0xffff5bb1);	/* 11 */
 		FF(b, c, d, a, 0, S14, 0x895cd7be);	/* 12 */
 		FF(a, b, c, d, 0, S11, 0x6b901122);	/* 13 */
 		FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
 		FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
 		FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
-
 		GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
 		GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
 		GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
@@ -358,32 +301,30 @@ inline void md5_digest(uint *x, uint *result, uint len,
 		GG(d, a, b, c, 0, S22, 0x2441453);	/* 22 */
 		GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
 		GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
-		GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
+		GG(a, b, c, d, 0, S21, 0x21e1cde6);	/* 25 */
 		GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
 		GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
-		GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
+		GG(b, c, d, a, 0, S24, 0x455a14ed);	/* 28 */
 		GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
 		GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
 		GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
 		GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
-
 		HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
-		HH2(d, a, b, c, x[8], S32, 0x8771f681);	/* 34 */
+		HH2(d, a, b, c, 0, S32, 0x8771f681);	/* 34 */
 		HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
 		HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
 		HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
 		HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
 		HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
-		HH2(b, c, d, a, 0, S34, 0xbebfbc70);/* 40 */
+		HH2(b, c, d, a, 0, S34, 0xbebfbc70);	/* 40 */
 		HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
 		HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
 		HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
 		HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
-		HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
-		HH2(d, a, b, c, 0, S32, 0xe6db99e5);/* 46 */
+		HH(a, b, c, d, 0, S31, 0xd9d4d039);	/* 45 */
+		HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
 		HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
 		HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
-
 		II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
 		II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
 		II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
@@ -392,16 +333,176 @@ inline void md5_digest(uint *x, uint *result, uint len,
 		II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
 		II(c, d, a, b, 0, S43, 0xffeff47d);	/* 55 */
 		II(b, c, d, a, x[1], S44, 0x85845dd1);	/* 56 */
-		II(a, b, c, d, x[8], S41, 0x6fa87e4f);	/* 57 */
+		II(a, b, c, d, 0, S41, 0x6fa87e4f);	/* 57 */
 		II(d, a, b, c, 0, S42, 0xfe2ce6e0);	/* 58 */
 		II(c, d, a, b, x[6], S43, 0xa3014314);	/* 59 */
 		II(b, c, d, a, 0, S44, 0x4e0811a1);	/* 60 */
 		II(a, b, c, d, x[4], S41, 0xf7537e82);	/* 61 */
 		II(d, a, b, c, 0, S42, 0xbd3af235);	/* 62 */
+		II(c, d, a, b, x[2], S43, 0x2ad7d2bb);	/* 63 */
+		II(b, c, d, a, 0, S44, 0xeb86d391);	/* 64 */
+	} else {
+		FF(a, b, c, d, x[8], S11, 0x698098d8);	/* 9 */
+		FF(d, a, b, c, x[9], S12, 0x8b44f7af);	/* 10 */
+		if (len <= 10*4*8) {
+			if (len == 10*4*8) {
+/* This code path is frequently reached with pass_len = 8, salt_len = 8 */
+				FF(c, d, a, b, 0x80, S13, 0xffff5bb1);	/* 11 */
+				FF(b, c, d, a, 0, S14, 0x895cd7be);	/* 12 */
+				FF(a, b, c, d, 0, S11, 0x6b901122);	/* 13 */
+				FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
+				FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
+				FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
+				GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
+				GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
+				GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
+				GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);	/* 20 */
+				GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
+				GG(d, a, b, c, 0x80, S22, 0x2441453);	/* 22 */
+				GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
+				GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
+				GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
+				GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
+				GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
+				GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
+				GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
+				GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
+				GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
+				GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
+				HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
+				HH2(d, a, b, c, x[8], S32, 0x8771f681);	/* 34 */
+				HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
+				HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
+				HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
+				HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
+				HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
+				HH2(b, c, d, a, 0x80, S34, 0xbebfbc70);	/* 40 */
+				HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
+				HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
+				HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
+				HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
+				HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
+				HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
+				HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
+				HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
+				II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
+				II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
+				II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
+				II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
+				II(a, b, c, d, 0, S41, 0x655b59c3);	/* 53 */
+				II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
+				II(c, d, a, b, 0x80, S43, 0xffeff47d);	/* 55 */
+			} else {
+				FF(c, d, a, b, 0, S13, 0xffff5bb1);	/* 11 */
+				FF(b, c, d, a, 0, S14, 0x895cd7be);	/* 12 */
+				FF(a, b, c, d, 0, S11, 0x6b901122);	/* 13 */
+				FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
+				FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
+				FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
+				GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
+				GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
+				GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
+				GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);	/* 20 */
+				GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
+				GG(d, a, b, c, 0, S22, 0x2441453);	/* 22 */
+				GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
+				GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
+				GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
+				GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
+				GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
+				GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
+				GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
+				GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
+				GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
+				GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
+				HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
+				HH2(d, a, b, c, x[8], S32, 0x8771f681);	/* 34 */
+				HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
+				HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
+				HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
+				HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
+				HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
+				HH2(b, c, d, a, 0, S34, 0xbebfbc70);	/* 40 */
+				HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
+				HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
+				HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
+				HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
+				HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
+				HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
+				HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
+				HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
+				II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
+				II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
+				II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
+				II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
+				II(a, b, c, d, 0, S41, 0x655b59c3);	/* 53 */
+				II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
+				II(c, d, a, b, 0, S43, 0xffeff47d);	/* 55 */
+			}
+			II(b, c, d, a, x[1], S44, 0x85845dd1);	/* 56 */
+			II(a, b, c, d, x[8], S41, 0x6fa87e4f);	/* 57 */
+			II(d, a, b, c, 0, S42, 0xfe2ce6e0);	/* 58 */
+			II(c, d, a, b, x[6], S43, 0xa3014314);	/* 59 */
+			II(b, c, d, a, 0, S44, 0x4e0811a1);	/* 60 */
+			II(a, b, c, d, x[4], S41, 0xf7537e82);	/* 61 */
+			II(d, a, b, c, 0, S42, 0xbd3af235);	/* 62 */
+		} else {
+			FF(c, d, a, b, x[10], S13, 0xffff5bb1);	/* 11 */
+			FF(b, c, d, a, x[11], S14, 0x895cd7be);	/* 12 */
+			FF(a, b, c, d, x[12], S11, 0x6b901122);	/* 13 */
+			FF(d, a, b, c, x[13], S12, 0xfd987193);	/* 14 */
+			FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
+			FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
+			GG(a, b, c, d, x[1], S21, 0xf61e2562);	/* 17 */
+			GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
+			GG(c, d, a, b, x[11], S23, 0x265e5a51);	/* 19 */
+			GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);	/* 20 */
+			GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
+			GG(d, a, b, c, x[10], S22, 0x2441453);	/* 22 */
+			GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
+			GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
+			GG(a, b, c, d, x[9], S21, 0x21e1cde6);	/* 25 */
+			GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
+			GG(c, d, a, b, x[3], S23, 0xf4d50d87);	/* 27 */
+			GG(b, c, d, a, x[8], S24, 0x455a14ed);	/* 28 */
+			GG(a, b, c, d, x[13], S21, 0xa9e3e905);	/* 29 */
+			GG(d, a, b, c, x[2], S22, 0xfcefa3f8);	/* 30 */
+			GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
+			GG(b, c, d, a, x[12], S24, 0x8d2a4c8a);	/* 32 */
+			HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
+			HH2(d, a, b, c, x[8], S32, 0x8771f681);	/* 34 */
+			HH(c, d, a, b, x[11], S33, 0x6d9d6122);	/* 35 */
+			HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
+			HH(a, b, c, d, x[1], S31, 0xa4beea44);	/* 37 */
+			HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
+			HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
+			HH2(b, c, d, a, x[10], S34, 0xbebfbc70);/* 40 */
+			HH(a, b, c, d, x[13], S31, 0x289b7ec6);	/* 41 */
+			HH2(d, a, b, c, x[0], S32, 0xeaa127fa);	/* 42 */
+			HH(c, d, a, b, x[3], S33, 0xd4ef3085);	/* 43 */
+			HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
+			HH(a, b, c, d, x[9], S31, 0xd9d4d039);	/* 45 */
+			HH2(d, a, b, c, x[12], S32, 0xe6db99e5);/* 46 */
+			HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
+			HH2(b, c, d, a, x[2], S34, 0xc4ac5665);	/* 48 */
+			II(a, b, c, d, x[0], S41, 0xf4292244);	/* 49 */
+			II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
+			II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
+			II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
+			II(a, b, c, d, x[12], S41, 0x655b59c3);	/* 53 */
+			II(d, a, b, c, x[3], S42, 0x8f0ccc92);	/* 54 */
+			II(c, d, a, b, x[10], S43, 0xffeff47d);	/* 55 */
+			II(b, c, d, a, x[1], S44, 0x85845dd1);	/* 56 */
+			II(a, b, c, d, x[8], S41, 0x6fa87e4f);	/* 57 */
+			II(d, a, b, c, 0, S42, 0xfe2ce6e0);	/* 58 */
+			II(c, d, a, b, x[6], S43, 0xa3014314);	/* 59 */
+			II(b, c, d, a, x[13], S44, 0x4e0811a1);	/* 60 */
+			II(a, b, c, d, x[4], S41, 0xf7537e82);	/* 61 */
+			II(d, a, b, c, x[11], S42, 0xbd3af235);	/* 62 */
+		}
+		II(c, d, a, b, x[2], S43, 0x2ad7d2bb);	/* 63 */
+		II(b, c, d, a, x[9], S44, 0xeb86d391);	/* 64 */
 	}
-
-	II(c, d, a, b, x[2], S43, 0x2ad7d2bb);	/* 63 */
-	II(b, c, d, a, x[9], S44, 0xeb86d391);	/* 64 */
 
 	a += 0x67452301;
 	b += 0xefcdab89;

--- a/src/opencl/cryptmd5_kernel.cl
+++ b/src/opencl/cryptmd5_kernel.cl
@@ -10,7 +10,12 @@
 
 #include "opencl_misc.h"
 
-//#define USE_BITSELECT 1
+#if gpu_amd(DEVICE_INFO)
+#define USE_BITSELECT 1
+#endif
+
+#define MD5_LUT3 HAVE_LUT3
+
 //#define BITALIGN_AGGRESSIVE
 //#define UNROLL_AGGRESSIVE
 //#define UNROLL_LESS
@@ -19,8 +24,6 @@
 #if !amd_gcn(DEVICE_INFO) || DEV_VER_MAJOR < 2500
 #define BUF_UPDATE_SWITCH
 #endif
-
-#undef MD5_LUT3 /* No good for this format, just here for reference */
 
 #define ROTATE_LEFT(x, s) rotate(x, (uint)s)
 
@@ -33,7 +36,7 @@
 #define G(x, y, z)	bitselect(y, x, z)
 #else
 #if HAVE_ANDNOT
-#define F(x, y, z) ((x & y) ^ ((~x) & z))
+#define F(x, y, z)	((x & y) ^ ((~x) & z))
 #else
 #define F(x, y, z)	(z ^ (x & (y ^ z)))
 #endif


### PR DESCRIPTION
The below description is edited to reflect extra commits pushed to this PR.

Since our private array variables are effectively in cached global memory, it makes sense to minimize accesses to them (more so than to minimize the amount of memory allocated, which has only indirect effect on speed through changes in locality of reference). Included in this PR are three relevant commits where one packs the contents of 2 tiny used-to-be arrays into 3 32-bit registers just before the main loop (the former "array elements" are then extracted by the loop using shifts and masks), another further reduces the number of reads from the current MD5 input buffer for commonly seen input lengths (there's no need to read zeroes beyond the filled length, and we can also infer when we'd read the 0x80 padding byte and avoid reading it if so), and a commit pushed later keeps the MD5 result in registers on every other iteration.

While at it, I've also re-enabled explicit bitselect and LUT3, which doesn't appear to have made any obvious difference, but didn't hurt either.

Finally, the latest commit disables specialization to password length if it varies within the group. This has a performance impact of maybe 2% when the length does not vary. It's also much less optimal than not even having the specialization code compiled in when the length does vary. But it feels like a reasonable trade-off for now.

Autotune ends up with much higher GWS now. That's because performance continues to improve with higher GWS. Forcing it to the previously seen lower GWS still results in improved speeds, but now there's opportunity for even higher speeds at higher GWS. The usability drawback of having higher GWS is unfortunate - e.g., it shows in high granularity of changes of p/s below. However, the performance impact of higher GWS with mixed password lengths is avoided by selectively disabling the specialization to password length in individual mixed-length groups.

Speeds for length 7:

```
[solar@super run]$ rm -r ~/.nv/ComputeCache # workaround issue #3620 for our GTX 1080
[solar@super run]$ ./john -form=md5crypt-opencl -dev=0,3,4,5 -fork=4 pw-md5crypt-diffsalt -v=4 -mask='?a?a?a?a?a?a?a'
Using default input encoding: UTF-8
Loaded 1000 password hashes with 1000 different salts (md5crypt-opencl, crypt(3) $1$ [MD5 OpenCL])
Node numbers 1-4 of 4 (fork)
Device 0: gfx900 [Radeon RX Vega]
Device 5: GeForce GTX TITAN
Device 4: GeForce GTX TITAN X
Device 3: GeForce GTX 1080
4: Local worksize (LWS) 128, global worksize (GWS) 21504 (168 blocks)
2: Local worksize (LWS) 32, global worksize (GWS) 327680 (10240 blocks)
1: Local worksize (LWS) 256, global worksize (GWS) 262144 (1024 blocks)
3: Local worksize (LWS) 64, global worksize (GWS) 786432 (12288 blocks)
Press 'q' or Ctrl-C to abort, almost any other key for status
4 0g 0:00:00:03  0g/s 0p/s 3278Kc/s 3278KC/s GPU:57C X6,6,6,..l*&6,6,
3 0g 0:00:00:02  0g/s 0p/s 7973Kc/s 7973KC/s GPU:61C C........#*LD...
2 0g 0:00:00:02  0g/s 0p/s 9290Kc/s 9290KC/s GPU:63C 6,6,6,6...n*,6,6
1 0g 0:00:00:03  0g/s 0p/s 6062Kc/s 6062KC/s aaaaaaa..Oojaaaa
4 0g 0:00:00:12  0g/s 1755p/s 3305Kc/s 3305KC/s GPU:62C s*&6,6,..NeQ6,6,
1 0g 0:00:00:12  0g/s 0p/s 6161Kc/s 6161KC/s aaaaaaa..Oojaaaa
2 0g 0:00:00:11  0g/s 0p/s 9418Kc/s 9418KC/s GPU:66C 6,6,6,6...n*,6,6
3 0g 0:00:00:11  0g/s 0p/s 8137Kc/s 8137KC/s GPU:65C C........#*LD...
2 0g 0:00:00:31  0g/s 0p/s 9408Kc/s 9408KC/s GPU:72C 6,6,6,6...n*,6,6
4 0g 0:00:00:32  0g/s 2667p/s 3292Kc/s 3292KC/s GPU:71C 9+'6,6,..D9%6,6,
1 0g 0:00:00:32  0g/s 0p/s 6181Kc/s 6181KC/s aaaaaaa..Oojaaaa
3 0g 0:00:00:31  0g/s 0p/s 8136Kc/s 8136KC/s GPU:73C C........#*LD...
4 0g 0:00:01:26  0g/s 3241p/s 3272Kc/s 3272KC/s GPU:81C Ehlb,6,..XG0b,6,
2 0g 0:00:01:25  0g/s 7656p/s 9336Kc/s 9336KC/s GPU:83C &Ae\6,6..1FI\6,6
1 0g 0:00:01:26  0g/s 6092p/s 6184Kc/s 6184KC/s )sJaaaa..h3:aaaa
3 0g 0:00:01:25  0g/s 0p/s 8083Kc/s 8083KC/s GPU:84C C........#*LD...
```

The autotuning for Vega 64 is now highly sub-optimal, maybe because the test vectors differ from actual passwords too much. The above shows 6200K, but we can also do 7200K at lower GWS:

```
[solar@super run]$ LWS=64 GWS=32768 ./john -form=md5crypt-opencl -dev=0 pw-md5crypt-diffsalt -v=4 -mask='?a?a?a?a?a?a?a' 
Device 0: gfx900 [Radeon RX Vega]
Using default input encoding: UTF-8
Loaded 1000 password hashes with 1000 different salts (md5crypt-opencl, crypt(3) $1$ [MD5 OpenCL])
Local worksize (LWS) 64, global worksize (GWS) 32768 (512 blocks)
Press 'q' or Ctrl-C to abort, almost any other key for status
0g 0:00:00:06  0g/s 5354p/s 7121Kc/s 7121KC/s [-iaaaa..'blaaaa
0g 0:00:00:17  0g/s 5742p/s 7225Kc/s 7225KC/s +"2aaaa..ZBcaaaa
0g 0:00:00:35  0g/s 6531p/s 7253Kc/s 7253KC/s CL7aaaa..Oojaaaa
0g 0:00:01:00  0g/s 7077p/s 7259Kc/s 7259KC/s o5.aaaa..>)Yaaaa
```

Speeds for length 8:

```
[solar@super run]$ rm -r ~/.nv/ComputeCache; ./john -form=md5crypt-opencl -dev=0,3,4,5 -fork=4 pw-md5crypt-diffsalt -v=4 -mask='?a?a?a?a?a?a?a?a'
Using default input encoding: UTF-8
Loaded 1000 password hashes with 1000 different salts (md5crypt-opencl, crypt(3) $1$ [MD5 OpenCL])
Node numbers 1-4 of 4 (fork)
Device 0: gfx900 [Radeon RX Vega]
Device 5: GeForce GTX TITAN
Device 4: GeForce GTX TITAN X
Device 3: GeForce GTX 1080
1: Local worksize (LWS) 64, global worksize (GWS) 262144 (4096 blocks)
4: Local worksize (LWS) 128, global worksize (GWS) 21504 (168 blocks)
Press 'q' or Ctrl-C to abort, almost any other key for status
3: Local worksize (LWS) 32, global worksize (GWS) 393216 (12288 blocks)
2: Local worksize (LWS) 32, global worksize (GWS) 163840 (5120 blocks)
4 0g 0:00:00:12  0g/s 1761p/s 3478Kc/s 3478KC/s GPU:61C Gmk,6,6,..`Dp,6,6,
2 0g 0:00:00:12  0g/s 0p/s 8624Kc/s 8624KC/s GPU:74C ,6,6,6,6..xO^6,6,6
1 0g 0:00:00:13  0g/s 0p/s 7661Kc/s 7661KC/s aaaaaaaa..Oojaaaaa
3 0g 0:00:00:11  0g/s 0p/s 7920Kc/s 7920KC/s GPU:65C ..........Gr>.....
1 0g 0:00:00:30  0g/s 0p/s 7688Kc/s 7688KC/s aaaaaaaa..Oojaaaaa
2 0g 0:00:00:29  0g/s 5628p/s 8628Kc/s 8628KC/s GPU:78C EO^6,6,6..a!mb,6,6
4 0g 0:00:00:29  0g/s 2945p/s 3470Kc/s 3470KC/s GPU:69C Fkz,6,6,..1Vx,6,6,
3 0g 0:00:00:28  0g/s 0p/s 7883Kc/s 7883KC/s GPU:72C ..........Gr>.....
4 0g 0:00:00:59  0g/s 3269p/s 3453Kc/s 3453KC/s GPU:78C Myq,6,6,..?U.,6,6,
2 0g 0:00:00:59  0g/s 8313p/s 8596Kc/s 8596KC/s GPU:83C  #vb,6,6..7<Db,6,6
1 0g 0:00:01:00  0g/s 4364p/s 7699Kc/s 7699KC/s Lojaaaaa..?sJaaaaa
3 0g 0:00:00:58  0g/s 6765p/s 7861Kc/s 7861KC/s GPU:81C Jr>......./*LD....
```

The autotuning problem for Vega 64 is also present, but is less significant - we got 7700K at highly inflated GWS, whereas we could do 7800K at much lower GWS:

```
[solar@super run]$ LWS=64 GWS=32768 ./john -form=md5crypt-opencl -dev=0 pw-md5crypt-diffsalt -v=4 -mask='?a?a?a?a?a?a?a?a' 
Device 0: gfx900 [Radeon RX Vega]
Using default input encoding: UTF-8
Loaded 1000 password hashes with 1000 different salts (md5crypt-opencl, crypt(3) $1$ [MD5 OpenCL])
Local worksize (LWS) 64, global worksize (GWS) 32768 (512 blocks)
Press 'q' or Ctrl-C to abort, almost any other key for status
0g 0:00:00:10  0g/s 6482p/s 7769Kc/s 7769KC/s ;blaaaaa..&"2aaaaa
0g 0:00:00:39  0g/s 7540p/s 7839Kc/s 7839KC/s wFwaaaaa..bjEaaaaa
0g 0:00:00:58  0g/s 7330p/s 7848Kc/s 7848KC/s o5.aaaaa..>)Yaaaaa
0g 0:00:01:01  0g/s 7506p/s 7836Kc/s 7836KC/s {)Yaaaaa.."TUaaaaa
```

Unfortunately, the extra specialization (meaning extra runtime checks, since it's just one shared kernel) I introduce here for length 8 hurt speeds observed for length 7 on our GTX 1080 a little bit, but it more significantly improves the speeds for length 8 (and doesn't hurt length 7 much on other GPUs).

For comparison, Hashcat at length 7:

```
$ ./hashcat --version
v5.1.0-42-g471a8cc+
$ ./hashcat -a3 -O -m500 -d1,4,5,6 -w3 pw-md5crypt-diffsalt '?a?a?a?a?a?a?a'
[...]
Session..........: hashcat
Status...........: Running
Hash.Type........: md5crypt, MD5 (Unix), Cisco-IOS $1$ (MD5)
Hash.Target......: pw-md5crypt-diffsalt
Time.Started.....: Fri Feb  1 10:42:44 2019 (1 min, 1 sec)
Time.Estimated...: Mon Dec 17 21:50:10 2136 (117 years, 319 days)
Guess.Mask.......: ?a?a?a?a?a?a?a [7]
Guess.Queue......: 1/1 (100.00%)
Speed.#4.........:  9826.1 kH/s (64.75ms) @ Accel:1024 Loops:1000 Thr:32 Vec:1
Speed.#5.........:  7306.6 kH/s (53.00ms) @ Accel:1024 Loops:500 Thr:32 Vec:1
Speed.#6.........:  1640.7 kH/s (69.25ms) @ Accel:512 Loops:500 Thr:32 Vec:1
Speed.#*.........: 18773.4 kH/s
Recovered........: 0/1000 (0.00%) Digests, 0/1000 (0.00%) Salts
Progress.........: 1154220032/69833729609375000 (0.00%)
Rejected.........: 0/1154220032 (0.00%)
Restore.Point....: 0/735091890625 (0.00%)
Restore.Sub.#4...: Salt:9 Amplifier:67-68 Iteration:0-1000
Restore.Sub.#5...: Salt:6 Amplifier:1-2 Iteration:500-1000
Restore.Sub.#6...: Salt:4 Amplifier:60-61 Iteration:0-500
Candidates.#4....: Uarieri -> UYiQUS1
Candidates.#5....: mTdWERI -> m&Q(199
Candidates.#6....: Z$Uyana -> Ztz>><3
Hardware.Mon.#4..: Temp: 77c Fan: 57% Util:100% Core:1759MHz Mem:4513MHz Bus:8
Hardware.Mon.#5..: Temp: 74c Fan: 31% Util:100% Core:1164MHz Mem:3304MHz Bus:16
Hardware.Mon.#6..: Temp: 63c Fan: 40% Util:100% Core:1045MHz Mem:3304MHz Bus:16
```

It fails to build its md5crypt kernel for Vega 64 with our driver because of trying to use inline asm, which the compiler doesn't recognize. Then uses the 3 NVIDIA cards. Hashcat's speed on GTX 1080 is still somewhat higher than ours (us 9300K, them 9800K), but now we're somewhat faster than Hashcat on Titan X Maxwell (us 8100K, them 7300K), and Hashcat's speed on the old Titan Kepler is twice lower than ours (this was the case prior to this PR as well, possibly to an even greater extent - we might have a slight regression here).

Hashcat at length 8 (invoked the same as above, just with different mask):

```
Session..........: hashcat
Status...........: Running
Hash.Type........: md5crypt, MD5 (Unix), Cisco-IOS $1$ (MD5)
Hash.Target......: pw-md5crypt-diffsalt
Time.Started.....: Fri Feb  1 19:55:00 2019 (1 min, 1 sec)
Time.Estimated...: Next Big Bang (11757 years, 181 days)
Guess.Mask.......: ?a?a?a?a?a?a?a?a [8]
Guess.Queue......: 1/1 (100.00%)
Speed.#4.........:  9046.0 kH/s (71.79ms) @ Accel:1024 Loops:1000 Thr:32 Vec:1
Speed.#5.........:  7206.5 kH/s (53.26ms) @ Accel:1024 Loops:500 Thr:32 Vec:1
Speed.#6.........:  1628.0 kH/s (69.78ms) @ Accel:512 Loops:500 Thr:32 Vec:1
Speed.#*.........: 17880.5 kH/s
Recovered........: 0/1000 (0.00%) Digests, 0/1000 (0.00%) Salts
Progress.........: 1086750720/6634204312890625000 (0.00%)
Rejected.........: 0/1086750720 (0.00%)
Restore.Point....: 0/69833729609375 (0.00%)
Restore.Sub.#4...: Salt:8 Amplifier:79-80 Iteration:0-1000
Restore.Sub.#5...: Salt:5 Amplifier:82-83 Iteration:0-500
Restore.Sub.#6...: Salt:4 Amplifier:51-52 Iteration:500-1000
Candidates.#4....: "arierin -> "YiQUS12
Candidates.#5....: &TdWERIN -> &&Q(1999
Candidates.#6....: F$Uyanan -> Ftz>><34
Hardware.Mon.#4..: Temp: 85c Fan: 66% Util:100% Core:1607MHz Mem:4513MHz Bus:8
Hardware.Mon.#5..: Temp: 82c Fan: 38% Util:100% Core:1151MHz Mem:3304MHz Bus:16
Hardware.Mon.#6..: Temp: 73c Fan: 44% Util:100% Core:1045MHz Mem:3304MHz Bus:16
```

Again, we're still somewhat slower than Hashcat on GTX 1080 (us 8600K, them 9050K), somewhat faster on Titan X Maxwell (us 7850K, them 7200K), and twice faster on Titan Kepler.

Adding `--markov-disable` to the Hashcat invocations (which I forgot to do above) appears to "swap" its speeds on GTX 1080 for length 7 and 8, while leaving speeds on other GPUs almost unchanged. Weird. Or maybe it's just the weirdness of our GTX 1080's boost clocks, etc.

Vega 64 gives 6200K or 7200K (autotuning vs. manual tuning) at length 7 and 7700K or 7800K at length 8. I have no results for Hashcat to compare these speeds against, but they look OK'ish to me for now. IIRC, they're about twice the speeds that Hashcat was reported to give on a HD7970 back then. Vega 64 is basically a 2x7970 at a higher max clock rate, but power limited.

I've also tried placing the context buffers in local memory (~28 KB, LWS=64), but this significantly hurt speeds on all 4 GPUs, so I don't include that unfinished code revision in here, not even as an option.

What I think could actually result in huge speedup is keeping all buffers in registers. This should be possible on AMD due to indexed access to VGPRs, but might require implementing the whole kernel in asm. It should also be possible on any arch through much larger code (in excess of L1 instruction caches, but possibly still OK as long as the fetches are in sync and their cost is amortized?) where we'd have 8 or so implementations of MD5 (or just of register copying before a shared implementation) using different registers as inputs, followed by a similar number of output buffer write implementations with different buffers and offsets (actually writing into different registers). Or we could put the main 8 MD5 buffers into registers in the same way I put the two tiny arrays into registers in this PR: one `ulong` or two `uint` (two 32-bit registers) can hold one byte from each of the 8 buffers. I wonder if extracting the data from there would be quicker than reading from cached memory. It might be.