### PR TITLE
[List.ZTEX:Devices] - ability to hide Serial Numbers

### DIFF
--- a/doc/README-ZTEX
+++ b/doc/README-ZTEX
@@ -84,3 +84,9 @@ each one with its own set of boards can be invoked. Right now such usage
 is considered experimental - on some USB subsystems several instances
 conflict one with another and errors appear.
 
+Each board has a factory programmed Serial Number (SN). JtR displays
+SNs on startup and in information/error messages. To hide SNs, you can
+list SNs of your boards in [List.ZTEX:Devices] section in john.conf.
+Board numbers (starting from 1) will appear instead of SNs. You can
+specify these numbers in --dev command-line option.
+

--- a/run/john.conf
+++ b/run/john.conf
@@ -395,6 +395,13 @@ AbortTemperature = 95
 
 
 # ZTEX specific settings
+[List.ZTEX:Devices]
+# If you list Serial Numbers (SN) of ZTEX boards here, it will display
+# numbers (starting from 1) instead of factory programmed SN's.
+# These numbers can be used in --dev command-line option.
+#04A31E0123
+#00AD034E01
+
 [ZTEX:descrypt]
 # The design has two programmable clocks. The 1st one is supplied to
 # pipelines of DES rounds, the 2nd clock is supplied to comparators.

--- a/src/ztex/Makefile.in
+++ b/src/ztex/Makefile.in
@@ -12,7 +12,7 @@ EXTRA_LIBS = -lusb-1.0
 
 SUBDIRS = pkt_comm
 
-TEST_OBJS = device.o inouttraffic.o ztex.o ztex_scan.o
+TEST_OBJS = device.o inouttraffic.o ztex.o ztex_scan.o ztex_sn.o
 
 OBJS = $(TEST_OBJS) device_format.o jtr_device.o jtr_mask.o task.o
 
@@ -30,18 +30,21 @@ all: $(SUBDIRS) $(OBJS)
 
 $(SUBDIRS):
 	$(MAKE) -C $@ all
-	
+
 device.o: device.c device.h
 	$(CC) $(CFLAGS) device.c
 
 inouttraffic.o: inouttraffic.c inouttraffic.h
 	$(CC) $(CFLAGS) inouttraffic.c
-	
+
 ztex.o: ztex.c ztex.h
 	$(CC) $(CFLAGS) ztex.c
 
 ztex_scan.o: ztex_scan.c ztex_scan.h
 	$(CC) $(CFLAGS) ztex_scan.c
+
+ztex_sn.o: ztex_sn.c ztex_sn.h
+	$(CC) $(CFLAGS) ztex_sn.c
 
 device_format.o: device_format.c device_format.h
 	$(CC) $(CFLAGS) device_format.c
@@ -51,7 +54,7 @@ jtr_device.o: jtr_device.c jtr_device.h
 
 jtr_mask.o: jtr_mask.c jtr_mask.h
 	$(CC) $(CFLAGS) jtr_mask.c
-	
+
 task.o: task.c task.h
 	$(CC) $(CFLAGS) task.c
 
@@ -59,7 +62,7 @@ task.o: task.c task.h
 
 simple_test: simple_test.c $(SUBDIRS) $(TEST_OBJS)
 	$(CC) $(CFLAGS_TEST) simple_test.c $(TEST_OBJS) $(TEST_EXTRA_OBJS) $(EXTRA_LIBS) -o simple_test
-	
+
 test: test.c $(SUBDIRS) $(TEST_OBJS)
 	$(CC) $(CFLAGS_TEST) test.c $(TEST_OBJS) $(TEST_EXTRA_OBJS) $(EXTRA_LIBS) -o test
 

--- a/src/ztex/ztex.h
+++ b/src/ztex/ztex.h
@@ -16,12 +16,13 @@
 #ifndef _ZTEX_H_
 #define _ZTEX_H_
 
+#include "ztex_sn.h"
+
 #define USB_CMD_TIMEOUT 150
 #define USB_RW_TIMEOUT 500
 
-#define ZTEX_SNSTRING_LEN 11 // includes '\0' terminator
-#define ZTEX_SNSTRING_MIN_LEN 5
-#define ZTEX_PRODUCT_STRING_LEN 32 // includes '\0' terminator
+// includes '\0' terminator
+#define ZTEX_PRODUCT_STRING_LEN 32
 
 #define ZTEX_IDVENDOR 0x221A
 #define ZTEX_IDPRODUCT 0x0100
@@ -42,6 +43,7 @@
 #define CAPABILITY_MAC_EEPROM 0,6
 // Capability index for multi FPGA support.
 #define CAPABILITY_MULTI_FPGA 0,7
+// Copy-pasted from ZTEX SDK! (java)
 // Capability index for Temperature sensor support
 #define CAPABILITY_TEMP_SENSOR 0,8
 // Capability index for 2nd FLASH memory support
@@ -77,8 +79,9 @@ struct ztex_device {
 	int selected_fpga;
 	int valid;
 	struct ztex_device *next;
-	// ZTEX specific stuff from device
 	char snString[ZTEX_SNSTRING_LEN];
+	// ZTEX specific stuff from device
+	char snString_orig[ZTEX_SNSTRING_LEN];
 	unsigned char productId[4];
 	unsigned char fwVersion;
 	unsigned char interfaceVersion;
@@ -90,9 +93,6 @@ struct ztex_device {
 struct ztex_dev_list {
 	struct ztex_device *dev;
 };
-
-// checks if given string is a valid Serial Number
-int ztex_sn_is_valid(char *sn);
 
 int ztex_device_new(libusb_device *usb_dev, struct ztex_device **ztex_dev);
 

--- a/src/ztex/ztex_scan.c
+++ b/src/ztex/ztex_scan.c
@@ -57,14 +57,28 @@ static int ztex_scan(struct ztex_dev_list *new_dev_list, struct ztex_dev_list *d
 
 		// If john is invoked with "--devices" command-line option,
 		// use only listed boards.
-		// If the board has SN of unsupported format - upload firmware.
-		if (jtr_devices_allow->count && (ztex_sn_is_valid(dev->snString)
-					|| !firmware_is_ok(dev)) ) {
-			if (!list_check(jtr_devices_allow, dev->snString)) {
+		if (jtr_devices_allow->count) {
+			// The board may have SN of unsupported format if firmware is
+			// not uploaded - skip check, proceed to firmware upload.
+			if (!ztex_sn_is_valid(dev->snString_orig)) {
+				if (firmware_is_ok(dev)) {
+					// This shouldn't happen (maybe hardware problem)
+					fprintf(stderr, "Error: firmware_is_ok, SN is of "
+						"unsupported format (%s)\n", dev->snString_orig);
+				}
+			}
+			else if (!list_check(jtr_devices_allow, dev->snString)) {
 				ztex_dev_list_remove(new_dev_list, dev);
 				continue;
 			}
 		}
+		/*
+		if (jtr_devices_allow->count && firmware_is_ok(dev)) {
+			if (!list_check(jtr_devices_allow, dev->snString)) {
+				ztex_dev_list_remove(new_dev_list, dev);
+				continue;
+			}
+		}*/
 
 		// Check device type
 		// only 1.15y devices supported for now

--- a/src/ztex/ztex_sn.c
+++ b/src/ztex/ztex_sn.c
@@ -1,0 +1,119 @@
+/*
+ * This software is Copyright (c) 2019 Denis Burykin
+ * [denis_burykin yahoo com], [denis-burykin2014 yandex ru]
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "ztex_sn.h"
+
+#include "../config.h"
+#include "../list.h"
+#include "../misc.h"
+
+
+int ztex_sn_is_valid(char *sn)
+{
+	int i;
+	for (i = 0; i < ZTEX_SNSTRING_LEN; i++) {
+		if (!sn[i])
+			return i < ZTEX_SNSTRING_MIN_LEN ? 0 : 1;
+		if ( !( (sn[i] >= '0' && sn[i] <= '9') || (sn[i] >= 'A' && sn[i] <= 'F')
+				|| (sn[i] >= 'a' && sn[i] <= 'f')) )
+			return 0;
+	}
+	if (sn[i])
+		return 0;
+
+	return 1;
+}
+
+
+struct cfg_list *ztex_sn_conf_devices = NULL;
+
+void ztex_sn_init_conf_devices(void)
+{
+	if (ztex_sn_conf_devices)
+		return;
+
+	ztex_sn_conf_devices = cfg_get_list("List.ZTEX:", "Devices");
+	if (!ztex_sn_conf_devices)
+		return;
+
+	struct cfg_line *line;
+	int found_error = 0;
+	for (line = ztex_sn_conf_devices->head; line; line = line->next) {
+		if (!ztex_sn_is_valid(line->data)) {
+			fprintf(stderr, "Error: [List.ZTEX:Devices] device %d "
+				"(line %d) bad Serial Number '%s'\n",
+				line->id + 1, line->number, line->data);
+			found_error = 1;
+		}
+	}
+
+	if (found_error)
+		error();
+}
+
+
+int ztex_sn_check_alias(char *alias)
+{
+	static int ztex_sn_get_by_alias_error = 0;
+
+	if (!ztex_sn_conf_devices) {
+		if (!ztex_sn_get_by_alias_error) {
+			fprintf(stderr, "Error: [List.ZTEX:Devices] not found\n");
+			ztex_sn_get_by_alias_error = 1;
+		}
+		return 0;
+	}
+
+	int id = atoi(alias); // alias specified in -dev option
+	if (!id) {
+		fprintf(stderr, "Error: invalid -dev=0. Devices are numbered "
+			"starting from 1.\n");
+		return 0;
+	}
+
+	struct cfg_line *line;
+	int last_id = 0;
+	for (line = ztex_sn_conf_devices->head; line; line = line->next) {
+		if (id == line->id + 1)
+			return 1;//line->data;
+		if (!line->next)
+			last_id = line->id + 1;
+	}
+
+	fprintf(stderr, "Error: invalid -dev=%d. Total %d devices are "
+		"defined in [List.ZTEX:Devices]\n", id, last_id);
+	ztex_sn_get_by_alias_error = 1;
+	return 0;
+}
+
+
+char *ztex_sn_get_by_sn_orig(char *sn_orig)
+{
+	if (!ztex_sn_conf_devices)
+		return sn_orig;
+
+	struct cfg_line *line;
+	int found = 0;
+	for (line = ztex_sn_conf_devices->head; line; line = line->next) {
+		if (!strncmp(line->data, sn_orig, ZTEX_SNSTRING_LEN)) {
+			found = 1;
+			break;
+		}
+	}
+	if (!found)
+		return sn_orig;
+
+	static char result[ZTEX_SNSTRING_LEN];
+	sprintf(result, "%d", line->id + 1);
+	return result;
+}
+

--- a/src/ztex/ztex_sn.h
+++ b/src/ztex/ztex_sn.h
@@ -1,0 +1,34 @@
+/*
+ * This software is Copyright (c) 2019 Denis Burykin
+ * [denis_burykin yahoo com], [denis-burykin2014 yandex ru]
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ */
+
+#ifndef _ZTEX_SN_H
+#define _ZTEX_SN_H
+
+// includes '\0' terminator
+#define ZTEX_SNSTRING_LEN 11
+#define ZTEX_SNSTRING_MIN_LEN 5
+
+
+// checks if given string is a valid Serial Number.
+// 3rd party firmware may have SN of different format.
+int ztex_sn_is_valid(char *sn);
+
+// Initialize [List.ZTEX:Devices] configuration section,
+// verify syntax correctness
+void ztex_sn_init_conf_devices(void);
+
+// Check if alias specified in --dev command-line option is correct
+// (SN is specified in [List.ZTEX:Devices])
+int ztex_sn_check_alias(char *alias);
+
+// Given original SN reported by the board, return SN
+// for display in the application.
+char *ztex_sn_get_by_sn_orig(char *sn_orig);
+
+#endif


### PR DESCRIPTION
Each board has a factory programmed Serial Number (SN). JtR displays
SNs on startup and in information/error messages. To hide SNs, you can
list SNs of your boards in [List.ZTEX:Devices] section in john.conf.
Board numbers (starting from 1) will appear instead of SNs. You can
specify these numbers in --dev command-line option.
