### PR TITLE
Take 2: modify cfg_name inside cfg_init() cautiously

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -235,24 +235,20 @@ void cfg_init(const char *name, int allow_missing)
 
 	if (cfg_database && !cfg_recursion) return;
 
-	cfg_name = str_alloc_copy(path_expand(name));
-	file = fopen(cfg_name, "r");
-	if (!file) {
-		cfg_name = str_alloc_copy(path_expand_ex(name));
-		file = fopen(cfg_name, "r");
-		if (!file) {
-			if (allow_missing && errno == ENOENT) return;
-			pexit("fopen: %s", path_expand(cfg_name));
-		}
+	if (!(file = fopen(path_expand(name), "r"))) {
+		if (allow_missing && errno == ENOENT) return;
+		pexit("fopen: %s", path_expand(name));
 	}
 
 	number = 0;
 	while (fgetl(line, sizeof(line), file))
-	if (cfg_process_line(line, ++number)) cfg_error(cfg_name, number);
+	if (cfg_process_line(line, ++number)) cfg_error(name, number);
 
 	if (ferror(file)) pexit("fgets");
 
 	if (fclose(file)) pexit("fclose");
+
+	cfg_name = str_alloc_copy(path_expand(name));
 
 	// merge final section (if it is a 'Local:" section)
 	cfg_merge_local_section();

--- a/src/john.c
+++ b/src/john.c
@@ -1566,7 +1566,6 @@ static void john_init(char *name, int argc, char **argv)
 
 	if (!make_check) {
 		if (options.config) {
-			path_init_ex(options.config);
 			cfg_init(options.config, 0);
 #if JOHN_SYSTEMWIDE
 			cfg_init(CFG_PRIVATE_FULL_NAME, 1);

--- a/src/path.c
+++ b/src/path.c
@@ -21,8 +21,6 @@
 
 static char *john_home_path = NULL;
 static int john_home_length;
-static char *john_home_pathex = NULL;
-static int john_home_lengthex;
 
 #if JOHN_SYSTEMWIDE
 #if (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER
@@ -109,49 +107,6 @@ void path_init(char **argv)
 		}
 	}
 #endif
-}
-
-void path_init_ex(const char *path)
-{
-	int dos = 0;
-	char *pos;
-
-	pos = strrchr(path, '/');
-	if (!pos) {
-		pos = strrchr(path, '\\');
-		if (pos>path && path[1] == ':') {
-			path += 2;
-			dos = 1;
-		}
-		else if (pos == path)
-			dos = 1;
-	}
-	if (pos) {
-		john_home_lengthex = pos - path + 1;
-		if (john_home_lengthex >= PATH_BUFFER_SIZE) return;
-
-		john_home_pathex = mem_alloc(PATH_BUFFER_SIZE);
-		memcpy(john_home_pathex, path, john_home_lengthex);
-		john_home_pathex[john_home_lengthex] = 0;
-		pos = strchr(john_home_pathex, '\\');
-		while (dos && pos) {
-			*pos = '/';
-			pos = strchr(pos, '\\');
-		}
-	}
-}
-
-const char *path_expand_ex(const char *name)
-{
-	if (john_home_pathex &&
-	    john_home_lengthex + strlen(name) < PATH_BUFFER_SIZE) {
-		char *p = basename(name);
-
-		strnzcpy(&john_home_pathex[john_home_lengthex], p,
-			PATH_BUFFER_SIZE - john_home_lengthex);
-		return john_home_pathex;
-	}
-	return name;
 }
 
 const char *path_expand(const char *name)
@@ -246,6 +201,4 @@ void path_done(void)
 #if JOHN_SYSTEMWIDE
 	MEM_FREE(user_home_path);
 #endif
-	if (john_home_pathex)
-		MEM_FREE(john_home_pathex);
 }

--- a/src/path.h
+++ b/src/path.h
@@ -32,17 +32,6 @@ extern const char *path_expand(const char *name);
 extern const char *path_expand_safe(const char *name);
 
 /*
- * these 2 are used when -conf=path is used.  Here, we have a 'base'
- * directory other than where john ran from (or likely can). Thus we
- * want to base file names from there. Since we have added #include
- * to the john.conf processing, we do want to look in the same
- * dir where we loaded the john.conf file, if -conf= arg is used.
- */
-extern void path_init_ex(const char *name);
-extern const char *path_expand_ex(const char *name);
-
-
-/*
  * Generates a filename for the given session name and filename suffix.
  * Memory for the resulting filename is allocated with mem_alloc_tiny().
  */


### PR DESCRIPTION
Well, in my opinion, this is the way to go. I dislike the idea of changing `$JOHN`and I want to kill `*_ex()`.

```
Tested:

$ ../run/john --test=0 --config=../run/john.ini           # renamed john.conf
Testing: [...]   # => Works

$ ../run/john --test=0 --config=\$JOHN/john.ini           # renamed john.conf
Testing: [...]   # => Works

$ ../run/john --test=0 --config=../abc/config.ini         # wrong conf file name
fopen: ../abc/config.ini: No such file or directory

$ ../run/john --test=0                                    # missing john.conf
fopen: ../run/john.conf: No such file or directory
```