### PR TITLE
SL3 and salted-sha1 opencl formats: Revert to using LWS=NULL when count is lower than GWS

### DIFF
--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -709,12 +709,10 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand%d\n", __FUNCTION__, count, local_work_size, global_work_size, key_idx, mask_int_cand.num_int_cand);
+	global_work_size = count;
 
 	if (keys_changed) {
 	// copy keys to the device

--- a/src/opencl_sl3_fmt_plug.c
+++ b/src/opencl_sl3_fmt_plug.c
@@ -665,12 +665,10 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+		&local_work_size : NULL;
 
-	size_t *lws = local_work_size ? &local_work_size : NULL;
-
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand%d\n", __FUNCTION__, count, local_work_size, global_work_size, key_idx, mask_int_cand.num_int_cand);
+	global_work_size = count;
 
 	if (keys_changed) {
 	// copy keys to the device


### PR DESCRIPTION
I just can't find whatever bug is triggered by not doing this.  Closes #3880.