### PR TITLE
mask: add event to free (destroy) mask objects

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -962,8 +962,10 @@ next:
 		ldr_free_test_db(test_db);
 		fmt_done(format);
 #ifndef BENCH_BUILD
-		if (options.flags & FLG_MASK_CHK)
+		if (options.flags & FLG_MASK_CHK) {
 			mask_done();
+			mask_destroy();
+		}
 #endif
 
 #ifndef BENCH_BUILD

--- a/src/john.c
+++ b/src/john.c
@@ -1881,10 +1881,13 @@ static void john_run(void)
 		if (options.flags & FLG_BATCH_CHK)
 			do_batch_crack(&database);
 
+		if (options.flags & FLG_MASK_CHK)
+			mask_done();
+
 		status_print();
 
 		if (options.flags & FLG_MASK_CHK)
-			mask_done();
+			mask_destroy();
 
 #if OS_FORK
 		if (options.fork && john_main_process)

--- a/src/mask.c
+++ b/src/mask.c
@@ -2466,6 +2466,14 @@ void mask_done()
 			rec_done(event_abort);
 		}
 	}
+}
+
+// Mask unload objects event. To be call after mask_done()
+void mask_destroy()
+{
+#ifdef MASK_DEBUG
+	fprintf(stderr, "%s()\n", __FUNCTION__);
+#endif
 
 	MEM_FREE(template_key);
 	MEM_FREE(template_key_offsets);

--- a/src/mask.h
+++ b/src/mask.h
@@ -90,6 +90,7 @@ extern void mask_crk_init(struct db_main *db);
 extern int do_mask_crack(const char *key);
 
 extern void mask_done(void);
+extern void mask_destroy(void);
 
 /*
  * These are exported for stacked modes (eg. hybrid mask)


### PR DESCRIPTION
To be called after *_done(). It seems, that in mask the done() method
is not only a cleanup; it has some pending tasks to do. The cleanup
has to be done later.