### PR TITLE
OpenCL: if SleepOnTemperature = 1, print sleeping message once

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -406,7 +406,9 @@ AbortTemperature = 95
 # Instead of aborting, sleep for this many seconds to cool the GPU down when
 # the temperature hits the AbortTemperature value, then re-test the temperature
 # and either wake up or go to sleep again.  Set this to 0 to actually abort.
-SleepOnTemperature = 30
+# Suppress repeated sleep/wakeup messages when SleepOnTemperature = 1,
+# we are interpreting this as intent to keep the GPU temperature around the limit.
+SleepOnTemperature = 1
 
 # ZTEX specific settings
 [List.ZTEX:Devices]


### PR DESCRIPTION
We are interpreting this as intent to keep the GPU temperature around
the limit.