### PR TITLE
Fixes command line prompt ambiguity

### DIFF
--- a/doc/INSTALL-UBUNTU
+++ b/doc/INSTALL-UBUNTU
@@ -83,11 +83,11 @@ system.
 
 === Test your build
 
-    $ ../run/john --test=0
+    ../run/john --test=0
 
 === Benchmark your build
 
-    $ ../run/john --test
+    ../run/john --test
 
 
 


### PR DESCRIPTION
Removes the `$ ` prompt for two commands. I think this is appropriate because none of the earlier commands include the `$ ` prompt.