### PR TITLE
Refactor and repurpose aix-smd5 format.

### DIFF
--- a/src/MD5_fmt.c
+++ b/src/MD5_fmt.c
@@ -28,7 +28,7 @@
 #endif
 
 #define FORMAT_LABEL			"md5crypt"
-#define FORMAT_NAME			"crypt(3) $1$"
+#define FORMAT_NAME			"crypt(3) $1$ (and variants)"
 
 #define BENCHMARK_COMMENT		""
 #define BENCHMARK_LENGTH		7

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -74,7 +74,7 @@ JOHN_OBJS = \
 	jumbo.o john_mpi.o \
 	DES_fmt.o DES_std.o DES_bs.o DES_bs_b.o \
 	BSDI_fmt.o \
-	MD5_fmt.o MD5_std.o md5crypt_common.o \
+	MD5_fmt.o MD5_std.o md5crypt_common.o md5crypt_long_fmt.o \
 	BF_fmt.o BF_std.o BF_common.o \
 	scrypt_fmt.o \
 	yescrypt/yescrypt-opt.o yescrypt/yescrypt-common.o \
@@ -394,6 +394,8 @@ md5.o:	md5.c md5.h arch.h os.h os-autoconf.h autoconfig.h jumbo.h memory.h
 MD5_fmt.o:	MD5_fmt.c arch.h misc.h jumbo.h autoconfig.h simd-intrinsics.h common.h memory.h pseudo_intrinsics.h aligned.h simd-intrinsics-load-flags.h MD5_std.h formats.h params.h md5crypt_common.h os.h os-autoconf.h
 
 MD5_std.o:	MD5_std.c arch.h common.h memory.h MD5_std.h os.h os-autoconf.h autoconfig.h jumbo.h
+
+md5crypt_long_fmt.o:	md5crypt_long_fmt.c md5crypt_common.h md5.h arch.h misc.h jumbo.h autoconfig.h common.h memory.h formats.h params.h omp_autotune.h options.h list.h loader.h getopt.h john_mpi.h common-get-hash.h
 
 md_helper.o:	md_helper.c
 

--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -112,7 +112,7 @@ JOHN_OBJS = \
 	jumbo.o john_mpi.o \
 	DES_fmt.o DES_std.o DES_bs.o DES_bs_b.o \
 	BSDI_fmt.o \
-	MD5_fmt.o MD5_std.o md5crypt_common.o \
+	MD5_fmt.o MD5_std.o md5crypt_common.o md5crypt_long_fmt.o \
 	BF_fmt.o BF_std.o BF_common.o \
 	scrypt_fmt.o \
 	yescrypt/yescrypt-opt.o yescrypt/yescrypt-common.o \

--- a/src/john.c
+++ b/src/john.c
@@ -143,7 +143,7 @@ extern int CPU_detect(void);
 extern char CPU_req_name[];
 #endif
 
-extern struct fmt_main fmt_DES, fmt_BSDI, fmt_MD5, fmt_BF;
+extern struct fmt_main fmt_DES, fmt_BSDI, fmt_MD5, fmt_smd5, fmt_BF;
 extern struct fmt_main fmt_scrypt;
 extern struct fmt_main fmt_AFS, fmt_LM;
 #ifdef HAVE_CRYPT
@@ -373,6 +373,7 @@ static void john_register_all(void)
 	john_register_one(&fmt_DES);
 	john_register_one(&fmt_BSDI);
 	john_register_one(&fmt_MD5);
+	john_register_one(&fmt_smd5);
 	john_register_one(&fmt_BF);
 	john_register_one(&fmt_scrypt);
 	john_register_one(&fmt_LM);


### PR DESCRIPTION
See #3872.

This commit unplugs the format, renames it to md5crypt-long and adds support for $apr1$.