### PR TITLE
Benchmark fixes; Unbreak "haval" format's OpenMP

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -828,6 +828,9 @@ AGAIN:
 		salts = 0;
 		if (!format->params.salt_size ||
 		    (format->params.benchmark_length & 0x100)) {
+			if (format->params.salt_size &&
+			    !(format->params.benchmark_length & 0x400))
+				salts = BENCHMARK_MANY;
 			msg_m = "Raw";
 			msg_1 = NULL;
 		} else if (format->params.benchmark_length & 0x200) {

--- a/src/formats.h
+++ b/src/formats.h
@@ -149,7 +149,10 @@ struct fmt_params {
 /* Comment about the benchmark (can be empty) */
 	const char *benchmark_comment;
 
-/* Benchmark for short/long passwords instead of for one/many salts */
+/* Benchmark for this password length.  Can also add one of:
+ * + 0x100 Force "Raw" benchmark even for a salted format
+ * + 0x200 Benchmark for short/long passwords instead of for one/many salts
+ * + 0x500 Make "Raw" behave like "Only one salt", not "Many salts" */
 	int benchmark_length;
 
 /* Minimum length of a plaintext password */

--- a/src/gost_fmt_plug.c
+++ b/src/gost_fmt_plug.c
@@ -47,7 +47,7 @@ john_register_one(&fmt_gost);
 #define ALGORITHM_NAME          "32/" ARCH_BITS_STR
 #endif
 #define BENCHMARK_COMMENT       ""
-#define BENCHMARK_LENGTH        0x107
+#define BENCHMARK_LENGTH        0x507
 #define PLAINTEXT_LENGTH        125
 #define CIPHERTEXT_LENGTH       64
 #define BINARY_SIZE             32

--- a/src/haval_fmt_plug.c
+++ b/src/haval_fmt_plug.c
@@ -19,6 +19,7 @@ john_register_one(&fmt_haval_128_4);
 
 #include <string.h>
 
+#include "arch.h"
 #if !FAST_FORMATS_OMP
 #undef _OPENMP
 #endif


### PR DESCRIPTION
Fixes #3819.

Let's _not_ squash these commits.