### PR TITLE
Fix some unaligned accesses, enhance some salt_hash()

### DIFF
--- a/src/ansible_fmt_plug.c
+++ b/src/ansible_fmt_plug.c
@@ -47,7 +47,7 @@ john_register_one(&fmt_ansible);
 #define BENCHMARK_LENGTH        7
 #define PLAINTEXT_LENGTH        125
 #define SALT_SIZE               sizeof(struct custom_salt)
-#define BINARY_ALIGN            1
+#define BINARY_ALIGN            sizeof(uint32_t) // see cmp_all() and ansible_common_get_binary()
 #define SALT_ALIGN              sizeof(uint64_t)
 #ifdef SIMD_COEF_32
 #define MIN_KEYS_PER_CRYPT      SSE_GROUP_SZ_SHA256

--- a/src/drupal7_common.h
+++ b/src/drupal7_common.h
@@ -116,7 +116,7 @@ static void * get_salt(char *ciphertext)
 
 static int salt_hash(void *salt)
 {
-	return *((uint32_t *)salt) & 0x3FF;
+	return *((uint32_t *)salt) & (SALT_HASH_SIZE - 1);
 }
 
 

--- a/src/phpassMD5_fmt_plug.c
+++ b/src/phpassMD5_fmt_plug.c
@@ -322,7 +322,7 @@ static void *get_salt(char *ciphertext)
 
 static int salt_hash(void *salt)
 {
-	return *((ARCH_WORD *)salt) & 0x3FF;
+	return *(uint32_t *)salt & (SALT_HASH_SIZE - 1);
 }
 
 struct fmt_main fmt_phpassmd5 = {

--- a/src/wpapsk.h
+++ b/src/wpapsk.h
@@ -44,8 +44,9 @@
 #define FORMAT_TAG           "$WPAPSK$"
 #define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
 
-typedef struct {
+typedef union {
 	unsigned char keymic[16];
+	uint32_t u32;
 } mic_t;
 
 typedef struct {
@@ -563,11 +564,15 @@ static void wpapsk_postprocess(int keys)
 #pragma omp parallel for default(none) private(i) shared(keys, outbuffer, data, hccap, mic)
 #endif
 		for (i = 0; i < keys; i++) {
-			uint32_t prf[20/4];
+			union {
+				uint32_t u32[20/4];
+				unsigned char uc[20];
+				uint64_t dummy; /* alignment for hmac_md5_init_K16() */
+			} prf;
 			HMACMD5Context ctx;
 
-			prf_512(outbuffer[i].v, data, prf); // PTK
-			hmac_md5_init_K16((unsigned char*)prf, &ctx);
+			prf_512(outbuffer[i].v, data, prf.u32); // PTK
+			hmac_md5_init_K16(prf.uc, &ctx);
 			hmac_md5_update(hccap.eapol, hccap.eapol_size, &ctx);
 			hmac_md5_final(mic[i].keymic, &ctx);
 		}
@@ -610,44 +615,37 @@ static void wpapsk_postprocess(int keys)
 
 static int get_hash_0(int index)
 {
-	uint32_t *h = (uint32_t *) mic[index].keymic;
-	return h[0] & PH_MASK_0;
+	return mic[index].u32 & PH_MASK_0;
 }
 
 static int get_hash_1(int index)
 {
-	uint32_t *h = (uint32_t *) mic[index].keymic;
-	return h[0] & PH_MASK_1;
+	return mic[index].u32 & PH_MASK_1;
 }
 
 static int get_hash_2(int index)
 {
-	uint32_t *h = (uint32_t *) mic[index].keymic;
-	return h[0] & PH_MASK_2;
+	return mic[index].u32 & PH_MASK_2;
 }
 
 static int get_hash_3(int index)
 {
-	uint32_t *h = (uint32_t *) mic[index].keymic;
-	return h[0] & PH_MASK_3;
+	return mic[index].u32 & PH_MASK_3;
 }
 
 static int get_hash_4(int index)
 {
-	uint32_t *h = (uint32_t *) mic[index].keymic;
-	return h[0] & PH_MASK_4;
+	return mic[index].u32 & PH_MASK_4;
 }
 
 static int get_hash_5(int index)
 {
-	uint32_t *h = (uint32_t *) mic[index].keymic;
-	return h[0] & PH_MASK_5;
+	return mic[index].u32 & PH_MASK_5;
 }
 
 static int get_hash_6(int index)
 {
-	uint32_t *h = (uint32_t *) mic[index].keymic;
-	return h[0] & PH_MASK_6;
+	return mic[index].u32 & PH_MASK_6;
 }
 
 static int cmp_all(void *binary, int count)
@@ -686,7 +684,7 @@ static int salt_hash(void *salt)
 	memcpy(&mac1, &s->mac1[2], 4);
 	memcpy(&mac2, &s->mac2[2], 4);
 
-	return (mac1 ^ mac2) & (SALT_HASH_SIZE - 1);
+	return (mac1 + mac2) & (SALT_HASH_SIZE - 1);
 }
 
 static int salt_compare(const void *x, const void *y)


### PR DESCRIPTION
With this, all formats (except for "monero", now disabled) passed `-test` for me on sparc64. (Of course, it's always possible some of the remaining formats passed test by lucky rather than guaranteed alignment.)