### PR TITLE
Workaround gcc 9 change for const vs. OpenMP shared()

### DIFF
--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -180,15 +180,15 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	const int count = *pcount;
+	int count = *pcount;
 	int index;
 
 #ifdef _OPENMP
 #ifndef SIMD_COEF_64
 #ifdef PRECOMPUTE_CTX_FOR_SALT
-#pragma omp parallel for default(none) private(index) shared(ctx_salt, saved_key, saved_len, crypt_out)
+#pragma omp parallel for default(none) private(index) shared(count, ctx_salt, saved_key, saved_len, crypt_out)
 #else
-#pragma omp parallel for default(none) private(index) shared(saved_salt, saved_key, saved_len, crypt_out)
+#pragma omp parallel for default(none) private(index) shared(count, saved_salt, saved_key, saved_len, crypt_out)
 #endif
 #else
 #pragma omp parallel for

--- a/src/XSHA_fmt_plug.c
+++ b/src/XSHA_fmt_plug.c
@@ -199,7 +199,7 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	const int count = *pcount;
+	int count = *pcount;
 #ifdef SIMD_COEF_32
 	int i = 0;
 #if defined(_OPENMP)
@@ -219,7 +219,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int i;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) private(i) shared(ctx_salt, saved_key, saved_len, crypt_out)
+#pragma omp parallel for default(none) private(i) shared(count, ctx_salt, saved_key, saved_len, crypt_out)
 #endif
 	for (i = 0; i < count; i++) {
 		SHA_CTX ctx;

--- a/src/django_scrypt_fmt_plug.c
+++ b/src/django_scrypt_fmt_plug.c
@@ -198,13 +198,13 @@ static void set_salt(void *salt)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	const int count = *pcount;
+	int count = *pcount;
 	int index;
 	int failed = 0;
 	yescrypt_params_t params = { .N = 1ULL << cur_salt->N, .r = cur_salt->r, .p = cur_salt->p };
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) private(index) shared(failed, params, max_threads, local, saved_key, cur_salt, crypt_out)
+#pragma omp parallel for default(none) private(index) shared(count, failed, params, max_threads, local, saved_key, cur_salt, crypt_out)
 #endif
 	for (index = 0; index < count; index++) {
 #ifdef _OPENMP

--- a/src/scrypt_fmt.c
+++ b/src/scrypt_fmt.c
@@ -413,12 +413,12 @@ static char *get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	const int count = *pcount;
+	int count = *pcount;
 	int index;
 	int failed = 0;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) private(index) shared(failed, max_threads, local, saved_salt, buffer)
+#pragma omp parallel for default(none) private(index) shared(count, failed, max_threads, local, saved_salt, buffer)
 #endif
 	for (index = 0; index < count; index++) {
 #ifdef _OPENMP


### PR DESCRIPTION
This is meant to address #3882, but wasn't actually tested with gcc 9 yet - need to test before closing that issue.