### PR TITLE
mask.c: Export a function for evaluating mask_add_len from a mask

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -754,7 +754,7 @@ AGAIN:
 			if (options.mask) {
 				static char benchmark_comment[16];
 				int bl = format->params.benchmark_length & 0x7f;
-				int el = mask_add_len;
+				int el = mask_calc_len(options.mask);
 
 				if (options.flags & FLG_MASK_STACKED)
 					el = MAX(el, bl);

--- a/src/mask.h
+++ b/src/mask.h
@@ -98,6 +98,9 @@ extern void mask_fix_state(void);
 extern void mask_save_state(FILE *file);
 extern int mask_restore_state(FILE *file);
 
+/* Evaluate mask_add_len from a given mask string without calling mask_init */
+extern int mask_calc_len(const char *mask);
+
 /*
  * Total number of candidates (per node) to begin with. Remains unchanged
  * throughout one call to do_mask_crack but may vary with hybrid parent key
@@ -122,6 +125,6 @@ extern int mask_cur_len;
 extern int mask_iter_warn;
 
 /* Mask mode is incrementing mask length */
-int mask_increments_len;
+extern int mask_increments_len;
 
 #endif


### PR DESCRIPTION
without calling mask_init().  Use said function when benchmarking
with mask, for getting a proper (length n) message.  See #3780.