### PR TITLE
Clarify the error `fopen: $JOHN/john.conf`

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -241,7 +241,7 @@ void cfg_init(char *name, int allow_missing)
 		file = fopen(cfg_name, "r");
 		if (!file) {
 			if (allow_missing && errno == ENOENT) return;
-			pexit("fopen: %s", cfg_name);
+			pexit("fopen: %s", path_expand(cfg_name));
 		}
 	}
 


### PR DESCRIPTION
JtR uses the `fopen:` as a pattern for this kind of error message. For now just path_expand() the file name before printing it.

``` 
Found 15 matches of fopen: in 10 files.	
  charset.c	
	pexit("fopen: %s", path_expand(charset));      [position 643:10]	
  config.c	
	pexit("fopen: %s", path_expand(cfg_name));      [position 244:11]	
  cracker.c	
	pexit("fopen: %s", path_expand(options.activepot));      [position 619:10]	
  fuzz.c	
	pexit("fopen: %s", options.fuzz_dic);      [position 99:10]	
	pexit("fopen: %s", status_file_path);      [position 536:10]	
	pexit("fopen: %s", file_name);      [position 617:10]	
  inc.c	
	pexit("fopen: %s", path_expand(charset));      [position 618:10]	
  loader.c	
	pexit("fopen: %s", path_expand(name));      [position 216:10]	
	pexit("fopen: %s", name);      [position 1376:12]	
  recovery.c	
	fprintf(stderr, "%u@%s: fopen: %s: %s\n",      [position 546:28]	
	pexit("fopen: %s", path_expand(rec_name));      [position 552:10]	
  unafs.c	
	pexit("fopen: %s", argv[1]);      [position 80:10]	
  unique.c	
	pexit("fopen: %s", &argv[i][9]);      [position 489:12]	
	pexit("fopen: %s", &argv[i][14]);      [position 497:12]	
  unshadow.c	
	pexit("fopen: %s", name);      [position 89:10]	
``` 
Closes #3670 
