### PR TITLE
Modify cfg_name inside cfg_init() cautiously 

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -230,28 +230,31 @@ void cfg_init(char *name, int allow_missing)
 {
 	FILE *file;
 	char line[LINE_BUFFER_SIZE];
+	char *tmp_name;
 	int number;
 
 	if (cfg_database && !cfg_recursion) return;
 
-	cfg_name = str_alloc_copy(path_expand(name));
-	file = fopen(cfg_name, "r");
+	tmp_name = path_expand(name);
+	file = fopen(tmp_name, "r");
 	if (!file) {
-		cfg_name = str_alloc_copy(path_expand_ex(name));
-		file = fopen(cfg_name, "r");
+		tmp_name = path_expand_ex(name);
+		file = fopen(tmp_name, "r");
 		if (!file) {
 			if (allow_missing && errno == ENOENT) return;
-			pexit("fopen: %s", path_expand(cfg_name));
+			pexit("fopen: %s", path_expand(name));
 		}
 	}
 
 	number = 0;
 	while (fgetl(line, sizeof(line), file))
-	if (cfg_process_line(line, ++number)) cfg_error(cfg_name, number);
+	if (cfg_process_line(line, ++number)) cfg_error(name, number);
 
 	if (ferror(file)) pexit("fgets");
 
 	if (fclose(file)) pexit("fclose");
+
+	cfg_name = str_alloc_copy(tmp_name);
 
 	// merge final section (if it is a 'Local:" section)
 	cfg_merge_local_section();


### PR DESCRIPTION
Depends on #3682.
****

Tested:
```
$ ../run/john --test=0 --config=../run/john.ini           # renamed john.conf
Testing: [...]   # => Works

$ ../run/john --test=0 --config=\$JOHN/john.ini           # renamed john.conf
Testing: [...]   # => Works

$ ../run/john --test=0 --config=../abc/config.ini         # wrong conf file name
fopen: ../abc/config.ini: No such file or directory

$ ../run/john --test=0                                    # missing john.conf
fopen: ../run/john.conf: No such file or directory
```