### PR TITLE
Ci tweak

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,16 @@ jobs:
           WINE: "wine"
           OMP_NUM_THREADS: 2
 
+  no-plugs:
+    <<: *common_linux
+    docker:
+      - image: claudioandre/john:opencl
+        environment:
+          OMP_NUM_THREADS: 2
+          PLUGS: "none"
+          UNIT_TESTS: "yes"
+          BUILD_OPTS: "CPPFLAGS=-DDYNAMIC_DISABLED"
+
   encoding-cpu:
     <<: *common_linux
     docker:
@@ -101,9 +111,12 @@ workflows:
     jobs:
       - asan
       - encoding-cpu
-      - non-SIMD
       - wine-64bits
+      - no-plugs
 
+      - non-SIMD:
+          requires:
+            - no-plugs
       - encoding-opencl:
           requires:
             - encoding-cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,23 +99,25 @@ workflows:
   version: 2
   build:
     jobs:
-      - wine-32bits
-      - wine-64bits
-      - encoding-cpu
       - asan
-      - more-tests:
-          type: approval
+      - encoding-cpu
+      - non-SIMD
+      - wine-64bits
 
       - encoding-opencl:
           requires:
-            - more-tests
+            - encoding-cpu
+      - wine-32bits:
+          requires:
+            - wine-64bits
+
+      - more-tests:
+          type: approval
+
       - test-full:
           requires:
             - more-tests
       - fast-formats-omp:
-          requires:
-            - more-tests
-      - non-SIMD:
           requires:
             - more-tests
       - fast-formats-omp-x-non-SIMD:

--- a/src/cracker.c
+++ b/src/cracker.c
@@ -181,7 +181,7 @@ void crk_init(struct db_main *db, void (*fix_state)(void),
 
 #if HAVE_OPENCL
 	/* This erases the 'spinning wheel' cursor from self-test */
-	if (john_main_process)
+	if (john_main_process && isatty(fileno(stderr)))
 		fprintf(stderr, " \b");
 #endif
 

--- a/src/gpu_common.c
+++ b/src/gpu_common.c
@@ -107,7 +107,7 @@ void advance_cursor()
 	static int pos = 0;
 	char cursor[4] = { '/', '-', '\\', '|' };
 
-	if (john_main_process) {
+	if (john_main_process && isatty(fileno(stderr))) {
 		fprintf(stderr, "%c\b", cursor[pos]);
 		pos = (pos + 1) % 4;
 	}

--- a/src/loader.c
+++ b/src/loader.c
@@ -1392,12 +1392,15 @@ static int ldr_salt_cmp_num(const void *x, const void *y) {
 }
 
 static void ldr_gen_salt_md5(struct db_salt *s, int dynamic) {
+#ifndef DYNAMIC_DISABLED
 	if (dynamic) {
 		dynamic_salt_md5(s);
 		return;
 	}
+#endif
 	dyna_salt_md5(s, ldr_fmt_salt_size);
 }
+
 /*
  * If there are more than 1 salt AND the format exports a salt_compare
  * function, then we reorder the salt array into the order the format

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1900,7 +1900,7 @@ void opencl_find_best_lws(size_t group_size_limit, int sequential_id,
 		}
 
 		/* Erase the 'spinning wheel' cursor */
-		if (john_main_process)
+		if (john_main_process && isatty(fileno(stderr)))
 			fprintf(stderr, " \b");
 
 		if (!endTime)
@@ -2127,8 +2127,8 @@ void opencl_find_best_gws(int step, int max_duration,
 			fprintf(stderr, "!!\n");
 	}
 
-	/* Erase the 'spinning wheel' cursor */
-	if (options.verbosity <= VERB_LEGACY && john_main_process)
+	/* Erase any 'spinning wheel' cursor */
+	if (john_main_process && isatty(fileno(stderr)))
 		fprintf(stderr, " \b");
 
 	// Release profiling queue and create new with profiling disabled


### PR DESCRIPTION
Doing some experiments.

First I moved "win32" to after "win64" (serially) because the two would complete long before "asan" anyway. This made room to promote "non-simd" to default. Then I also put "encoding-opencl" to after "encoding-cpu" (serially) for the same reason.

Then added "delete all plugins" test a.k.a "no-plugs" which also disable the dynamic formats - effectively building a "core-formats Jumbo". This one is super quick so I also added the unit-tests to it. The "non-simd" test will run after "no-plugs" has finished. Disabling dynamics revealed a bug in loader.c that is now fixed in a separate commit.

All in all, we now do three more tests, still within the time of "asan" which is the slowest default one. And we still have a slot free under "more tests".
