### PR TITLE
Mask-mode benchmark: Add/replace benchmark_comment with "(length n)" …

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -750,6 +750,20 @@ AGAIN:
 
 			fakedb.format = format;
 			mask_init(&fakedb, options.mask);
+
+			if (options.mask) {
+				static char benchmark_comment[16];
+				int bl = format->params.benchmark_length & 0x7f;
+				int el = mask_add_len;
+
+				if (options.flags & FLG_MASK_STACKED)
+					el = MAX(el, bl);
+
+				sprintf(benchmark_comment, " (length %d)", el);
+				format->params.benchmark_comment =
+					benchmark_comment;
+			}
+
 		}
 #endif
 

--- a/src/external.c
+++ b/src/external.c
@@ -704,7 +704,7 @@ int do_external_hybrid_crack(struct db_main *db, const char *base_word) {
 			*internal = 0;
 		}
 
-		if (options.mask) {
+		if (options.flags & FLG_MASK_CHK) {
 			if (do_mask_crack(int_word)) {
 				retval = 1;
 				goto out;

--- a/src/inc.c
+++ b/src/inc.c
@@ -419,7 +419,7 @@ update_last:
 			return 1;
 		inc_hybrid_fix_state();
 	} else
-	if (options.mask) {
+	if (options.flags & FLG_MASK_CHK) {
 		if (do_mask_crack(key))
 			return 1;
 	} else
@@ -497,8 +497,8 @@ void do_incremental_crack(struct db_main *db, const char *mode)
 
 	if ((options.flags & FLG_BATCH_CHK || rec_restored) && john_main_process) {
 		fprintf(stderr, "Proceeding with incremental:%s", mode);
-		if (options.mask)
-			fprintf(stderr, ", hybrid mask:%s", options.mask);
+		if (options.flags & FLG_MASK_CHK)
+			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
 		if (options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 		if (options.req_minlength >= 0 || options.req_maxlength)
@@ -851,7 +851,7 @@ void do_incremental_crack(struct db_main *db, const char *mode)
 					break;
 				inc_hybrid_fix_state();
 			} else
-			if (options.mask) {
+			if (options.flags & FLG_MASK_CHK) {
 				if (!skip && do_mask_crack(fmt_null_key))
 					break;
 			} else

--- a/src/mkv.c
+++ b/src/mkv.c
@@ -109,7 +109,7 @@ static int show_pwd_rnbs(struct db_main *db, struct s_pwd *pwd)
 					return 1;
 				mkv_hybrid_fix_state();
 			} else
-			if (options.mask) {
+			if (options.flags & FLG_MASK_CHK) {
 				if (do_mask_crack(pass))
 					return 1;
 			} else
@@ -175,7 +175,7 @@ static int show_pwd_r(struct db_main *db, struct s_pwd *pwd, unsigned int bs)
 					return 1;
 				mkv_hybrid_fix_state();
 			} else
-			if (options.mask) {
+			if (options.flags & FLG_MASK_CHK) {
 				if (do_mask_crack(pass))
 					return 1;
 			} else
@@ -215,7 +215,7 @@ static int show_pwd_r(struct db_main *db, struct s_pwd *pwd, unsigned int bs)
 					return 1;
 				mkv_hybrid_fix_state();
 			} else
-			if (options.mask) {
+			if (options.flags & FLG_MASK_CHK) {
 				if (do_mask_crack(pass))
 					return 1;
 			} else
@@ -271,7 +271,7 @@ static int show_pwd(struct db_main *db, uint64_t start)
 						return 1;
 					mkv_hybrid_fix_state();
 				} else
-				if (options.mask) {
+				if (options.flags & FLG_MASK_CHK) {
 					if (do_mask_crack(pass))
 						return 1;
 				} else
@@ -308,7 +308,7 @@ static int show_pwd(struct db_main *db, uint64_t start)
 					return 1;
 				mkv_hybrid_fix_state();
 			} else
-			if (options.mask) {
+			if (options.flags & FLG_MASK_CHK) {
 				if (do_mask_crack(pass))
 					return 1;
 			} else
@@ -734,8 +734,8 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 	if (rec_restored && john_main_process) {
 		fprintf(stderr, "Proceeding with Markov%s%s",
 		        param ? " " : "", param ? param : "");
-		if (options.mask)
-			fprintf(stderr, ", hybrid mask:%s", options.mask);
+		if (options.flags & FLG_MASK_CHK)
+			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
 		if (options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 		if (options.req_minlength >= 0 || options.req_maxlength)

--- a/src/options.c
+++ b/src/options.c
@@ -521,6 +521,7 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 	} else
 #endif
 	if (options.flags & FLG_MASK_CHK) {
+		options.eff_mask = options.mask;
 		if (options.flags & FLG_TEST_CHK) {
 			options.flags &= ~FLG_PWD_SUP;
 			if (john_main_process && !(options.flags & FLG_NOTESTS))

--- a/src/options.h
+++ b/src/options.h
@@ -268,8 +268,11 @@ struct options_main {
 	char *fuzz_dump;
 #endif
 
-/* Mask mode's mask */
+/* Mask mode's requested mask (as given) */
 	char *mask;
+
+/* Mask mode's effective mask (as used, may be default from john.conf etc.) */
+	char *eff_mask;
 
 /* Can't use HAVE_WINDOWS_H here so the below need to be maintained */
 #if defined (_MSC_VER) || defined (__MINGW32__) || defined (__CYGWIN32__)

--- a/src/pp.c
+++ b/src/pp.c
@@ -1316,8 +1316,8 @@ void do_prince_crack(struct db_main *db, const char *wordlist, int rules)
       else
         fprintf(stderr, ", rules:%s", options.activewordlistrules);
     }
-    if (options.mask)
-      fprintf(stderr, ", hybrid mask:%s", options.mask);
+    if (options.flags & FLG_MASK_CHK)
+      fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
     if (!options.activewordlistrules && options.rule_stack)
       fprintf(stderr, ", rules-stack:%s", options.rule_stack);
     if (options.req_minlength >= 0 || options.req_maxlength)
@@ -2308,7 +2308,7 @@ void do_prince_crack(struct db_main *db, const char *wordlist, int rules)
                   break;
                 pp_hybrid_fix_state();
               } else
-              if (options.mask) {
+              if (options.flags & FLG_MASK_CHK) {
                 if ((jtr_done = do_mask_crack(pw_buf)))
                   break;
               } else
@@ -2341,7 +2341,7 @@ void do_prince_crack(struct db_main *db, const char *wordlist, int rules)
                       break;
                     pp_hybrid_fix_state();
                   } else
-                  if (options.mask) {
+                  if (options.flags & FLG_MASK_CHK) {
                     if ((jtr_done = do_mask_crack(word)))
                       break;
                   } else

--- a/src/regex.c
+++ b/src/regex.c
@@ -269,7 +269,7 @@ int do_regex_hybrid_crack(struct db_main *db, const char *regex,
 	}
 
 	if (!regex[0]) {
-		if (options.mask) {
+		if (options.flags & FLG_MASK_CHK) {
 			if (do_mask_crack(fmt_null_key)) {
 				retval = 1;
 				goto out;
@@ -294,7 +294,7 @@ int do_regex_hybrid_crack(struct db_main *db, const char *regex,
 		  */
 		//if (options.internal_cp != UTF_8)
 		//	utf8_to_cp_r(word, word, sizeof(word));
-		if (options.mask) {
+		if (options.flags & FLG_MASK_CHK) {
 			if (do_mask_crack(word)) {
 				retval = 1;
 				goto out;
@@ -342,8 +342,8 @@ void do_regex_crack(struct db_main *db, const char *regex)
 
 	if (rec_restored && john_main_process) {
 		fprintf(stderr, "Proceeding with regex:%s", regex);
-		if (options.mask)
-			fprintf(stderr, ", hybrid mask:%s", options.mask);
+		if (options.flags & FLG_MASK_CHK)
+			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
 		if (options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 		if (options.req_minlength >= 0 || options.req_maxlength)
@@ -362,7 +362,7 @@ void do_regex_crack(struct db_main *db, const char *regex)
 		c_simplestring_clear(buffer);
 		c_iterator_value(iter, buffer);
 		word = c_simplestring_to_string(buffer);
-		if (options.mask) {
+		if (options.flags & FLG_MASK_CHK) {
 			if (do_mask_crack(word))
 				break;
 		} else

--- a/src/subsets.c
+++ b/src/subsets.c
@@ -394,7 +394,7 @@ static int submit(UTF32 *subset)
 		utf32_to_enc(out, sizeof(out), subset);
 	}
 
-	if (options.mask)
+	if (options.flags & FLG_MASK_CHK)
 		return do_mask_crack((char*)out);
 	else
 		return crk_process_key((char*)out);
@@ -603,8 +603,8 @@ int do_subsets_crack(struct db_main *db, char *req_charset)
 		fprintf(stderr, "Proceeding with \"subsets\"%s%s",
 		        req_charset ? ": " : "",
 		        req_charset ? req_charset : "");
-		if (options.mask)
-			fprintf(stderr, ", hybrid mask:%s", options.mask);
+		if (options.flags & FLG_MASK_CHK)
+			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
 		if (options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 		if (options.req_minlength >= 0 || options.req_maxlength)

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -654,8 +654,8 @@ void do_wordlist_crack(struct db_main *db, const char *name, int rules)
 			else
 				fprintf(stderr, ", rules:%s", options.activewordlistrules);
 		}
-		if (options.mask)
-			fprintf(stderr, ", hybrid mask:%s", options.mask);
+		if (options.flags & FLG_MASK_CHK)
+			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
 		if (!options.activewordlistrules && options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 		if (options.req_minlength >= 0 || options.req_maxlength)
@@ -1281,7 +1281,7 @@ REDO_AFTER_LMLOOP:
 					}
 					wordlist_hybrid_fix_state();
 				} else
-				if (options.mask) {
+				if (options.flags & FLG_MASK_CHK) {
 					if (do_mask_crack(word)) {
 						rule = NULL;
 						rules = 0;
@@ -1348,7 +1348,7 @@ REDO_AFTER_LMLOOP:
 					}
 					wordlist_hybrid_fix_state();
 				} else
-				if (options.mask) {
+				if (options.flags & FLG_MASK_CHK) {
 					if (do_mask_crack(word)) {
 						rule = NULL;
 						rules = 0;
@@ -1427,7 +1427,7 @@ process_word:
 						}
 						wordlist_hybrid_fix_state();
 					} else
-					if (options.mask) {
+					if (options.flags & FLG_MASK_CHK) {
 						if (do_mask_crack(word)) {
 							rule = NULL;
 							rules = 0;


### PR DESCRIPTION
…if a custom mask is being specified.  Also separate used mask from requested mask (so we can see whether mask is default or not).