### PR TITLE
Handle spurious EAGAIN when using fcntl() file locking

### DIFF
--- a/src/autoconfig.h.in
+++ b/src/autoconfig.h.in
@@ -57,9 +57,6 @@
 /* Define to 1 if you have the `DSA_get0_pqg' function. */
 #undef HAVE_DSA_GET0_PQG
 
-/* Define to 1 if you have the <fcntl.h> header file. */
-#undef HAVE_FCNTL_H
-
 /* Define to 1 if you have the `fopen64' function. */
 #undef HAVE_FOPEN64
 

--- a/src/configure
+++ b/src/configure
@@ -755,7 +755,6 @@ with_openssl
 with_commoncrypto
 with_endian
 with_systemwide
-with_flock
 enable_asan
 enable_ubsan
 enable_ubsantrap
@@ -1425,7 +1424,6 @@ Optional Packages:
                           Set endianness for target if it doesn't detect
                           properly
   --with-systemwide       install for all users
-  --with-flock            use flock() file locking instead of fcntl()
 
 Some influential environment variables:
   CFLAGS_EXTRA
@@ -3439,14 +3437,6 @@ if test "${with_systemwide+set}" = set; then :
   withval=$with_systemwide;
 else
   with_systemwide=no
-fi
-
-
-# Check whether --with-flock was given.
-if test "${with_flock+set}" = set; then :
-  withval=$with_flock;
-else
-  with_flock=no
 fi
 
 
@@ -14291,7 +14281,7 @@ fi
 
 
 
-for ac_header in arpa/inet.h crypt.h dirent.h fcntl.h limits.h locale.h \
+for ac_header in arpa/inet.h crypt.h dirent.h limits.h locale.h \
                   malloc.h net/ethernet.h netdb.h netinet/in.h \
                   netinet/in_systm.h string.h strings.h \
                   sys/ethernet.h sys/file.h sys/param.h sys/socket.h \

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -61,7 +61,6 @@ dnl Cludge for endian (if not auto detected)
 AC_ARG_WITH(endian, [AS_HELP_STRING([--with-endian=little|big],[Set endianness for target if it doesn't detect properly])],,[endian=unknown])
 dnl -DJOHN_SYSTEMWIDE
 AC_ARG_WITH(systemwide, [AS_HELP_STRING([--with-systemwide],[install for all users])],,[with_systemwide=no])
-AC_ARG_WITH(flock, [AS_HELP_STRING([--with-flock],[use flock() file locking instead of fcntl()])],,[with_flock=no])
 
 AC_ARG_ENABLE([asan], [AS_HELP_STRING([--enable-asan], [* Build with AddressSanitizer])], [asan=$enableval], [asan=no])
 AC_ARG_ENABLE([ubsan], [AS_HELP_STRING([--enable-ubsan], [* Build with UndefinedBehaviorSanitizer])], [ubsan=$enableval], [ubsan=no])
@@ -741,7 +740,7 @@ AX_ZTEX
 
 dnl Checks for header files.
 dnl Eg. if sys/times.h is found, the below will define HAVE_SYS_TIMES_H
-AC_CHECK_HEADERS([arpa/inet.h crypt.h dirent.h fcntl.h limits.h locale.h \
+AC_CHECK_HEADERS([arpa/inet.h crypt.h dirent.h limits.h locale.h \
                   malloc.h net/ethernet.h netdb.h netinet/in.h \
                   netinet/in_systm.h string.h strings.h \
                   sys/ethernet.h sys/file.h sys/param.h sys/socket.h \

--- a/src/dmg2john.c
+++ b/src/dmg2john.c
@@ -27,16 +27,15 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <math.h>
-#if (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER
-#include <unistd.h>
-#endif
 #include <string.h>
-#if (!AC_BUILT || HAVE_FCNTL_H)
 #include <fcntl.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+
+#if (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER
+#include <unistd.h>
+#endif
 
 #include "arch.h"
 #include "filevault.h"

--- a/src/dmg_fmt_plug.c
+++ b/src/dmg_fmt_plug.c
@@ -52,10 +52,8 @@ john_register_one(&fmt_dmg);
 #endif
 
 #include <string.h>
-#include <errno.h> // required
-#if !AC_BUILT || HAVE_FCNTL_H
+#include <errno.h>
 #include <fcntl.h>
-#endif
 #include <stdlib.h>
 #include <stdint.h>
 #include <sys/types.h>
@@ -71,10 +69,6 @@ john_register_one(&fmt_dmg);
 #include <omp.h>
 #endif
 
-#ifdef DMG_DEBUG
-#define NEED_OS_FLOCK
-#include "os.h"
-#endif
 #include "arch.h"
 #include "aes.h"
 #include "hmac_sha.h"
@@ -86,6 +80,7 @@ john_register_one(&fmt_dmg);
 #include "dmg_common.h"
 #include "pbkdf2_hmac_sha1.h"
 #include "loader.h"
+#include "logger.h"
 
 #define FORMAT_LABEL        "dmg"
 #define FORMAT_NAME         "Apple DMG"
@@ -578,33 +573,22 @@ static void hash_plugin_check_hash(int index)
 		/* Write block as hex, strings or raw to a file. */
 		if (cracked[index+j] && !bench_or_test_running) {
 #if DMG_DEBUG == 4
+			const char debug_file = "dmg.debug.main";
 			int fd;
 
-			if ((fd = open("dmg.debug.main", O_RDWR | O_CREAT | O_TRUNC, 0660)) == -1)
-				perror("open()");
-			else {
-#if FCNTL_LOCKS
-				struct flock lock = { 0 };
+			if ((fd = open(debug_file, O_RDWR | O_CREAT | O_TRUNC, 0660)) == -1)
+				perror("open(%s)", debug_file);
+			else
+				jtr_lock(fd, F_SETLKW, F_WRLCK, debug_file);
 
-				lock.l_type = F_WRLCK;
-				while (fcntl(fd, F_SETLKW, &lock)) {
-					if (errno != EINTR)
-						pexit("fcntl(F_WRLCK)");
-				}
-#elif OS_FLOCK
-				while (flock(fd, LOCK_EX)) {
-					if (errno != EINTR)
-						pexit("flock(LOCK_EX)");
-				}
-#endif
-				if ((write(fd, outbuf, cur_salt->data_size) == -1))
+			if ((write(fd, outbuf, cur_salt->data_size) == -1))
+				perror("write()");
+			if (cur_salt->scp == 1)
+				if ((write(fd, outbuf2, 4096) == -1))
 					perror("write()");
-				if (cur_salt->scp == 1)
-					if ((write(fd, outbuf2, 4096) == -1))
-						perror("write()");
-				if (close(fd))
-					perror("close");
-			}
+			if (close(fd))
+				perror("close");
+
 #endif
 #if DMG_DEBUG == 3
 			dump_stuff(outbuf, cur_salt->data_size);

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -17,10 +17,9 @@
 #define _BSD_SOURCE 1
 #define _DEFAULT_SOURCE 1
 #endif
-#define NEED_OS_FLOCK
-#include "os.h"
 
 #include <unistd.h>
+#include <fcntl.h>
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
@@ -300,13 +299,11 @@ static void listconf_list_build_info(void)
 	       JS_REGEX_MAJOR_VERSION, JS_REGEX_MINOR_VERSION,
 	       rexgen_version());
 #endif
-
-#if FCNTL_LOCKS
-	puts("File locking: fcntl()");
-#elif OS_FLOCK
-	puts("File locking: flock()");
-#else
+#if defined(F_SETLK) && defined(F_SETLKW) && defined(F_UNLCK)	  \
+	&& defined(F_RDLCK) && defined(F_WRLCK)
 	puts("File locking: NOT supported by this build - do not run concurrent sessions!");
+#else
+	puts("File locking: fcntl()");
 #endif
 	printf("fseek(): " STR_MACRO(jtr_fseek64) "\n");
 	printf("ftell(): " STR_MACRO(jtr_ftell64) "\n");

--- a/src/logger.h
+++ b/src/logger.h
@@ -17,6 +17,39 @@
 #ifndef _JOHN_LOGGER_H
 #define _JOHN_LOGGER_H
 
+#include <fcntl.h>
+
+#if defined(F_SETLK) && defined(F_SETLKW) && defined(F_UNLCK)	  \
+	&& defined(F_RDLCK) && defined(F_WRLCK)
+/*
+ * File locking helper. Always use the macro!
+ * Return 0 on success, -1 on failure
+ */
+#define jtr_lock(fd, cmd, type, name)	  \
+	log_lock(fd, cmd, type, name, __FUNCTION__, __FILE__, __LINE__)
+
+extern int log_lock(int fd, int cmd, int type, const char *name,
+                    const char *function, const char *file, int line);
+#else
+
+/*
+ * This clause likely only used on MinGW and MSVC.
+ *
+ * Surely someone should be able to write a trivial fcntl emulator for
+ * windows supporting locks, no?!  This is 2019, I simply can't believe
+ * there is none. However, *I* am not going to find or write one.
+ */
+#define jtr_lock(...)
+
+#define F_SETLK
+#define F_SETLKW
+#define F_UNLCK
+#define F_RDLCK
+#define F_WRLCK
+
+#endif /* #if defined(F_SETLK) && defined(F_SETLKW) && defined(F_UNLCK)
+		&& defined(F_RDLCK) && defined(F_WRLCK) */
+
 /*
  * Initializes the logger (opens john.pot and a log file).
  */

--- a/src/opencl_DES_bs.h
+++ b/src/opencl_DES_bs.h
@@ -9,14 +9,12 @@
 #ifndef _JOHN_DES_BS_H
 #define _JOHN_DES_BS_H
 
+#include <fcntl.h>
+
 #include "arch.h"
 #include "opencl_common.h"
 #include "opencl_DES_hst_dev_shared.h"
 #include "loader.h"
-
-#if (!AC_BUILT || HAVE_FCNTL_H)
-#include <fcntl.h>		// For file locks.
-#endif
 
 #define DES_BS_OPENCL_ALGORITHM_NAME	"DES OpenCL"
 

--- a/src/os-autoconf.h
+++ b/src/os-autoconf.h
@@ -47,32 +47,6 @@
 
 #endif
 
-#ifdef NEED_OS_FLOCK
-
-#if defined (_MSC_VER) || defined (__MINGW32__)
-#define OS_FLOCK			0
-#else
-#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
-#define _DARWIN_C_SOURCE /* for LOCK_EX */
-#endif
-#if PREFER_FLOCK
-#include <sys/file.h>
-#ifdef LOCK_EX
-#define OS_FLOCK			1
-#else
-#define OS_FLOCK			0
-#warning LOCK_EX is not available - will skip locking
-#endif
-#else
-#define OS_FLOCK			0
-#if (HAVE_FCNTL_H)
-#define FCNTL_LOCKS			1
-#endif
-#endif
-#endif
-
-#endif
-
 #ifdef NEED_OS_FORK
 
 #ifdef HAVE_WORKING_FORK

--- a/src/os.h
+++ b/src/os.h
@@ -40,30 +40,6 @@
 
 #endif
 
-#ifdef NEED_OS_FLOCK
-
-#if defined (_MSC_VER)
-#define OS_FLOCK			0
-#else
-#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
-#define _DARWIN_C_SOURCE /* for LOCK_EX */
-#endif
-#if PREFER_FLOCK
-#include <sys/file.h>
-#ifdef LOCK_EX
-#define OS_FLOCK			1
-#else
-#define OS_FLOCK			0
-#warning LOCK_EX is not available - will skip locking
-#endif
-#else
-#define OS_FLOCK			0
-#define FCNTL_LOCKS			1
-#endif
-#endif
-
-#endif
-
 #ifdef NEED_OS_FORK
 
 #if defined(__DJGPP__) || defined(__CYGWIN__) || defined(_MSC_VER) || defined(__MINGW32__)

--- a/src/putty2john.c
+++ b/src/putty2john.c
@@ -21,13 +21,14 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <fcntl.h>
+
 #if !AC_BUILT || HAVE_LIMITS_H
 #include <limits.h>
 #endif
-#include <sys/types.h>
-#if !AC_BUILT || HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
+
 #include "memory.h"
 #include "jumbo.h"
 #if _MSC_VER

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -393,6 +393,7 @@ void rec_save(void)
 	if (!options.fork && fsync(rec_fd))
 		pexit("fsync");
 #endif
+	sig_reset_timer();
 }
 
 void rec_init_hybrid(void (*save_mode)(FILE *file)) {

--- a/src/signals.c
+++ b/src/signals.c
@@ -304,6 +304,17 @@ static void sig_handle_reload(int signum);
 #endif
 #endif
 
+void sig_reset_timer(void)
+{
+#ifndef BENCH_BUILD
+#if OS_TIMER
+	timer_save_value = timer_save_interval;
+#else
+	timer_save_value = status_get_time() + timer_save_interval;
+#endif
+#endif
+}
+
 static void sig_handle_timer(int signum)
 {
 	int saved_errno = errno;
@@ -326,7 +337,6 @@ static void sig_handle_timer(int signum)
 #endif
 	}
 	if (!--timer_save_value) {
-		timer_save_value = timer_save_interval;
 		event_save = event_pending = 1;
 		event_reload = options.reload_at_save;
 	}
@@ -565,11 +575,12 @@ void sig_init_late(void)
 	unsigned int time;
 
 #if OS_TIMER
-	timer_save_value = timer_save_interval;
+	timer_save_value = timer_save_interval + ((NODE + 1) & 63);
 
 	time = 0;
 #else
-	timer_save_value = status_get_time() + timer_save_interval;
+	timer_save_value =
+		status_get_time() + timer_save_interval + ((NODE + 1) & 63);
 	time = status_get_time();
 #endif
 #endif

--- a/src/signals.h
+++ b/src/signals.h
@@ -78,6 +78,12 @@ extern void sig_init(void);
 extern void sig_init_late(void);
 
 /*
+ * Resets the save timer. This is called after *completing* an event_save
+ * with the rationale of keeping any separation we got by waiting for locks
+ */
+extern void sig_reset_timer(void);
+
+/*
  * Performs additional (re-)initialization after fork().  Assumes that
  * sig_init() has already been called.
  */

--- a/src/unique.c
+++ b/src/unique.c
@@ -19,16 +19,15 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#if !AC_BUILT || HAVE_FCNTL_H
 #include <fcntl.h>
-#endif
 #include <string.h>
+#include <stdint.h>
+
 #ifdef _MSC_VER
 #include <io.h>
 #pragma warning ( disable : 4996 )
 #define fdopen _fdopen
 #endif
-#include <stdint.h>
 
 #include "arch.h"
 #include "misc.h"

--- a/src/unrar.c
+++ b/src/unrar.c
@@ -26,9 +26,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#if !AC_BUILT || HAVE_FCNTL_H
 #include <fcntl.h>
-#endif
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
I now dropped `flock` and dropped AC testing of `fcntl()`.

I also had these thoughts in https://github.com/magnumripper/JohnTheRipper/pull/3958#issuecomment-493705445
> Done. For the sleep, I use `rand()` (which should do fine for this task, seeded with node number) as in
> 
> ```c
> 			/* Sleep for a random time of max. 130 ms */
> 			t.tv_sec = 0; t.tv_usec = (rand() & 1023) << 7;
> 			select(0, NULL, NULL, NULL, &t);
> 			continue;
> ```
> 
> This is 0-130 ms, is that fine? I have no idea of what time frames we have here. Perhaps once we hit this wall, a much longer wait would do more good and hopefully separate the nodes in time so they clash less at next event.

I now changed it to 0-260 ms but I'm also considering something like eg. 100-360 ms.

> Hmm come to think of it, the timers (assuming they're the cause of clash) wont separate anyway - next `timer_save` will clash just as much, right? Some ideas:
> 1. The **initial** `timer_save_value` in `sig_init()` could be ` += (NODE & 31)` (or 63) for 32x or 64x better separation without any other drawback than that the very first rec & log save will be up to 31 or 63 seconds later.
> 2. And/or we could add a new function in `signals.c` that merely does `timer_save_value++;` - and call that function whenever we get an `EAGAIN` here. Perhaps even when we get a `EINTR`?
> 3. And/or we could reset `timer_save_value` *after* files are saved instead of when setting `event_save = event_pending = 1`.
> 4. We could also automagically increase the `LOG_BUFFER_SIZE` buffers according to total number of nodes, with "some" formula.
