### PR TITLE
unicode_range.c: Work around brain-dead clang

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -105,7 +105,7 @@ JOHN_OBJS = \
 	memory.o misc.o options.o params.o path.o recovery.o rpp.o rules.o signals.o single.o status.o \
 	tty.o  wordlist.o \
 	mkv.o mkvlib.o \
-	subsets.o \
+	subsets.o unicode_range.o \
 	listconf.o \
 	fake_salts.o \
 	win32_memmap.o \
@@ -402,7 +402,10 @@ missing_getopt.o:	missing_getopt.c missing_getopt.h os.h os-autoconf.h autoconfi
 
 mkv.o:	mkv.c arch.h misc.h jumbo.h autoconfig.h params.h path.h memory.h os.h os-autoconf.h signals.h formats.h loader.h list.h logger.h status.h recovery.h config.h charset.h external.h compiler.h cracker.h options.h getopt.h common.h john.h mkv.h mkvlib.h mask.h
 
-subsets.o: subsets.c subsets.h unicode_range.c loader.h cracker.h options.h logger.h status.h recovery.h
+subsets.o: subsets.c subsets.h unicode_range.h loader.h cracker.h options.h logger.h status.h recovery.h
+
+unicode_range.o: unicode_range.c unicode_range.h
+	$(CC) $(CFLAGS) $(OPT_NORMAL) -O0 unicode_range.c
 
 mkvcalcproba.o:	mkvcalcproba.c autoconfig.h params.h arch.h mkvlib.h memory.h jumbo.h os.h os-autoconf.h
 
@@ -532,10 +535,10 @@ zip2john.o:	zip2john.c arch.h common.h memory.h jumbo.h formats.h params.h misc.
 ######## End auto-generated
 
 princeprocessor:
-	$(CC) @CFLAGS@ @JOHN_NO_SIMD@ @CFLAGS_EXTRA@ @OPENSSL_CFLAGS@ @OPENMP_CFLAGS@ @HAVE_MPI@ @PTHREAD_CFLAGS@ @HT@ $(RELEASE_BLD) $(CPPFLAGS) $(OPT_NORMAL) -Wno-declaration-after-statement -std=c99 -DLINUX pp.c $(LDFLAGS) -o ../run/pp
+	$(CC) @CFLAGS@ @JOHN_NO_SIMD@ @CFLAGS_EXTRA@ @OPENSSL_CFLAGS@ @OPENMP_CFLAGS@ @HAVE_MPI@ @PTHREAD_CFLAGS@ @HT@ $(RELEASE_BLD) $(CPPFLAGS) $(OPT_NORMAL) -std=c99 -DLINUX pp.c $(LDFLAGS) -o ../run/pp
 
 pp.o:	pp.c autoconfig.h arch.h win32_memmap.h os.h os-autoconf.h jumbo.h mmap-windows.c memory.h mpz_int128.h int128.h misc.h config.h params.h common.h path.h signals.h loader.h list.h formats.h logger.h status.h recovery.h options.h getopt.h external.h compiler.h cracker.h john.h unicode.h prince.h rpp.h rules.h mask.h
-	$(CC) $(CFLAGS) $(OPT_NORMAL) -DJTR_MODE -Wno-declaration-after-statement -std=c99 -c pp.c
+	$(CC) $(CFLAGS) $(OPT_NORMAL) -DJTR_MODE -std=c99 -c pp.c
 
 version.h: find_version
 

--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -145,7 +145,7 @@ JOHN_OBJS = \
 	params.o path.o recovery.o rpp.o rules.o signals.o single.o status.o \
 	tty.o wordlist.o \
 	mkv.o mkvlib.o \
-	subsets.o \
+	subsets.o unicode_range.o \
 	listconf.o \
 	fake_salts.o \
 	win32_memmap.o \
@@ -1912,6 +1912,9 @@ john.com: john.asm
 
 ../run/hccap2john: common.o hccap2john.o jumbo.o
 	$(LD) $(LDFLAGS) common.o hccap2john.o jumbo.o -o ../run/hccap2john
+
+unicode_range.o: unicode_range.c unicode_range.h
+	$(CC) $(CFLAGS) $(OPT_NORMAL) -O0 unicode_range.c
 
 # Inlining the S-boxes produces faster code as long as they fit in the cache.
 DES_bs_b.o: DES_bs_b.c sboxes.c nonstd.c sboxes-s.c sboxes-t.c

--- a/src/subsets.c
+++ b/src/subsets.c
@@ -43,7 +43,7 @@
 #include "recovery.h"
 #include "mask.h"
 #include "unicode.h"
-#include "unicode_range.c"
+#include "unicode_range.h"
 
 #define SUBSET_DEBUG 1
 

--- a/src/unicode_range.c
+++ b/src/unicode_range.c
@@ -1,9 +1,15 @@
-#ifdef __GNUC__
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
-#endif
+/*
+ * This software is Copyright (c) 2018 magnum
+ * and is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+#include <stddef.h>
+#include <stdint.h>
 
-static size_t full_unicode_charset(UTF32* charset)
+#include "unicode.h"
+
+size_t full_unicode_charset(UTF32* charset)
 {
 	int i, c;
 
@@ -2281,7 +2287,3 @@ static size_t full_unicode_charset(UTF32* charset)
 
 	return i;
 }
-
-#ifdef __GNUC__
-#pragma GCC pop_options
-#endif

--- a/src/unicode_range.h
+++ b/src/unicode_range.h
@@ -1,0 +1,6 @@
+#ifndef YOUVE_GOTTA_LOVE_CLANG
+#define YOUVE_GOTTA_LOVE_CLANG
+
+extern size_t full_unicode_charset(UTF32* charset);
+
+#endif


### PR DESCRIPTION
unicode_range.c: Work around brain-dead clang claiming to be compatible with gcc despite it isn't. Closes #3691