### PR TITLE
Stop duplicating the path in cfg_init()

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -145,7 +145,9 @@ char *path_expand_ex(char *name)
 {
 	if (john_home_pathex &&
 	    john_home_lengthex + strlen(name) < PATH_BUFFER_SIZE) {
-		strnzcpy(&john_home_pathex[john_home_lengthex], name,
+		char *p = basename(name);
+
+		strnzcpy(&john_home_pathex[john_home_lengthex], p,
 			PATH_BUFFER_SIZE - john_home_lengthex);
 		return john_home_pathex;
 	}


### PR DESCRIPTION
As it is now, `cfg_init()` misbehaves when a file name contains directory components. To fix that and handle both situations (file names with and without directory information), the use of `basename()` is needed.

See https://github.com/magnumripper/JohnTheRipper/pull/3681#issuecomment-475896251