### PR TITLE
SIPDump and eapmd5tojohn: source <getopt.h> instead of declaring extern optind.

### DIFF
--- a/src/SIPdump.c
+++ b/src/SIPdump.c
@@ -56,6 +56,8 @@
 #elif HAVE_PCAP_PCAP_H
 #include <pcap/pcap.h>
 #endif
+#include <getopt.h>
+
 #include "SIPdump.h"
 
 #define SIP_LINE_LEN   1024	/* Maximum length of SIP protocol lines */
@@ -141,7 +143,6 @@ int main(int argc, char *argv[])
 	pcap_t *handle = NULL;
 	bpf_u_int32 mask, net;
 	struct bpf_program fp;
-	extern int optind;
 
 	memset(&fp, 0, sizeof(struct bpf_program));
 

--- a/src/eapmd5tojohn.c
+++ b/src/eapmd5tojohn.c
@@ -11,6 +11,7 @@
 #include <openssl/md5.h>
 #include <pcap.h>
 #include <errno.h>
+#include <getopt.h>
 
 /* $FreeBSD: src/sys/net80211/ieee80211_radiotap.h,v 1.5 2005/01/22 20:12:05 sam Exp $ */
 /* $NetBSD: ieee80211_radiotap.h,v 1.11 2005/06/22 06:16:02 dyoung Exp $ */
@@ -1049,7 +1050,6 @@ int main(int argc, char *argv[])
 	char errbuf[PCAP_ERRBUF_SIZE], iface[17], pcapfile[1024];
 	int opt = 0, datalink = 0, ret = 0;
 	extern struct eapmd5pass_data em;
-	extern int optind;
 
 	memset(&em, 0, sizeof(em));
 	memset(pcapfile, 0, sizeof(pcapfile));


### PR DESCRIPTION
See #3799