### PR TITLE
Check OpenCL headers version and bail out if 1.2 is not supported.

### DIFF
--- a/src/opencl_common.h
+++ b/src/opencl_common.h
@@ -31,6 +31,10 @@
 #include <CL/cl_ext.h>
 #endif
 
+#if !CL_VERSION_1_2
+#error We need minimum OpenCL 1.2 to build with OpenCL support. The headers currently used does not comply.
+#endif
+
 #include "gpu_common.h"
 #include "arch.h"
 #include "misc.h"


### PR DESCRIPTION
See #3918.

I think this is enough pre-release. Changing autoconf is more error-prone so let's wait with that until post release.