### PR TITLE
keystore2john.py: Python2/3 compatibility

### DIFF
--- a/run/keystore2john.py
+++ b/run/keystore2john.py
@@ -171,10 +171,10 @@ def process_file(filename):
     assert(len(md) == 20)
 
     sys.stdout.write("%s:$keystore$0$%d$%s" % (os.path.basename(filename), pos,
-                                               hexlify(data[0:pos])))
+                                               hexlify(data[0:pos]).decode('utf-8')))
 
-    sys.stdout.write("$%s" % hexlify(md))
-    sys.stdout.write("$%d$%d$%s" % (count, keysize, hexlify(protectedPrivKey)))
+    sys.stdout.write("$%s" % hexlify(md).decode('utf-8'))
+    sys.stdout.write("$%d$%d$%s" % (count, keysize, hexlify(protectedPrivKey).decode('utf-8')))
     sys.stdout.write(":::::%s\n" % filename)
 
 


### PR DESCRIPTION
Make it work with both by adding .decode('utf-8')
to hexlified data. Python2 thinks it has type 'str'
and python3 treats it as 'bytes'. After decode()
both think it has type 'str'.

This should fix issue #3658 .