### PR TITLE
7z formats: Move the compile-time TRUST_PADDING macro to a john.conf option

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -335,28 +335,6 @@ AbortGraceTime = 30
 # This may produce some false positives if enabled, at least for SAP-B.
 SAPhalfHashes = N
 
-# Changing this to Yes will enable legacy-style benchmarks, for comparisons
-[Debug]
-Benchmarks_1_8 = N
-
-# This allows you to list a few words/names that will be used by single mode
-# as if they were included in every GECOS field.  Use sparingly! Please note
-# that the example words are commented out, so the list is empty!
-[List.Single:SeedWords]
-#Pass
-#Secret
-#Test
-
-# This allows you to read extra pot files when loading hashes. Nothing will
-# ever be written to these files, they are just read. Any directory in this
-# list will be traversed and files in it with an extension of .pot will be
-# read. However there will NOT be any recursion down further directory levels.
-# Any entries that don't exist will be silently ignored.
-[List.Extra:Potfiles]
-#somefile.pot
-#somedirectory
-#$JOHN/my.pot
-
 [Options:CPUtune]
 # If preset is given, use it and skip autotune (NOTE: non-intel archs will
 # currently ignore this option and always autotune)
@@ -382,14 +360,6 @@ MPIOMPverbose = Y
 # Assume all MPI nodes are homogenous; Enforce same OpenCL workgroup sizes.
 MPIAllGPUsSame = N
 
-# These formats are disabled from all-formats --test runs, or auto-selection
-# of format from an input file. Even when disabled, you can use them as long
-# as you spell them out with the --format option. Or you can delete a line,
-# comment it out, or change to 'N'
-[Disabled:Formats]
-#formatname = Y
-.include '$JOHN/dynamic_disabled.conf'
-
 # Options that may affect both GPUs and other accelerators (eg. FPGA)
 [Options:GPU]
 # Show GPU temperature, fan and utilization along with normal status output
@@ -409,6 +379,92 @@ AbortTemperature = 95
 # Suppress repeated sleep/wakeup messages when SleepOnTemperature = 1,
 # we are interpreting this as intent to keep the GPU temperature around the limit.
 SleepOnTemperature = 1
+
+[Options:OpenCL]
+# Set default OpenCL device(s). Command line option will override this.
+# If not set, we will search for a GPU or fall-back to the most
+# powerful device.  Syntax is same as --device option.
+Device =
+
+# If set to true, store LWS and GWS in session file for later resume.
+# Note that when resuming, this option is ignored: If the session file
+# was written with this option set, it will still be used.
+ResumeWS = N
+
+# Global max. single kernel invocation duration, in ms. Setting this low
+# (eg. 10-100 ms) gives you a better responding desktop but lower performance.
+# Setting it high (eg. 200-500 ms) will maximize performance but your desktop
+# may lag. Really high values may trip watchdogs (eg. 5 seconds). Some versions
+# of AMD Catalyst may hang if you go above 200 ms, and in general any good
+# kernel will perform optimally at 100-200 ms anyway.
+Global_MaxDuration =
+
+# Some formats vectorize their kernels in case the device says it's a good
+# idea. Some devices give "improper" hints which means we vectorize but get
+# a performance drop. If you have such a device, uncommenting the below
+# will disable vectorizing globally.
+# With this set to N (or commented out) you can force it per session with
+# the --force-scalar command-line option instead.
+ForceScalar = N
+
+# Global build options. Format-specific build options below may be
+# concatenated to this.
+GlobalBuildOpts = -cl-mad-enable
+
+# Initial local work-size for auto-tune (CPU devices excepted).
+# 0 means let the OpenCL implementation pick a suitable value.
+# 1 means query for "best multiple" (usually corresponds to "warp size").
+# Any other value (eg. 64) will be taken verbatim.
+AutotuneLWS = 1
+
+# Format-specific settings:
+
+# Uncomment the below for nvidia sm_30 and beyond.
+# Please, check if it is really better.
+#sha512crypt_BuildOpts = -cl-nv-maxrregcount=80
+
+# Best configuration value to be used at runtime.
+sha512crypt_Bonaire = -DUNROLL_LOOP=132104
+
+# Example: Override auto-tune for RAR format.
+#rar_LWS = 128
+#rar_GWS = 8192
+
+[List.OpenCL:Drivers]
+#Driver ; Description         ; Recommendation
+#AMD driver versions
+938 , 2 ; 12.8                ;
+1084, 4 ; 13.1                ;
+1124, 2 ; 13.4                ;
+1214, 3 ; 13.6 beta           ;
+1311, 2 ; 13.11 beta-1        ;
+1348, 5 ; 13.12               ;
+1445, 5 ; 14.4 (Mantle)       ;
+1526, 3 ; 14.6 beta (Mantle)  ;
+1573, 4 ; 14.9 (Mantle)       ; VGL S
+1642, 5 ; 14.12 (Omega)       ; VGL S
+1702, 3 ; 15.5 beta           ;     T
+1729, 3 ; 15.5                ;
+1800, 5 ; 15.7                ; VG* R
+1800, 8 ; 15.7.1              ; VGW R
+1800, 11; 15.9                ; VGL S
+1912, 5 ; 15.12               ;
+#NVIDIA driver versions
+346, 0  ;                     ; N*  R
+319, 0  ;                     ; N*  S
+#End
+0, 0    ;                     ;
+
+#Labels
+# * -> all OS
+# N -> NVIDIA
+# G -> GCN
+# V -> VLIW4 and VLIW5
+# W -> Windows
+# L -> Linux
+# R -> recommended
+# S -> supported
+# T -> not recommended: really bad software. I mean "trash".
 
 # ZTEX specific settings
 [List.ZTEX:Devices]
@@ -475,98 +531,48 @@ Frequency = 180
 Frequency = 180
 #TargetRounds = 2048
 
-[Options:OpenCL]
-# Set default OpenCL device(s). Command line option will override this.
-# If not set, we will search for a GPU or fall-back to the most
-# powerful device.  Syntax is same as --device option.
-Device =
+# These formats are disabled from all-formats --test runs, or auto-selection
+# of format from an input file. Even when disabled, you can use them as long
+# as you spell them out with the --format option. Or you can delete a line,
+# comment it out, or change to 'N'
+[Disabled:Formats]
+#formatname = Y
+.include '$JOHN/dynamic_disabled.conf'
 
-# If set to true, store LWS and GWS in session file for later resume.
-# Note that when resuming, this option is ignored: If the session file
-# was written with this option set, it will still be used.
-ResumeWS = N
+[Formats:7z]
+# With this enabled, the 7z formats check padding after AES decryption which
+# more or less guarantees we don't get any false positives, and also makes
+# the formats faster (in some cases a LOT faster).  We've had one (1) report
+# of getting a false negative having this enabled though, so if you fail to
+# crack some archive you may want to disable this and re-try all attacks.
+TrustPadding = Y
 
-# Global max. single kernel invocation duration, in ms. Setting this low
-# (eg. 10-100 ms) gives you a better responding desktop but lower performance.
-# Setting it high (eg. 200-500 ms) will maximize performance but your desktop
-# may lag. Really high values may trip watchdogs (eg. 5 seconds). Some versions
-# of AMD Catalyst may hang if you go above 200 ms, and in general any good
-# kernel will perform optimally at 100-200 ms anyway.
-Global_MaxDuration =
+# This allows you to list a few words/names that will be used by single mode
+# as if they were included in every GECOS field.  Use sparingly! Please note
+# that the example words are commented out, so the list is empty!
+[List.Single:SeedWords]
+#Pass
+#Secret
+#Test
 
-# Some formats vectorize their kernels in case the device says it's a good
-# idea. Some devices give "improper" hints which means we vectorize but get
-# a performance drop. If you have such a device, uncommenting the below
-# will disable vectorizing globally.
-# With this set to N (or commented out) you can force it per session with
-# the --force-scalar command-line option instead.
-ForceScalar = N
+# This allows you to read extra pot files when loading hashes. Nothing will
+# ever be written to these files, they are just read. Any directory in this
+# list will be traversed and files in it with an extension of .pot will be
+# read. However there will NOT be any recursion down further directory levels.
+# Any entries that don't exist will be silently ignored.
+[List.Extra:Potfiles]
+#somefile.pot
+#somedirectory
+#$JOHN/my.pot
 
-# Global build options. Format-specific build options below may be
-# concatenated to this.
-GlobalBuildOpts = -cl-mad-enable
-
-# Initial local work-size for auto-tune (CPU devices excepted).
-# 0 means let the OpenCL implementation pick a suitable value.
-# 1 means query for "best multiple" (usually corresponds to "warp size").
-# Any other value (eg. 64) will be taken verbatim.
-AutotuneLWS = 1
-
-
-# Format-specific settings:
-
-# Uncomment the below for nvidia sm_30 and beyond.
-# Please, check if it is really better.
-#sha512crypt_BuildOpts = -cl-nv-maxrregcount=80
-
-# Best configuration value to be used at runtime.
-sha512crypt_Bonaire = -DUNROLL_LOOP=132104
-
-# Example: Override auto-tune for RAR format.
-#rar_LWS = 128
-#rar_GWS = 8192
-
-[List.OpenCL:Drivers]
-#Driver ; Description         ; Recommendation
-#AMD driver versions
-938 , 2 ; 12.8                ;
-1084, 4 ; 13.1                ;
-1124, 2 ; 13.4                ;
-1214, 3 ; 13.6 beta           ;
-1311, 2 ; 13.11 beta-1        ;
-1348, 5 ; 13.12               ;
-1445, 5 ; 14.4 (Mantle)       ;
-1526, 3 ; 14.6 beta (Mantle)  ;
-1573, 4 ; 14.9 (Mantle)       ; VGL S
-1642, 5 ; 14.12 (Omega)       ; VGL S
-1702, 3 ; 15.5 beta           ;     T
-1729, 3 ; 15.5                ;
-1800, 5 ; 15.7                ; VG* R
-1800, 8 ; 15.7.1              ; VGW R
-1800, 11; 15.9                ; VGL S
-1912, 5 ; 15.12               ;
-#NVIDIA driver versions
-346, 0  ;                     ; N*  R
-319, 0  ;                     ; N*  S
-#End
-0, 0    ;                     ;
-
-#Labels
-# * -> all OS
-# N -> NVIDIA
-# G -> GCN
-# V -> VLIW4 and VLIW5
-# W -> Windows
-# L -> Linux
-# R -> recommended
-# S -> supported
-# T -> not recommended: really bad software. I mean "trash".
+# Changing this to Yes will enable legacy-style benchmarks, for comparisons
+[Debug]
+Benchmarks_1_8 = N
 
 [PRINCE]
 # Default wordlist file name. Will fall back to standard wordlist if not
 # defined.
 Wordlist =
-
 
 # Markov modes, see ../doc/MARKOV for more information
 [Markov:Default]

--- a/src/params.h
+++ b/src/params.h
@@ -201,6 +201,7 @@
 #define SECTION_PRINCE			"PRINCE"
 #define SECTION_DISABLED		"Disabled:"
 #define SUBSECTION_FORMATS		"Formats"
+#define SECTION_FORMATS			"Formats:"
 
 /*
  * Number of different password hash table sizes.


### PR DESCRIPTION
... so user can decide.  Have it default to true, since we've only had a single report of false negative and that was an archive of somewhat dubious origin.  Closes #3806.

Note: This commit also tosses some config stuff around, to keep related things together.