### PR TITLE
{sha256|sha512|md5}crypt-ztex: salt_len=0: warning, don't process

### DIFF
--- a/src/ztex_sha256crypt.c
+++ b/src/ztex_sha256crypt.c
@@ -165,6 +165,7 @@ typedef struct {
 
 static int valid(char * ciphertext, struct fmt_main * self) {
 	char *pos, *start;
+	char *salt_pos, *salt_end_pos;
 
 	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
 			return 0;
@@ -179,13 +180,20 @@ static int valid(char * ciphertext, struct fmt_main * self) {
 					return 0;
 		if (*endp == '$')
 			ciphertext = endp + 1;
-			}
+	}
+	salt_pos = ciphertext;
 	for (pos = ciphertext; *pos && *pos != '$'; pos++);
-	if (!*pos || pos < ciphertext) return 0;
+	if (!*pos || pos > &ciphertext[SALT_LENGTH])
+		return 0;
+	salt_end_pos = pos;
 
 	start = ++pos;
 	while (atoi64[ARCH_INDEX(*pos)] != 0x7F) pos++;
 	if (*pos || pos - start != CIPHERTEXT_LENGTH) return 0;
+	if (salt_end_pos == salt_pos) {
+		printf("Warning: ZTEX: sha256crypt hash with salt_length=0 skipped.\n");
+		return 0;
+	}
 	return 1;
 }
 

--- a/src/ztex_sha512crypt.c
+++ b/src/ztex_sha512crypt.c
@@ -152,6 +152,43 @@ static struct fmt_tests tests[] = {
 };
 
 
+static int valid_salt0(char * ciphertext, struct fmt_main * self) {
+	char *pos, *start;
+	char *salt_pos;
+
+	if (!valid(ciphertext, self)) // -Wunused-function
+		return 0;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+		return 0;
+
+	ciphertext += FORMAT_TAG_LEN;
+
+	if (!strncmp(ciphertext, ROUNDS_PREFIX, sizeof(ROUNDS_PREFIX) - 1)) {
+		const char *num = ciphertext + sizeof(ROUNDS_PREFIX) - 1;
+		char *endp;
+
+		if (!strtoul(num, &endp, 10))
+			return 0;
+		if (*endp == '$')
+			ciphertext = endp + 1;
+	}
+	salt_pos = ciphertext;
+	for (pos = ciphertext; *pos && *pos != '$'; pos++);
+	if (!*pos || pos < ciphertext || pos > &ciphertext[SALT_LENGTH]) return 0;
+	if (pos == salt_pos) {
+		printf("Warning: ZTEX: sha512crypt hash with salt_length=0 skipped.\n");
+		return 0;
+	}
+
+	start = ++pos;
+	while (atoi64[ARCH_INDEX(*pos)] != 0x7F) pos++;
+	if (*pos || pos - start != CIPHERTEXT_LENGTH)
+		return 0;
+	return 1;
+}
+
+
 static void *get_salt(char *ciphertext)
 {
 	static sha512crypt_salt_t salt;
@@ -323,7 +360,7 @@ struct fmt_main fmt_ztex_sha512crypt = {
 		device_format_done,
 		device_format_reset,
 		fmt_default_prepare,
-		valid,
+		valid_salt0,
 		fmt_default_split,
 		get_binary,
 		get_salt,


### PR DESCRIPTION
- Discussed in #3721
- If password file contains only hashes with zero salt length, John reverts to CPU version.
- After the fix included in the next hardware design versions, the warning will be removed.