### PR TITLE
Ensure we never benchmark less than two salts for "Many salts".

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -599,9 +599,9 @@ char *benchmark_format(struct fmt_main *format, int salts,
 		sig_timer_emu_tick();
 #endif
 		salts_done++;
-	} while (benchmark_time &&
-		 (((wait && salts_done < salts) ||
-	          bench_running) && !event_abort));
+	} while (benchmark_time && (bench_running ||
+		(salts_done < (wait ? salts : MIN(salts, 2)))) &&
+	         !event_abort);
 
 #if defined (__MINGW32__) || defined (_MSC_VER)
 	end_real = clock();


### PR DESCRIPTION
Closes #3912.