### PR TITLE
[SIP] Wrong comment statement which may confuse

### DIFF
--- a/src/sip_fmt_plug.c
+++ b/src/sip_fmt_plug.c
@@ -249,7 +249,7 @@ static void *get_salt(char *ciphertext)
 	//snprintf(salt.dynamic_hash_data, DYNAMIC_HASH_SIZE, "%s:%s:", login.user, login.realm);
 	//salt.dynamic_hash_data_len = strlen(salt.dynamic_hash_data);
 
-	/* Construct last part of final hash data: ':NONCE(:CNONCE:NONCE_COUNT:QOP):<static_hash>' */
+	/* Construct last part of final hash data: ':NONCE(:NONCE_COUNT:CNONCE:QOP):<static_hash>' */
 	/* no qop */
 	if (!strlen(login.qop))
 		snprintf(salt.static_hash_data, STATIC_HASH_SIZE, ":%s:%s", login.nonce, static_hash);


### PR DESCRIPTION
Wrong comment statement which may confuse: NONCE_COUNT should go prior to CNONCE

RFC: https://tools.ietf.org/html/rfc2617#section-3.2.2.1
request-digest  = <"> < KD ( H(A1),     unq(nonce-value)
                                          ":" nc-value
                                          ":" unq(cnonce-value)
                                          ":" unq(qop-value)
                                          ":" H(A2)
The code which actually concatenates the values however is correct:
snprintf(salt.static_hash_data, STATIC_HASH_SIZE, ":%s:%s:%s:%s:%s",
				login.nonce, login.nonce_count, login.cnonce,
				login.qop, static_hash);