### PR TITLE
md5crypt-opencl: Further specialization for password length 8

### DIFF
--- a/src/opencl/cryptmd5_kernel.cl
+++ b/src/opencl/cryptmd5_kernel.cl
@@ -296,56 +296,110 @@ inline void md5_digest(uint *x, uint *y, uint *z, uint *zmem, uint zmem_offset, 
 	FF(d, a, b, c, x[5], S12, 0x4787c62a);	/* 6 */
 	FF(c, d, a, b, x[6], S13, 0xa8304613);	/* 7 */
 	FF(b, c, d, a, x[7], S14, 0xfd469501);	/* 8 */
-	if (len + unify < 8*4*8) {
-		FF(a, b, c, d, 0, S11, 0x698098d8);	/* 9 */
-		FF(d, a, b, c, 0, S12, 0x8b44f7af);	/* 10 */
-		FF(c, d, a, b, 0, S13, 0xffff5bb1);	/* 11 */
-		FF(b, c, d, a, 0, S14, 0x895cd7be);	/* 12 */
-		FF(a, b, c, d, 0, S11, 0x6b901122);	/* 13 */
-		FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
-		FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
-		FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
-		GG(a, b, c, d, x1, S21, 0xf61e2562);	/* 17 */
-		GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
-		GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
-		GG(b, c, d, a, x0, S24, 0xe9b6c7aa);	/* 20 */
-		GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
-		GG(d, a, b, c, 0, S22, 0x2441453);	/* 22 */
-		GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
-		GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
-		GG(a, b, c, d, 0, S21, 0x21e1cde6);	/* 25 */
-		GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
-		GG(c, d, a, b, x3, S23, 0xf4d50d87);	/* 27 */
-		GG(b, c, d, a, 0, S24, 0x455a14ed);	/* 28 */
-		GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
-		GG(d, a, b, c, x2, S22, 0xfcefa3f8);	/* 30 */
-		GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
-		GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
-		HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
-		HH2(d, a, b, c, 0, S32, 0x8771f681);	/* 34 */
-		HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
-		HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
-		HH(a, b, c, d, x1, S31, 0xa4beea44);	/* 37 */
-		HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
-		HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
-		HH2(b, c, d, a, 0, S34, 0xbebfbc70);	/* 40 */
-		HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
-		HH2(d, a, b, c, x0, S32, 0xeaa127fa);	/* 42 */
-		HH(c, d, a, b, x3, S33, 0xd4ef3085);	/* 43 */
-		HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
-		HH(a, b, c, d, 0, S31, 0xd9d4d039);	/* 45 */
-		HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
-		HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
-		HH2(b, c, d, a, x2, S34, 0xc4ac5665);	/* 48 */
-		II(a, b, c, d, x0, S41, 0xf4292244);	/* 49 */
-		II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
-		II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
-		II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
-		II(a, b, c, d, 0, S41, 0x655b59c3);	/* 53 */
-		II(d, a, b, c, x3, S42, 0x8f0ccc92);	/* 54 */
-		II(c, d, a, b, 0, S43, 0xffeff47d);	/* 55 */
-		II(b, c, d, a, x1, S44, 0x85845dd1);	/* 56 */
-		II(a, b, c, d, 0, S41, 0x6fa87e4f);	/* 57 */
+	uint lenu = len + unify;
+	if (lenu <= 8*4*8) {
+		if (lenu == 8*4*8) {
+/* This code path is frequently reached with pass_len = 8 */
+			FF(a, b, c, d, 0x80, S11, 0x698098d8);	/* 9 */
+			FF(d, a, b, c, 0, S12, 0x8b44f7af);	/* 10 */
+			FF(c, d, a, b, 0, S13, 0xffff5bb1);	/* 11 */
+			FF(b, c, d, a, 0, S14, 0x895cd7be);	/* 12 */
+			FF(a, b, c, d, 0, S11, 0x6b901122);	/* 13 */
+			FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
+			FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
+			FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
+			GG(a, b, c, d, x1, S21, 0xf61e2562);	/* 17 */
+			GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
+			GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
+			GG(b, c, d, a, x0, S24, 0xe9b6c7aa);	/* 20 */
+			GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
+			GG(d, a, b, c, 0, S22, 0x2441453);	/* 22 */
+			GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
+			GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
+			GG(a, b, c, d, 0, S21, 0x21e1cde6);	/* 25 */
+			GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
+			GG(c, d, a, b, x3, S23, 0xf4d50d87);	/* 27 */
+			GG(b, c, d, a, 0x80, S24, 0x455a14ed);	/* 28 */
+			GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
+			GG(d, a, b, c, x2, S22, 0xfcefa3f8);	/* 30 */
+			GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
+			GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
+			HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
+			HH2(d, a, b, c, 0x80, S32, 0x8771f681);	/* 34 */
+			HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
+			HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
+			HH(a, b, c, d, x1, S31, 0xa4beea44);	/* 37 */
+			HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
+			HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
+			HH2(b, c, d, a, 0, S34, 0xbebfbc70);	/* 40 */
+			HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
+			HH2(d, a, b, c, x0, S32, 0xeaa127fa);	/* 42 */
+			HH(c, d, a, b, x3, S33, 0xd4ef3085);	/* 43 */
+			HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
+			HH(a, b, c, d, 0, S31, 0xd9d4d039);	/* 45 */
+			HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
+			HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
+			HH2(b, c, d, a, x2, S34, 0xc4ac5665);	/* 48 */
+			II(a, b, c, d, x0, S41, 0xf4292244);	/* 49 */
+			II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
+			II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
+			II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
+			II(a, b, c, d, 0, S41, 0x655b59c3);	/* 53 */
+			II(d, a, b, c, x3, S42, 0x8f0ccc92);	/* 54 */
+			II(c, d, a, b, 0, S43, 0xffeff47d);	/* 55 */
+			II(b, c, d, a, x1, S44, 0x85845dd1);	/* 56 */
+			II(a, b, c, d, 0x80, S41, 0x6fa87e4f);	/* 57 */
+		} else {
+			FF(a, b, c, d, 0, S11, 0x698098d8);	/* 9 */
+			FF(d, a, b, c, 0, S12, 0x8b44f7af);	/* 10 */
+			FF(c, d, a, b, 0, S13, 0xffff5bb1);	/* 11 */
+			FF(b, c, d, a, 0, S14, 0x895cd7be);	/* 12 */
+			FF(a, b, c, d, 0, S11, 0x6b901122);	/* 13 */
+			FF(d, a, b, c, 0, S12, 0xfd987193);	/* 14 */
+			FF(c, d, a, b, len, S13, 0xa679438e);	/* 15 */
+			FF(b, c, d, a, 0, S14, 0x49b40821);	/* 16 */
+			GG(a, b, c, d, x1, S21, 0xf61e2562);	/* 17 */
+			GG(d, a, b, c, x[6], S22, 0xc040b340);	/* 18 */
+			GG(c, d, a, b, 0, S23, 0x265e5a51);	/* 19 */
+			GG(b, c, d, a, x0, S24, 0xe9b6c7aa);	/* 20 */
+			GG(a, b, c, d, x[5], S21, 0xd62f105d);	/* 21 */
+			GG(d, a, b, c, 0, S22, 0x2441453);	/* 22 */
+			GG(c, d, a, b, 0, S23, 0xd8a1e681);	/* 23 */
+			GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);	/* 24 */
+			GG(a, b, c, d, 0, S21, 0x21e1cde6);	/* 25 */
+			GG(d, a, b, c, len, S22, 0xc33707d6);	/* 26 */
+			GG(c, d, a, b, x3, S23, 0xf4d50d87);	/* 27 */
+			GG(b, c, d, a, 0, S24, 0x455a14ed);	/* 28 */
+			GG(a, b, c, d, 0, S21, 0xa9e3e905);	/* 29 */
+			GG(d, a, b, c, x2, S22, 0xfcefa3f8);	/* 30 */
+			GG(c, d, a, b, x[7], S23, 0x676f02d9);	/* 31 */
+			GG(b, c, d, a, 0, S24, 0x8d2a4c8a);	/* 32 */
+			HH(a, b, c, d, x[5], S31, 0xfffa3942);	/* 33 */
+			HH2(d, a, b, c, 0, S32, 0x8771f681);	/* 34 */
+			HH(c, d, a, b, 0, S33, 0x6d9d6122);	/* 35 */
+			HH2(b, c, d, a, len, S34, 0xfde5380c);	/* 36 */
+			HH(a, b, c, d, x1, S31, 0xa4beea44);	/* 37 */
+			HH2(d, a, b, c, x[4], S32, 0x4bdecfa9);	/* 38 */
+			HH(c, d, a, b, x[7], S33, 0xf6bb4b60);	/* 39 */
+			HH2(b, c, d, a, 0, S34, 0xbebfbc70);	/* 40 */
+			HH(a, b, c, d, 0, S31, 0x289b7ec6);	/* 41 */
+			HH2(d, a, b, c, x0, S32, 0xeaa127fa);	/* 42 */
+			HH(c, d, a, b, x3, S33, 0xd4ef3085);	/* 43 */
+			HH2(b, c, d, a, x[6], S34, 0x4881d05);	/* 44 */
+			HH(a, b, c, d, 0, S31, 0xd9d4d039);	/* 45 */
+			HH2(d, a, b, c, 0, S32, 0xe6db99e5);	/* 46 */
+			HH(c, d, a, b, 0, S33, 0x1fa27cf8);	/* 47 */
+			HH2(b, c, d, a, x2, S34, 0xc4ac5665);	/* 48 */
+			II(a, b, c, d, x0, S41, 0xf4292244);	/* 49 */
+			II(d, a, b, c, x[7], S42, 0x432aff97);	/* 50 */
+			II(c, d, a, b, len, S43, 0xab9423a7);	/* 51 */
+			II(b, c, d, a, x[5], S44, 0xfc93a039);	/* 52 */
+			II(a, b, c, d, 0, S41, 0x655b59c3);	/* 53 */
+			II(d, a, b, c, x3, S42, 0x8f0ccc92);	/* 54 */
+			II(c, d, a, b, 0, S43, 0xffeff47d);	/* 55 */
+			II(b, c, d, a, x1, S44, 0x85845dd1);	/* 56 */
+			II(a, b, c, d, 0, S41, 0x6fa87e4f);	/* 57 */
+		}
 		II(d, a, b, c, 0, S42, 0xfe2ce6e0);	/* 58 */
 		II(c, d, a, b, x[6], S43, 0xa3014314);	/* 59 */
 		II(b, c, d, a, 0, S44, 0x4e0811a1);	/* 60 */
@@ -356,8 +410,8 @@ inline void md5_digest(uint *x, uint *y, uint *z, uint *zmem, uint zmem_offset, 
 	} else {
 		FF(a, b, c, d, x[8], S11, 0x698098d8);	/* 9 */
 		FF(d, a, b, c, x[9], S12, 0x8b44f7af);	/* 10 */
-		if (len + unify <= 10*4*8) {
-			if (len == 10*4*8) {
+		if (lenu <= 10*4*8) {
+			if (lenu == 10*4*8) {
 /* This code path is frequently reached with pass_len = 8, salt_len = 8 */
 				FF(c, d, a, b, 0x80, S13, 0xffff5bb1);	/* 11 */
 				FF(b, c, d, a, 0, S14, 0x895cd7be);	/* 12 */


### PR DESCRIPTION
Much better speeds at length 8:

```
[solar@super run]$ rm -r ~/.nv/ComputeCache; ./john -form=md5crypt-opencl -dev=0,3,4,5 -fork=4 pw-md5crypt-diffsalt -v=4 -mask='?a?a?a?a?a?a?a?a'
Using default input encoding: UTF-8
Loaded 1000 password hashes with 1000 different salts (md5crypt-opencl, crypt(3) $1$ [MD5 OpenCL])
Node numbers 1-4 of 4 (fork)
Device 0: gfx900 [Radeon RX Vega]
Device 5: GeForce GTX TITAN
Device 4: GeForce GTX TITAN X
Device 3: GeForce GTX 1080
1: Local worksize (LWS) 64, global worksize (GWS) 32768 (512 blocks)
Press 'q' or Ctrl-C to abort, almost any other key for status
4: Local worksize (LWS) 128, global worksize (GWS) 172032 (1344 blocks)
2: Local worksize (LWS) 32, global worksize (GWS) 163840 (5120 blocks)
3: Local worksize (LWS) 32, global worksize (GWS) 1572864 (49152 blocks)
1 0g 0:00:00:28  0g/s 8177p/s 8248Kc/s 8248KC/s CL7aaaaa..Oojaaaaa
2 0g 0:00:00:26  0g/s 6299p/s 9505Kc/s 9505KC/s GPU:78C EO^6,6,6..a!mb,6,6
4 0g 0:00:00:24  0g/s 0p/s 3386Kc/s 3386KC/s GPU:74C 6,6,6,6,..0?S,6,6,
3 0g 0:00:00:24  0g/s 0p/s 8127Kc/s 8127KC/s GPU:77C ..........`&fB....
1 0g 0:00:01:15  0g/s 8296p/s 8318Kc/s 8318KC/s G}/aaaaa..BJ\aaaaa
2 0g 0:00:01:13  0g/s 8977p/s 9338Kc/s 9338KC/s GPU:85C k<Db,6,6..]e#b,6,6
4 0g 0:00:01:11  0g/s 2396p/s 3311Kc/s 3311KC/s GPU:80C 2?S,6,6,..>< ,6,6,
3 0g 0:00:01:11  0g/s 0p/s 7912Kc/s 7912KC/s GPU:83C ..........`&fB....
```

Length 7 isn't hurt too much:

```
[solar@super run]$ rm -r ~/.nv/ComputeCache; ./john -form=md5crypt-opencl -dev=0,3,4,5 -fork=4 pw-md5crypt-diffsalt -v=4 -mask='?a?a?a?a?a?a?a'
Using default input encoding: UTF-8
Loaded 1000 password hashes with 1000 different salts (md5crypt-opencl, crypt(3) $1$ [MD5 OpenCL])
Node numbers 1-4 of 4 (fork)
Device 0: gfx900 [Radeon RX Vega]
Device 5: GeForce GTX TITAN
Device 4: GeForce GTX TITAN X
Device 3: GeForce GTX 1080
4: Local worksize (LWS) 128, global worksize (GWS) 172032 (1344 blocks)
1: Local worksize (LWS) 64, global worksize (GWS) 32768 (512 blocks)
2: Local worksize (LWS) 32, global worksize (GWS) 655360 (20480 blocks)
Press 'q' or Ctrl-C to abort, almost any other key for status
3: Local worksize (LWS) 64, global worksize (GWS) 786432 (12288 blocks)
1 0g 0:00:00:10  0g/s 6520p/s 7173Kc/s 7173KC/s ;blaaaa..&"2aaaa
4 0g 0:00:00:08  0g/s 0p/s 3367Kc/s 3367KC/s GPU:52C X6,6,6,..Pj`6,6,
3 0g 0:00:00:08  0g/s 0p/s 8090Kc/s 8090KC/s GPU:55C C........#*LD...
2 0g 0:00:00:09  0g/s 0p/s 9321Kc/s 9321KC/s GPU:55C 6,6,6,6..\Ae\6,6
1 0g 0:00:01:00  0g/s 7093p/s 7222Kc/s 7222KC/s o5.aaaa..>)Yaaaa
2 0g 0:00:00:59  0g/s 0p/s 9300Kc/s 9300KC/s GPU:70C 6,6,6,6..\Ae\6,6
4 0g 0:00:00:58  0g/s 2941p/s 3344Kc/s 3344KC/s GPU:74C Kj`6,6,..Sxcb,6,
3 0g 0:00:00:58  0g/s 0p/s 8027Kc/s 8027KC/s GPU:76C C........#*LD...
```

See #3627 for previous and hashcat speeds.