### PR TITLE
ZTEX: small corrections

### DIFF
--- a/src/ztex/ztex_scan.c
+++ b/src/ztex/ztex_scan.c
@@ -67,7 +67,11 @@ static int ztex_scan(struct ztex_dev_list *new_dev_list, struct ztex_dev_list *d
 						"unsupported format (%s)\n", dev->snString_orig);
 				}
 			}
-			else if (!list_check(jtr_devices_allow, dev->snString)) {
+			else if (list_check(jtr_devices_allow, dev->snString)
+				|| (ztex_sn_alias_is_valid(dev->snString)
+					&& list_check(jtr_devices_allow, dev->snString_orig)) ) {
+			}
+			else {
 				ztex_dev_list_remove(new_dev_list, dev);
 				continue;
 			}

--- a/src/ztex_drupal7.c
+++ b/src/ztex_drupal7.c
@@ -50,7 +50,7 @@ static struct device_bitstream bitstream = {
 	1024,		// 1K keys/fpga for self-test
 	512 * 1024,	// Absolute max. keys/crypt_all_interval for all devices.
 	512,		// Max. number of entries in onboard comparator.
-	160,		// Min. number of keys for effective device utilization
+	12 * 16,	// Min. number of keys for effective device utilization
 	1, { 160 },	// Programmable clocks
 	"Drupal7",	// label for configuration file
 	"\x01", 1	// Initialization data


### PR DESCRIPTION
- allow to specify SN in ```-dev``` cmd-line option if board is listed in config; 
- drupal7 min_keys value to reflect new bitstream (makes 1% performance difference)