### PR TITLE
Handle spurious EAGAIN when using fcntl() file locking

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -18,6 +18,27 @@
 #define _JOHN_LOGGER_H
 
 /*
+ * Locking helper functions. Always use the macros!
+ *
+ * Return 1 on success, 0 on failure
+ */
+#define jtr_lock(fd, type, mode, name)	  \
+	real_lock(fd, type, mode, name, __FUNCTION__, __FILE__, __LINE__)
+
+#define jtr_unlock(fd, name)	  \
+	real_unlock(fd, name, __FUNCTION__, __FILE__, __LINE__)
+
+#define EXCLUSIVE 1
+#define SHARED 0
+#define WAIT 1
+#define NOWAIT 0
+
+extern int real_lock(int fd, int type, int mode, const char *name,
+                     const char *function, const char *file, int line);
+extern void real_unlock(int fd, const char *name,
+                        const char *function, const char *file, int line);
+
+/*
  * Initializes the logger (opens john.pot and a log file).
  */
 extern void log_init(char *log_name, char *pot_name, char *session);

--- a/src/opencl_DES_bs_plug.c
+++ b/src/opencl_DES_bs_plug.c
@@ -16,6 +16,7 @@
 #include "unicode.h"
 #include "bt_interface.h"
 #include "mask_ext.h"
+#include "logger.h"
 
 typedef struct {
 	unsigned char *pxkeys[DES_BS_DEPTH]; /* Pointers into xkeys.c */
@@ -1220,38 +1221,23 @@ char *get_device_name(int id)
 void save_lws_config(const char* config_file, int id_gpu, size_t lws, unsigned int forced_global_key)
 {
 	FILE *file;
-	char config_file_name[500];
+	char config_file_name[PATH_BUFFER_SIZE];
 	char *d_name;
 
 	sprintf(config_file_name, config_file, d_name = get_device_name(id_gpu));
 	MEM_FREE(d_name);
+	strnzcpy(config_file_name, path_expand(config_file_name),
+	         sizeof(config_file_name));
 
-	file = fopen(path_expand(config_file_name), "r");
+	file = fopen(config_file_name, "r");
 	if (file != NULL) {
 		fclose(file);
 		return;
 	}
-	file = fopen(path_expand(config_file_name), "w");
+	file = fopen(config_file_name, "w");
 
-#if OS_FLOCK || FCNTL_LOCKS
-	{
-#if FCNTL_LOCKS
-		struct flock lock;
+	jtr_lock(fileno(file), EXCLUSIVE, WAIT, config_file_name);
 
-		memset(&lock, 0, sizeof(lock));
-		lock.l_type = F_WRLCK;
-		while (fcntl(fileno(file), F_SETLKW, &lock)) {
-			if (errno != EINTR)
-				pexit("fcntl(F_WRLCK)");
-		}
-#else
-		while (flock(fileno(file), LOCK_EX)) {
-			if (errno != EINTR)
-				pexit("flock(LOCK_EX)");
-		}
-#endif
-	}
-#endif
 	fprintf(file, ""Zu" %u", lws, forced_global_key);
 	fclose(file);
 }
@@ -1259,37 +1245,21 @@ void save_lws_config(const char* config_file, int id_gpu, size_t lws, unsigned i
 int restore_lws_config(const char *config_file, int id_gpu, size_t *lws, size_t extern_lws_limit, unsigned int *forced_global_key)
 {
 	FILE *file;
-	char config_file_name[500];
+	char config_file_name[PATH_BUFFER_SIZE];
 	char *d_name;
 	unsigned int param;
 
 	sprintf(config_file_name, config_file, d_name = get_device_name(id_gpu));
 	MEM_FREE(d_name);
+	strnzcpy(config_file_name, path_expand(config_file_name),
+	         sizeof(config_file_name));
 
-	file = fopen(path_expand(config_file_name), "r");
+	file = fopen(config_file_name, "r");
 	if (file == NULL)
 		return 0;
 
+	jtr_lock(fileno(file), SHARED, WAIT, config_file_name);
 
-#if OS_FLOCK || FCNTL_LOCKS
-	{
-#if FCNTL_LOCKS
-		struct flock lock;
-
-		memset(&lock, 0, sizeof(lock));
-		lock.l_type = F_RDLCK;
-		while (fcntl(fileno(fp), F_SETLKW, &lock)) {
-			if (errno != EINTR)
-				pexit("fcntl(F_RDLCK)");
-		}
-#else
-		while (flock(fileno(fp), LOCK_SH)) {
-			if (errno != EINTR)
-				pexit("flock(LOCK_SH)");
-		}
-#endif
-	}
-#endif
 	if (fscanf(file, ""Zu" %u", lws, &param) != 2 || *lws > extern_lws_limit) {
 		if (forced_global_key)
 			*forced_global_key = param;

--- a/src/os-autoconf.h
+++ b/src/os-autoconf.h
@@ -59,6 +59,7 @@
 #include <sys/file.h>
 #ifdef LOCK_EX
 #define OS_FLOCK			1
+#define LOCK_FUNC "flock"
 #else
 #define OS_FLOCK			0
 #warning LOCK_EX is not available - will skip locking
@@ -67,6 +68,7 @@
 #define OS_FLOCK			0
 #if (HAVE_FCNTL_H)
 #define FCNTL_LOCKS			1
+#define LOCK_FUNC "fcntl"
 #endif
 #endif
 #endif

--- a/src/os.h
+++ b/src/os.h
@@ -52,6 +52,7 @@
 #include <sys/file.h>
 #ifdef LOCK_EX
 #define OS_FLOCK			1
+#define LOCK_FUNC "flock"
 #else
 #define OS_FLOCK			0
 #warning LOCK_EX is not available - will skip locking
@@ -59,6 +60,7 @@
 #else
 #define OS_FLOCK			0
 #define FCNTL_LOCKS			1
+#define LOCK_FUNC "fcntl"
 #endif
 #endif
 

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -105,93 +105,37 @@ static void rec_name_complete(void)
 #if OS_FLOCK || FCNTL_LOCKS
 static void rec_lock(int shared)
 {
-	int lockmode;
-#if FCNTL_LOCKS
-	int blockmode;
-	struct flock lock;
-#endif
+	int type = SHARED, mode = NOWAIT;
 
 	/*
 	 * In options.c, MPI code path call rec_restore_args(mpi_p)
-	 * relying on anything >1 meaning LOCK_SH. After restore, the
+	 * relying on anything >1 meaning SHARED. After restore, the
 	 * root node must block, in case some other node has not yet
 	 * closed the original file
 	 */
 	if (shared == 1) {
-#if FCNTL_LOCKS
-		lockmode = F_WRLCK;
-		blockmode = F_SETLKW;
-#else
-		lockmode = LOCK_EX;
-#endif
+		type = EXCLUSIVE;
 #ifdef HAVE_MPI
 		if (!rec_restored || mpi_id || mpi_p == 1)
+			mode = WAIT;
 #endif
-#if FCNTL_LOCKS
-			blockmode = F_SETLK;
-#else
-			lockmode |= LOCK_NB;
-#endif
-	} else
-#if FCNTL_LOCKS
-	{
-		lockmode = F_RDLCK;
-		blockmode = F_SETLK;
 	}
 
-#else
-		lockmode = LOCK_SH | LOCK_NB;
-#endif
-
-#ifdef LOCK_DEBUG
-	fprintf(stderr, "%s(%u): Locking session file...\n", __FUNCTION__, options.node_min);
-#endif
-#if FCNTL_LOCKS
-	memset(&lock, 0, sizeof(lock));
-	lock.l_type = lockmode;
-	if (fcntl(rec_fd, blockmode, &lock)) {
-		if (errno == EAGAIN || errno == EACCES) {
-#else
-	if (flock(rec_fd, lockmode)) {
-		if (errno == EWOULDBLOCK) {
-#endif
+	if (!jtr_lock(rec_fd, type, mode, path_expand(rec_name))) {
 #ifdef HAVE_MPI
-			fprintf(stderr, "Node %d@%s: Crash recovery file is"
-			        " locked: %s\n", mpi_id + 1, mpi_name,
-			        path_expand(rec_name));
+		fprintf(stderr, "Node %d@%s: Crash recovery file is locked: %s\n",
+		        mpi_id + 1, mpi_name, path_expand(rec_name));
 #else
-			fprintf(stderr, "Crash recovery file is locked: %s\n",
-				path_expand(rec_name));
+		fprintf(stderr, "Crash recovery file is locked: %s\n",
+		        path_expand(rec_name));
 #endif
-			error();
-		} else
-#if FCNTL_LOCKS
-			pexit("fcntl()");
-#else
-			pexit("flock()");
-#endif
+		error();
 	}
-#ifdef LOCK_DEBUG
-	fprintf(stderr, "%s(%u): Locked session file (%s)\n", __FUNCTION__, options.node_min, shared == 1 ? "exclusive" : "shared");
-#endif
 }
 
 static void rec_unlock(void)
 {
-#if FCNTL_LOCKS
-	struct flock lock = { 0 };
-	lock.l_type = F_UNLCK;
-#endif
-#ifdef LOCK_DEBUG
-	fprintf(stderr, "%s(%u): Unlocking session file\n", __FUNCTION__, options.node_min);
-#endif
-#if FCNTL_LOCKS
-	if (fcntl(rec_fd, F_SETLK, &lock))
-		pexit("fcntl(F_UNLCK)");
-#else
-	if (flock(rec_fd, LOCK_UN))
-		pexit("flock(LOCK_UN)");
-#endif
+	jtr_unlock(rec_fd, rec_name);
 }
 #else
 #define rec_lock(lock) \


### PR DESCRIPTION
We should never get EAGAIN with F_SETLKW, but a user saw it, see #3956.