### PR TITLE
cracker.c: Detect when a reset() call lowered min. kpc, adjust warnings accordingly

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -150,7 +150,7 @@ static void crk_help(void)
 	printed = 1;
 }
 
-void crk_set_kpc_warn(void)
+static void crk_set_kpc_warn(void)
 {
 	kpc_warn = crk_params->min_keys_per_crypt;
 


### PR DESCRIPTION
I think this is more or less exactly as suggested, no reason to make it more complicated.