### PR TITLE
Better error message when some rule is missing in a list, eg. --rules=one,two.

### DIFF
--- a/src/rpp.c
+++ b/src/rpp.c
@@ -56,8 +56,10 @@ int rpp_init(struct rpp_context *ctx, const char *subsection)
 		cp = strtokm(buf, ",");
 		while (cp) {
 			struct cfg_line *lp;
-			if ((list = cfg_get_list(SECTION_RULES, cp))==NULL)
+			if ((list = cfg_get_list(SECTION_RULES, cp)) == NULL) {
+				fprintf(stderr, "\"%s\" not found; ", cp);
 				return 1;
+			}
 			lp = list->head;
 			while (lp) {
 				if (!first) {


### PR DESCRIPTION
Closes #3935.

Before:
```
$ ../run/john -stdout -w -rules-stack:wordlist,signle
Using default input encoding: UTF-8
No "wordlist,signle" mode rules found in ../run/john.conf
```

After:
```
$ ../run/john -stdout -w -rules-stack:wordlist,signle
Using default input encoding: UTF-8
"signle" not found; No "wordlist,signle" mode rules found in ../run/john.conf
```