### PR TITLE
OpenCL: rawSHA256 force auto-tuning

### DIFF
--- a/src/opencl_rawsha256_fmt_plug.c
+++ b/src/opencl_rawsha256_fmt_plug.c
@@ -305,7 +305,7 @@ static void tune(struct db_main *db)
 {
 	char *tmp_value;
 	size_t gws_limit;
-	int autotune_limit = 200;
+	int autotune_limit = 500;
 
 	if ((tmp_value = getenv("_GPU_AUTOTUNE_LIMIT")))
 		autotune_limit = atoi(tmp_value);


### PR DESCRIPTION
It was resulting in a cracking performance less than ideal.