### PR TITLE
scrypt-using format enhancements

### DIFF
--- a/src/yescrypt/yescrypt-opt.c
+++ b/src/yescrypt/yescrypt-opt.c
@@ -28,6 +28,9 @@
  * online backup system.
  */
 
+/* JtR hack: don't use OpenMP inside (ye)scrypt */
+#undef _OPENMP
+
 /*
  * AVX and especially XOP speed up Salsa20 a lot, but this mostly matters for
  * classic scrypt and for YESCRYPT_WORM (which use 8 rounds of Salsa20 per

--- a/src/yescrypt/yescrypt-platform.c
+++ b/src/yescrypt/yescrypt-platform.c
@@ -22,7 +22,7 @@
 #include <sys/mman.h>
 #endif
 
-#define HUGEPAGE_THRESHOLD		(32 * 1024 * 1024)
+#define HUGEPAGE_THRESHOLD		(12 * 1024 * 1024)
 
 #ifdef __x86_64__
 #define HUGEPAGE_SIZE			(2 * 1024 * 1024)


### PR DESCRIPTION
I'd like my separate commits here to be retained on merge - please don't squash them.

Fixes #2871. The most notable speedup is for Ethereum, from:

```
[solar@super src]$ GOMP_CPU_AFFINITY=0-31 OMP_NUM_THREADS=31 ../run/john -test -form=ethereum -cost=2,1:1
Will run 31 OpenMP threads
Benchmarking: ethereum, Ethereum Wallet [PBKDF2-SHA256/scrypt Keccak 128/128 AVX 4x]... (31xOMP) DONE
Speed for cost 1 (iteration count) of 1024, cost 2 (kdf [0:PBKDF2-SHA256 1:scrypt 2:PBKDF2-SHA256 presale]) of 1
Warning: "Many salts" test limited: 39/256
Many salts:     4741 c/s real, 359 c/s virtual
Only one salt:  4712 c/s real, 361 c/s virtual
```

to:

```
[solar@super src]$ GOMP_CPU_AFFINITY=0-31 OMP_NUM_THREADS=31 ../run/john -test -form=ethereum -cost=2,1:1
Will run 31 OpenMP threads
Benchmarking: ethereum, Ethereum Wallet [PBKDF2-SHA256/scrypt Keccak 128/128 AVX 4x]... (31xOMP) DONE
Speed for cost 1 (iteration count) of 1024, cost 2 (kdf [0:PBKDF2-SHA256 1:scrypt 2:PBKDF2-SHA256 presale]) of 1
Warning: "Many salts" test limited: 123/256
Many salts:     15252 c/s real, 490 c/s virtual
Only one salt:  15100 c/s real, 491 c/s virtual
```

(31 threads because an unrelated job is using one logical CPU on "super")

There are smaller speedups for django-scrypt and multibit, from:

```
[solar@super src]$ GOMP_CPU_AFFINITY=0-31 OMP_NUM_THREADS=31 ../run/john -test -form=multibit -cost=2,2:3
Will run 31 OpenMP threads
Benchmarking: multibit, MultiBit Wallet [MD5/scrypt AES 32/64]... (31xOMP) DONE
Speed for cost 1 (iteration count) of 16384, cost 2 (kdf [1:MD5 2:scrypt hd 3:scrypt classic]) of 3 and 2
Warning: "Many salts" test limited: 21/256
Many salts:     644 c/s real, 24.1 c/s virtual
Only one salt:  655 c/s real, 24.2 c/s virtual
```

to:

```
[solar@super src]$ GOMP_CPU_AFFINITY=0-31 OMP_NUM_THREADS=31 ../run/john -test -form=multibit -cost=2,2:3
Will run 31 OpenMP threads
Benchmarking: multibit, MultiBit Wallet [MD5/scrypt AES 32/64]... (31xOMP) DONE
Speed for cost 1 (iteration count) of 16384, cost 2 (kdf [1:MD5 2:scrypt hd 3:scrypt classic]) of 3 and 2
Warning: "Many salts" test limited: 29/256
Many salts:     881 c/s real, 29.9 c/s virtual
Only one salt:  881 c/s real, 29.9 c/s virtual
```

multibit format's OMP_SCALE of 4 is neither here nor there - it's unnecessary for scrypt-based multibit (could be 1), but is too low for the fast variation we're benchmarking by default (should probably be 16+ for dual-socket machines like "super", where 16 is ~2x faster than the default of 4). We might want to deal with that separately.