### PR TITLE
ztex improvements

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -421,9 +421,9 @@ Frequency = 190
 # Define typical setting of hashes it's going to process. It allows
 # to adjust for best performance.
 TargetSetting = 5
-# Startup frequency for bcrypt-ztex is 141. Design tools guaranteed
-# 141.5 in worst-case temperature and voltage.
-Frequency = 141
+# Startup frequency for bcrypt-ztex is 150. At this frequency tested boards
+# perform reliably.
+Frequency = 150
 # For any algorithm it's possible to set frequency on per-board and
 # per-FPGA basis, but the lowest frequency will determine performance.
 #Frequency_04A36E0FD6 = 142

--- a/run/john.conf
+++ b/run/john.conf
@@ -421,8 +421,8 @@ Frequency = 190
 # Define typical setting of hashes it's going to process. It allows
 # to adjust for best performance.
 TargetSetting = 5
-# Startup frequency for bcrypt-ztex is 150. At this frequency tested boards
-# perform reliably.
+# Design tools reported possible frequency to be 141.5 MHz.
+# Tested boards work reliably at 150, so that's what we use by default.
 Frequency = 150
 # For any algorithm it's possible to set frequency on per-board and
 # per-FPGA basis, but the lowest frequency will determine performance.

--- a/src/john.c
+++ b/src/john.c
@@ -361,15 +361,13 @@ static void john_register_all(void)
 
 	/* Let ZTEX formats appear before CPU formats */
 #ifdef HAVE_ZTEX
-	if (!(options.flags & FLG_SHOW_CHK)) {
-		john_register_one(&fmt_ztex_descrypt);
-		john_register_one(&fmt_ztex_bcrypt);
-		john_register_one(&fmt_ztex_sha512crypt);
-		john_register_one(&fmt_ztex_drupal7);
-		john_register_one(&fmt_ztex_sha256crypt);
-		john_register_one(&fmt_ztex_md5crypt);
-		john_register_one(&fmt_ztex_phpass);
-	}
+	john_register_one(&fmt_ztex_descrypt);
+	john_register_one(&fmt_ztex_bcrypt);
+	john_register_one(&fmt_ztex_sha512crypt);
+	john_register_one(&fmt_ztex_drupal7);
+	john_register_one(&fmt_ztex_sha256crypt);
+	john_register_one(&fmt_ztex_md5crypt);
+	john_register_one(&fmt_ztex_phpass);
 #endif
 	john_register_one(&fmt_DES);
 	john_register_one(&fmt_BSDI);

--- a/src/ztex/fpga-bcrypt/README.md
+++ b/src/ztex/fpga-bcrypt/README.md
@@ -1,8 +1,8 @@
 ## Overview
 
 - bcrypt for ZTEX 1.15y board computes 496 keys in parallel, equipped with on-board candidate generator and comparator.
-- Measured performance for the board (4 FPGA) at default frequency on hashes with setting 5 is 111.6 Kc/s, on hashes with setting 12 is 908 c/s (116 Kc/s if recalculated to setting 5).
-- It operates at 141 MHz. Runtime frequency adjustment is available.
+- Measured performance for the board (4 FPGA) at default frequency on hashes with setting 5 is 118.9 Kc/s, on hashes with setting 12 is 965 c/s (123.5 Kc/s if recalculated to setting 5).
+- It operates at 150 MHz. Runtime frequency adjustment is available.
 - The design contains 124 cores. On-chip comparison against up to 512 hashes is available. Salts with more than 512 hashes are processed with onboard comparators turned off, computed hashes are output and compared on host, this leads to some reduction in c/s especially on hashes with lower setting and when multiple boards are in use.
 - Resource utilization: each core uses 4 BRAMs (x 1 Kbyte), 390 LUTs. Device utilization summary: 96% BRAMs, 55% LUTs, 16% FFs, 1% DSPs.
 - Current consumption (12V input): 2.2A, idle 0.4A.
@@ -15,6 +15,7 @@
 - Each core gets IVs, gets data for computation, performs computation and output independently from other cores. The approach where several cores share same control logic was not taken - such an approach would save LUTs while there's an excess of LUTs anyway.
 - Each Blowfish round takes 1 cycle. Because BRAM memory allows only synchronous read, the start of the cycle is shifted to the start of such read. Overall, 16 Blowfish rounds take 18 cycles - 2 cycles used for additional XOR's and save into "S" or "P".
 - Communication framework including on-chip candidate password generator was initially taken from descrypt-ztex project. bcrypt-ztex has an area-optimized version of the generator.
+- Sizes of I/O buffers from communication framework were reviewed. Input buffer was reduced to 10 KB to allow more BRAMs for cores, asserts 'not full' when it has 6 KB free. Output buffer was increased to 8 KB for better USB performance when comparator is off, hashes output to host.
 
 
 ## Design Placement and Routing details

--- a/src/ztex/jtr_device.c
+++ b/src/ztex/jtr_device.c
@@ -106,10 +106,8 @@ int PKT_DEBUG = 1;
 
 struct jtr_device_list *jtr_device_list_init()
 {
-	int result;
-
 	if (!libusb_initialized) {
-		result = libusb_init(NULL);
+		int result = libusb_init(NULL);
 		if (result < 0) {
 			fprintf(stderr, "libusb_init() returns %d: %s\n",
 					result, libusb_error_name(result));
@@ -128,13 +126,7 @@ PKT_DEBUG = 1; // print erroneous packets recieved from devices
 		device_list = device_init_scan(jtr_bitstream);
 
 		int device_count = device_list_count(device_list);
-
-		if (device_count) {
-			//fprintf(stderr, "%d device(s) ZTEX 1.15y ready\n", device_count);
-			//ztex_dev_list_print(device_list->ztex_dev_list);
-
-			device_list_print(device_list);
-		} else {
+		if (!device_count) {
 			fprintf(stderr, "no valid ZTEX devices found\n");
 			return NULL;
 		}
@@ -145,7 +137,6 @@ PKT_DEBUG = 1; // print erroneous packets recieved from devices
 	} else {
 		device_list_init(device_list, jtr_bitstream);
 
-		device_list_print(device_list);
 		int device_count = device_list_count(device_list);
 		if (!device_count) {
 			fprintf(stderr, "no valid ZTEX devices found\n");
@@ -157,6 +148,19 @@ PKT_DEBUG = 1; // print erroneous packets recieved from devices
 	// TODO: remove old jtr_device's if any
 	jtr_device_list = jtr_device_list_new(device_list);
 	return jtr_device_list;
+}
+
+
+void jtr_device_list_print()
+{
+	device_list_print(device_list);
+}
+
+
+void jtr_device_list_print_count()
+{
+	int device_count = device_list_count(device_list);
+	fprintf(stderr, "%d device(s) ZTEX 1.15y ready\n", device_count);
 }
 
 

--- a/src/ztex/jtr_device.h
+++ b/src/ztex/jtr_device.h
@@ -85,6 +85,12 @@ struct jtr_device *jtr_device_by_device(
 // Uses global device_list
 struct jtr_device_list *jtr_device_list_init();
 
+// Print a line for every connected board
+void jtr_device_list_print();
+
+// Print a line with total number of boards
+void jtr_device_list_print_count();
+
 // Devices from the 2nd list go to the 1st list. jtr_device_list_1 deleted.
 void jtr_device_list_merge(
 		struct jtr_device_list *jtr_device_list,

--- a/src/ztex_bcrypt.c
+++ b/src/ztex_bcrypt.c
@@ -1,5 +1,5 @@
 /*
- * This software is Copyright (c) 2016-2017 Denis Burykin
+ * This software is Copyright (c) 2016-2017,2019 Denis Burykin
  * [denis_burykin yahoo com], [denis-burykin2014 yandex ru]
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
@@ -45,7 +45,7 @@
 #define BINARY_SIZE				4
 #define BINARY_ALIGN			4
 #define SALT_SIZE				sizeof(BF_salt)
-#define SALT_ALIGN				1
+#define SALT_ALIGN				4
 
 
 static struct device_bitstream bitstream = {
@@ -63,7 +63,7 @@ static struct device_bitstream bitstream = {
 	512,		// Max. number of entries in onboard comparator.
 	124,		// Min. number of keys for effective device utilization
 	0,
-	1, { 141 },	// Programmable clocks
+	1, { 150 },	// Programmable clocks
 	"bcrypt",	// label for configuration file
 	NULL, 0		// Initialization data
 };
@@ -73,7 +73,11 @@ static struct fmt_tests tests[] = {
 
 	{"$2a$05$CCCCCCCCCCCCCCCCCCCCC.VGOzA784oUp/Z0DY336zx7pLYAy0lwK",
 		"U*U*"},
-	// 32 lower bits of hash are equal to the above hash - self-test fails
+	// 32 lower bits of hash are equal to the above hash - self-test fails.
+	// In formats.c:is_key_right() it takes the first index for which
+	// cmp_one() returns true, and expects cmp_exact() also to return true
+	// for that index which is the case in CPU version.
+	// Here results arrive in the reverse order and it fails.
 	//{"$2a$05$CCCCCCCCCCCCCCCCCCCCC.VGOzAxtE4OUcU.5p75hOF2yn2i1ocvO",
 	//	"1E!dpr"},
 	{"$2a$05$CCCCCCCCCCCCCCCCCCCCC.7uG0VCzI2bS7j6ymqJi9CdcdxiRTWNy",


### PR DESCRIPTION
- Moved board initialization from ```init()``` to ```reset()```. That fixes all ```show=``` options, removes the necessity to skip format registration dependent on command-line options.
- Print the list of boards only once per run. Don't print every board if ```verbosity < VERB_DEFAULT```.
- Print count of boards.
- bcrypt-ztex default frequency is set to 150 MHz.
- small fixes, documentation updates.
This fixes #3709 