### PR TITLE
2x SHA-1 for XOP; OpenBSD-SoftRAID benchmark fix

### DIFF
--- a/src/openbsdsoftraid_fmt_plug.c
+++ b/src/openbsdsoftraid_fmt_plug.c
@@ -47,8 +47,8 @@ john_register_one(&fmt_openbsd_softraid);
 #else
 #define ALGORITHM_NAME              "PBKDF2-SHA1 32/" ARCH_BITS_STR
 #endif
-#define BENCHMARK_COMMENT           " (8192 iterations)"
-#define BENCHMARK_LENGTH            0x107
+#define BENCHMARK_COMMENT           ""
+#define BENCHMARK_LENGTH            0x507
 #define PLAINTEXT_LENGTH            125
 #define SALT_SIZE                   sizeof(struct custom_salt)
 #define SALT_ALIGN                  4

--- a/src/x86-64.h
+++ b/src/x86-64.h
@@ -269,10 +269,8 @@
 #define SIMD_PARA_SHA1			2
 #elif defined(__llvm__)
 #define SIMD_PARA_SHA1			2
-#elif defined(__GNUC__) && GCC_VERSION < 40504	// 4.5.4
-#define SIMD_PARA_SHA1			1
-#elif !defined(__AVX__) && defined(__GNUC__) && GCC_VERSION > 40700 // 4.7.0
-#define SIMD_PARA_SHA1			1
+#elif defined(__XOP__)
+#define SIMD_PARA_SHA1			2
 #else
 #define SIMD_PARA_SHA1			1
 #endif


### PR DESCRIPTION
As discussed starting with https://github.com/magnumripper/JohnTheRipper/issues/2914#issuecomment-491791916