### PR TITLE
OpenCL: tune for the length a run will be using

### DIFF
--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1539,15 +1539,15 @@ static void* fill_opencl_device(size_t gws)
 		if (options.verbosity == VERB_DEBUG)
 			fprintf(stderr, "Tuning to length %d\n", len);
 
-		memset(key, 0x61, sizeof(key));
+		memset(key, 0x41, sizeof(key));
+		key[len] = 0;
 
 		for (i = 0; i < kpc; i++) {
-			int l = 0;
+			int l = len - 1;
 
-			key[len] = 0;
 			self->methods.set_key(key, i);
-			while (++key[l] > 0x7a)
-				key[l++] = 0x21;
+			while (l >= 0 && ++key[l] > 0x60)
+				key[l--] = 0x21;
 		}
 	}
 


### PR DESCRIPTION
Print the length used for auto-tune.

Avoid code duplication.

For auto-tune keep length in range:
- if -mask and no min/max are set:
  - just use mask length

- otherwise:
  - tentatively choose self->params.benchmark_length & 0x7f, but:
  - if min is set and the previously chosen length is below min, then use min, and
  - if max is set and the previously chosen length is above max, then use max, and
  - similarly obey the format's min/max constraints, if any.